### PR TITLE
[playground] Extract jest config from package.json

### DIFF
--- a/packages/playground/jest.config.js
+++ b/packages/playground/jest.config.js
@@ -1,0 +1,23 @@
+module.exports = {
+  "transform": {
+    "^.+\\.tsx?$": "ts-jest"
+  },
+  "moduleFileExtensions": [
+    "ts",
+    "js",
+    "node",
+    "json"
+  ],
+  "testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.(js|ts)$",
+  "setupFiles": [],
+  "collectCoverage": true,
+  "coverageDirectory": "./",
+  "coverageReporters": [
+    "lcov"
+  ],
+  "coveragePathIgnorePatterns": [
+    "/node_modules/",
+    "/test/",
+    "/dist/"
+  ]
+}

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -36,28 +36,5 @@
     "protobufjs": "^6.8.6"
   },
   "baseUrl": "types",
-  "typeRoots": ["src/types"],
-  "jest": {
-    "transform": {
-      "^.+\\.tsx?$": "ts-jest"
-    },
-    "moduleFileExtensions": [
-      "ts",
-      "js",
-      "node",
-      "json"
-    ],
-    "testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.(js|ts)$",
-    "setupFiles": [],
-    "collectCoverage": true,
-    "coverageDirectory": "./",
-    "coverageReporters": [
-      "lcov"
-    ],
-    "coveragePathIgnorePatterns": [
-      "/node_modules/",
-      "/test/",
-      "/dist/"
-    ]
-  }
+  "typeRoots": ["src/types"]
 }


### PR DESCRIPTION
An alternative is to use a JSON file and pass the path via the `--config` flag when running jest.