### PR TITLE
[playground] Use arrow functions

### DIFF
--- a/packages/playground/src/examples/crypto.ts
+++ b/packages/playground/src/examples/crypto.ts
@@ -21,43 +21,42 @@ interface IKeyPair {
 //   readonly [key: string]: T;
 // }
 
-// init must be called and the promise resolved before any other functions are called
-export const initNacl = (opts: NaclOpts): Promise<Nacl> => new Promise((res: NaclCallback): void => {
-  const setup = (nacl: Nacl) => res(nacl);
-  return instantiate(setup, opts);
-});
-
-export const getAddress = (nacl: Nacl, pubkey: SignerPublicKey): string => {
-  // this is a prefix for all pubkey signatures
-  const id = getIdentifier(pubkey);
-  const hash = nacl.crypto_hash_sha256(id);
-  return nacl.to_hex(hash).slice(0, 40); // 20 bytes
-}
-
 // ugh, how to get this to compile????
 export const getIdentifier = (pubkey: SignerPublicKey): Uint8Array => {
   const prefix = Buffer.from("sigs/ed25519/");
   return new Uint8Array([...prefix, ...pubkey]);
-}
+};
+
+// init must be called and the promise resolved before any other functions are called
+export const initNacl = (opts: NaclOpts): Promise<Nacl> =>
+  new Promise((res: NaclCallback): void => {
+    const setup = (nacl: Nacl) => res(nacl);
+    return instantiate(setup, opts);
+  });
+
+export const getAddress = (nacl: Nacl) => (pubkey: SignerPublicKey): string => {
+  // this is a prefix for all pubkey signatures
+  const id = getIdentifier(pubkey);
+  const hash = nacl.crypto_hash_sha256(id);
+  return nacl.to_hex(hash).slice(0, 40); // 20 bytes
+};
 
 // generateKeyPair creates a private/public key pair
-export const generateKeyPair = (nacl: Nacl): IKeyPair => {
+export const generateKeyPair = (nacl: Nacl) => (): IKeyPair => {
   const keypair: any = nacl.crypto_sign_keypair();
   return {
     // nonce: {},
     pubkey: keypair.signPk,
     secret: keypair.signSk
   };
-}
+};
 
-export const sign = (
-  nacl: Nacl,
+export const sign = (nacl: Nacl) => (
   msg: Message,
   secret: SignerSecretKey
 ): SignatureBuffer => nacl.crypto_sign_detached(msg, secret);
 
-export const verify = (
-  nacl: Nacl,
+export const verify = (nacl: Nacl) => (
   msg: Message,
   sig: SignatureBuffer,
   pubkey: SignerPublicKey


### PR DESCRIPTION
The first commit here just switches out `function` declarations for arrow function syntax. In some cases it doesn't make too much difference, but for any function with just a return statement it instantly reduces clutter.

The second commit is a bit more experimental: currying functions which need a nacl instance. That way you could have a function which takes your newly created nacl instance, passes it into these functions, and spits out a whole load of partially-applied functions so you only have to worry about messages and secrets etc, rather than keeping track of the nacl instance. Whether it's useful in this case or not, it demonstrates that the type annotations are *much* smoother with arrow functions than for `function` declarations when it comes to HOFs.