### PR TITLE
Add unsupported npm package lockfile to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ typings/
 
 # OS-specific files
 .DS_Store
+
+# Unsupported files
+package-lock.json


### PR DESCRIPTION
Sometimes it's helpful to `npm install --no-save` for testing purposes.