### PR TITLE
Keybase tidy

### DIFF
--- a/packages/iov-keybase/src/examples/actions_private.ts
+++ b/packages/iov-keybase/src/examples/actions_private.ts
@@ -20,16 +20,16 @@ import {
   RestoreUser,
   SetActiveKey,
   SignTransaction,
-  SubmitPassword
+  UnlockUser
 } from "../types/actions_private";
 
 export const listUsersAction: ListUsers = {
   type: PrivateActionType.LIST_USERS
 };
 
-export const submitPasswordAction: SubmitPassword = {
+export const unlockUserAction: UnlockUser = {
   password: "password123" as PasswordString,
-  type: PrivateActionType.SUBMIT_PASSWORD,
+  type: PrivateActionType.UNLOCK_USER,
   username: "my_username" as UsernameString
 };
 

--- a/packages/iov-keybase/src/types/actions_private.d.ts
+++ b/packages/iov-keybase/src/types/actions_private.d.ts
@@ -12,7 +12,7 @@ import { PasswordString, UsernameString } from "./accounts";
 
 export const enum PrivateActionType {
   LIST_USERS = "LIST_USERS",
-  SUBMIT_PASSWORD = "SUBMIT_PASSWORD",
+  UNLOCK_USER = "UNLOCK_USER",
   CREATE_USER = "CREATE_USER",
   RESTORE_USER = "RESTORE_USER",
   IMPORT_PRIVATE_KEY = "IMPORT_PRIVATE_KEY",
@@ -27,8 +27,8 @@ export interface ListUsers {
   readonly type: PrivateActionType.LIST_USERS;
 }
 
-export interface SubmitPassword {
-  readonly type: PrivateActionType.SUBMIT_PASSWORD;
+export interface UnlockUser {
+  readonly type: PrivateActionType.UNLOCK_USER;
   readonly username: UsernameString;
   readonly password: PasswordString;
 }
@@ -87,7 +87,7 @@ export interface GrantStoreAccess {
 
 export type PrivateAction =
   | ListUsers
-  | SubmitPassword
+  | UnlockUser
   | CreateUser
   | RestoreUser
   | ImportPrivateKey


### PR DESCRIPTION
Removing private actions which won't be the focus of the initial MVP. Also removes password as a requirement for importing a private key, and renames the "Unlock" action. But as mentioned, I think we need to model our User/Profile/Account/Key/Keyring/Wallet concepts and use the terms with a pedantically high level of consistency, otherwise we're going to get lost.