### PR TITLE
Make keypair a single word

### DIFF
--- a/packages/iov-types/src/examples/keys.ts
+++ b/packages/iov-types/src/examples/keys.ts
@@ -1,8 +1,8 @@
 import {
   AddressString,
   Algorithm,
-  KeyPairBytes,
-  KeyPairString,
+  KeypairBytes,
+  KeypairString,
   MnemonicString,
   PrivateKeyBundle,
   PrivateKeyBytes,
@@ -44,13 +44,13 @@ export const publicKeyBundle: PublicKeyBundle = {
   data: publicKeyBytes
 };
 
-export const keyPairBytes: KeyPairBytes = {
+export const keypairBytes: KeypairBytes = {
   algo: Algorithm.ED25519,
   private: privateKeyBytes,
   public: publicKeyBytes
 };
 
-export const keyPairString: KeyPairString = {
+export const keypairString: KeypairString = {
   algo: Algorithm.ED25519,
   private: privateKeyString,
   public: publicKeyString

--- a/packages/iov-types/src/types/keys.d.ts
+++ b/packages/iov-types/src/types/keys.d.ts
@@ -35,13 +35,13 @@ type Signature = typeof SignatureSymbol;
 export type SignatureBytes = Signature & Uint8Array;
 export type SignatureString = Signature & string;
 
-export interface KeyPairBytes {
+export interface KeypairBytes {
   readonly algo: Algorithm;
   readonly private: PrivateKeyBytes;
   readonly public: PublicKeyBytes;
 }
 
-export interface KeyPairString {
+export interface KeypairString {
   readonly algo: Algorithm;
   readonly private: PrivateKeyString;
   readonly public: PublicKeyString;


### PR DESCRIPTION
In software development, you often compose multiple words together in one symbol, where things are easier to parse for readers when there are fewer words (`crypro_sign_key_pair` vs. `crypro_sign_keypair`; `KeypairBytes` vs. `KeyPairBytes`). Thus whenever possible, I'd write words atomic. Looks like [keypair](https://en.wiktionary.org/wiki/keypair) is okay to use without spaces.