### PR TITLE
bns-codec: Use error assertions

### DIFF
--- a/packages/bns-codec/tests/codec.spec.ts
+++ b/packages/bns-codec/tests/codec.spec.ts
@@ -52,16 +52,14 @@ describe("Check codec", () => {
       const decoded = Codec.parseBytes(noBuffer, trial.transaction.chainId);
       expect(decoded).toEqual(trial);
     };
-    try {
+    expect(async () => {
       await verify(signedTxJson);
       await verify(randomTxJson);
       await verify(setNameTxJson);
       await verify(swapCounterTxJson);
       await verify(swapClaimTxJson);
       await verify(swapTimeoutTxJson);
-    } catch (err) {
-      fail("Unexpected exception: " + err.message);
-    }
-    done();
+      done();
+    }).not.toThrow();
   });
 });

--- a/packages/bns-codec/tests/decode.spec.ts
+++ b/packages/bns-codec/tests/decode.spec.ts
@@ -39,25 +39,13 @@ describe("Decode transactions", () => {
   it("decode invalid transaction fails", () => {
     /* tslint:disable-next-line:no-bitwise */
     const badBin = signedTxBin.map((x: number, i: number) => (i % 5 ? x ^ 0x01 : x));
-    try {
-      codec.app.Tx.decode(badBin);
-    } catch (err) {
-      expect(err.toString()).toContain("RangeError");
-      return;
-    }
-    fail("Should throw error");
+    expect(codec.app.Tx.decode.bind(null, badBin)).toThrowError(RangeError);
   });
 
   // unsigned tx will fail as parsing requires a sig to extract signer
   it("decode unsigned transaction fails", () => {
     const decoded = codec.app.Tx.decode(sendTxBin);
-    try {
-      parseTx(decoded, chainId);
-    } catch (err) {
-      expect(err.toString()).toContain("missing first signature");
-      return;
-    }
-    fail("Should throw error");
+    expect(parseTx.bind(null, decoded, chainId)).toThrowError(/missing first signature/);
   });
 
   it("decode signed transaction", () => {


### PR DESCRIPTION
Closes #68 

It's not so obvious how to use these assertions in e.g. `iov-crypto/tests/crypto.spec.ts` where `fail` is being used currently, but in general it's much nicer to use the error-related assertions provided by Jasmine than to use verbose custom logic.