### PR TITLE
[iov-crypto] Don't run prettier on auto-generated code

### DIFF
--- a/packages/iov-crypto/package.json
+++ b/packages/iov-crypto/package.json
@@ -12,7 +12,7 @@
   },
   "scripts": {
     "lint": "tslint -t verbose --project .",
-    "format": "prettier --write **/*.ts",
+    "format": "prettier --write ./src/**/*.ts",
     "test-node": "./jasmine-testrunner.js",
     "test-firefox": "yarn build-browser && karma start --single-run --browsers Firefox",
     "test-chrome": "yarn build-browser && karma start --single-run --browsers ChromeHeadless",


### PR DESCRIPTION
before, prettier was also changing ./types/*.d.ts which caused a lot of
unnecessary diffs during the build process