### PR TITLE
[iov-crypro] Ensure that EnglishMnemonic rejects other languages

### DIFF
--- a/packages/iov-crypto/custom_types/bip39/index.d.ts
+++ b/packages/iov-crypto/custom_types/bip39/index.d.ts
@@ -1,2 +1,3 @@
 // types not available
 declare module 'bip39';
+declare module "bip39/wordlists/english.json";

--- a/packages/iov-crypto/src/bip39.spec.ts
+++ b/packages/iov-crypto/src/bip39.spec.ts
@@ -149,6 +149,26 @@ describe("Bip39", () => {
       new EnglishMnemonic("zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo");
     }).toThrowError(/invalid mnemonic checksum/i);
 
+    // valid Spanish and Italian bip39 mnemonics
+    expect(() => {
+      new EnglishMnemonic("humo odio oriente colina taco fingir salto geranio glaciar academia suave vigor");
+    }).toThrowError(/contains invalid word/i);
+    expect(() => {
+      new EnglishMnemonic("yema folleto tos llave obtener natural fruta deseo laico sopa novato lazo imponer afinar vena hoja zarza cama");
+    }).toThrowError(/contains invalid word/i);
+    expect(() => {
+      new EnglishMnemonic("burla plaza arroz ronda pregunta vacuna veloz boina retiro exento prensa tortuga cabeza pilar anual molino molde fiesta masivo jefe leve fatiga clase plomo");
+    }).toThrowError(/contains invalid word/i);
+    expect(() => {
+      new EnglishMnemonic("braccio trincea armonia emiro svedese lepre stridulo metallo baldo rasente potassio rilassato");
+    }).toThrowError(/contains invalid word/i);
+    expect(() => {
+      new EnglishMnemonic("riparato arrosto globulo singolo bozzolo roba pirolisi ultimato padrone munto leggero avanzato monetario guanto lorenzo latino inoltrare modulo");
+    }).toThrowError(/contains invalid word/i);
+    expect(() => {
+      new EnglishMnemonic("promessa mercurio spessore snodo trave risata mecenate vichingo ceto orecchino vissuto risultato canino scarso futile fune epilogo uovo inedito apatico folata egoismo rifugio coma");
+    }).toThrowError(/contains invalid word/i);
+
     // tslint:enable:no-unused-expression
   });
 

--- a/packages/iov-crypto/src/bip39.ts
+++ b/packages/iov-crypto/src/bip39.ts
@@ -1,4 +1,6 @@
 import * as bip39 from "bip39";
+// tslint:disable-next-line:no-submodule-imports
+import bip39_wordlist_english from "bip39/wordlists/english.json";
 import { pbkdf2 } from "pbkdf2";
 import * as unorm from "unorm";
 
@@ -18,6 +20,12 @@ export class EnglishMnemonic {
     const words = mnemonic.split(" ");
     if (words.length !== 12 && words.length !== 18 && words.length !== 24) {
       throw new Error(`Invalid word count in mnemonic (allowed: 12, 18, 24 got: ${words.length})`);
+    }
+
+    for (const word of words) {
+      if ((bip39_wordlist_english as ReadonlyArray<string>).indexOf(word) === -1) {
+        throw new Error("Mnemonic contains invalid word");
+      }
     }
 
     // Throws with informative error message if mnemonic is not valid


### PR DESCRIPTION
this adds a set of tests ensuring that EnglishMnemonic does not accept valid mnemonics of other languages