### PR TITLE
[iov-keycontrol] Move canSign property into KeyringEntry

### DIFF
--- a/packages/iov-keycontrol/src/keyring-entries/ed25519.spec.ts
+++ b/packages/iov-keycontrol/src/keyring-entries/ed25519.spec.ts
@@ -34,7 +34,6 @@ describe("Ed25519KeyringEntry", () => {
       expect(newIdentity.algo).toEqual(firstIdentity.algo);
       expect(newIdentity.data).toEqual(firstIdentity.data);
       expect(newIdentity.nickname).toEqual(firstIdentity.nickname);
-      expect(newIdentity.canSign).toEqual(firstIdentity.canSign);
 
       done();
     })().catch(error => {
@@ -58,13 +57,11 @@ describe("Ed25519KeyringEntry", () => {
       expect(newIdentity1.algo).toEqual(firstIdentity.algo);
       expect(newIdentity1.data).toEqual(firstIdentity.data);
       expect(newIdentity1.nickname).toEqual(firstIdentity.nickname);
-      expect(newIdentity1.canSign).toEqual(firstIdentity.canSign);
 
       const lastIdentity = (await keyringEntry.getIdentities())[4];
       expect(newIdentity5.algo).toEqual(lastIdentity.algo);
       expect(newIdentity5.data).toEqual(lastIdentity.data);
       expect(newIdentity5.nickname).toEqual(lastIdentity.nickname);
-      expect(newIdentity5.canSign).toEqual(lastIdentity.canSign);
 
       done();
     })().catch(error => {
@@ -137,19 +134,16 @@ describe("Ed25519KeyringEntry", () => {
       expect(decodedJson[0].publicIdentity.algo).toEqual("ed25519");
       expect(decodedJson[0].publicIdentity.data).toMatch(/[0-9a-f]{64}/);
       expect(decodedJson[0].publicIdentity.nickname).toBeUndefined();
-      expect(decodedJson[0].publicIdentity.canSign).toEqual(true);
       expect(decodedJson[0].privkey).toMatch(/[0-9a-f]{64}/);
       expect(decodedJson[1].publicIdentity).toBeTruthy();
       expect(decodedJson[1].publicIdentity.algo).toEqual("ed25519");
       expect(decodedJson[1].publicIdentity.data).toMatch(/[0-9a-f]{64}/);
       expect(decodedJson[1].publicIdentity.nickname).toEqual("");
-      expect(decodedJson[1].publicIdentity.canSign).toEqual(true);
       expect(decodedJson[1].privkey).toMatch(/[0-9a-f]{64}/);
       expect(decodedJson[2].publicIdentity).toBeTruthy();
       expect(decodedJson[2].publicIdentity.algo).toEqual("ed25519");
       expect(decodedJson[2].publicIdentity.data).toMatch(/[0-9a-f]{64}/);
       expect(decodedJson[2].publicIdentity.nickname).toEqual("foo");
-      expect(decodedJson[2].publicIdentity.canSign).toEqual(true);
       expect(decodedJson[2].privkey).toMatch(/[0-9a-f]{64}/);
 
       // keys are different
@@ -179,30 +173,27 @@ describe("Ed25519KeyringEntry", () => {
 
       {
         // one element
-        const serialized = '[{"publicIdentity": { "algo": "ed25519", "data": "aabbccdd", "nickname": "foo", "canSign": true }, "privkey": "223322112233aabb"}]' as KeyDataString;
+        const serialized = '[{"publicIdentity": { "algo": "ed25519", "data": "aabbccdd", "nickname": "foo" }, "privkey": "223322112233aabb"}]' as KeyDataString;
         const entry = new Ed25519KeyringEntry(serialized);
         expect(entry).toBeTruthy();
         expect((await entry.getIdentities()).length).toEqual(1);
         expect((await entry.getIdentities())[0].algo).toEqual("ed25519");
         expect((await entry.getIdentities())[0].data).toEqual(Encoding.fromHex("aabbccdd"));
         expect((await entry.getIdentities())[0].nickname).toEqual("foo");
-        expect((await entry.getIdentities())[0].canSign).toEqual(true);
       }
 
       {
         // two elements
-        const serialized = '[{"publicIdentity": { "algo": "ed25519", "data": "aabbccdd", "nickname": "foo", "canSign": true }, "privkey": "223322112233aabb"}, {"publicIdentity": { "algo": "ed25519", "data": "ddccbbaa", "nickname": "bar", "canSign": true }, "privkey": "ddddeeee"}]' as KeyDataString;
+        const serialized = '[{"publicIdentity": { "algo": "ed25519", "data": "aabbccdd", "nickname": "foo" }, "privkey": "223322112233aabb"}, {"publicIdentity": { "algo": "ed25519", "data": "ddccbbaa", "nickname": "bar" }, "privkey": "ddddeeee"}]' as KeyDataString;
         const entry = new Ed25519KeyringEntry(serialized);
         expect(entry).toBeTruthy();
         expect((await entry.getIdentities()).length).toEqual(2);
         expect((await entry.getIdentities())[0].algo).toEqual("ed25519");
         expect((await entry.getIdentities())[0].data).toEqual(Encoding.fromHex("aabbccdd"));
         expect((await entry.getIdentities())[0].nickname).toEqual("foo");
-        expect((await entry.getIdentities())[0].canSign).toEqual(true);
         expect((await entry.getIdentities())[1].algo).toEqual("ed25519");
         expect((await entry.getIdentities())[1].data).toEqual(Encoding.fromHex("ddccbbaa"));
         expect((await entry.getIdentities())[1].nickname).toEqual("bar");
-        expect((await entry.getIdentities())[1].canSign).toEqual(true);
       }
 
       done();

--- a/packages/iov-keycontrol/src/keyring-entries/ed25519.ts
+++ b/packages/iov-keycontrol/src/keyring-entries/ed25519.ts
@@ -15,6 +15,8 @@ export class Ed25519KeyringEntry implements KeyringEntry {
     return identity.algo + "|" + Encoding.toHex(identity.data);
   }
 
+  public readonly canSign = true;
+
   private readonly identities: PublicIdentity[];
   private readonly privkeys: Map<string, Ed25519Keypair>;
 
@@ -32,7 +34,6 @@ export class Ed25519KeyringEntry implements KeyringEntry {
           algo: record.publicIdentity.algo,
           data: keypair.pubkey as PublicKeyBytes,
           nickname: record.publicIdentity.nickname,
-          canSign: true, // TODO: get from serialized data
         };
         const identityId = Ed25519KeyringEntry.identityId(identity);
         identities.push(identity);
@@ -51,7 +52,6 @@ export class Ed25519KeyringEntry implements KeyringEntry {
     const newIdentity: PublicIdentity = {
       algo: Algorithm.ED25519,
       data: keypair.pubkey as PublicKeyBytes,
-      canSign: true,
     };
     const identityId = Ed25519KeyringEntry.identityId(newIdentity);
     this.privkeys.set(identityId, keypair);
@@ -71,7 +71,6 @@ export class Ed25519KeyringEntry implements KeyringEntry {
       algo: this.identities[index].algo,
       data: this.identities[index].data,
       nickname: nickname,
-      canSign: this.identities[index].canSign,
     };
   }
 
@@ -97,7 +96,6 @@ export class Ed25519KeyringEntry implements KeyringEntry {
           algo: identity.algo,
           data: Encoding.toHex(identity.data),
           nickname: identity.nickname,
-          canSign: identity.canSign,
         },
         privkey: Encoding.toHex(keypair.privkey),
       };

--- a/packages/iov-keycontrol/src/keyring.d.ts
+++ b/packages/iov-keycontrol/src/keyring.d.ts
@@ -13,12 +13,6 @@ export interface PublicIdentity extends PublicKeyBundle {
   // nickname is an optional, local name.
   // this is not exposed to other people, use BNS registration for that
   readonly nickname?: string;
-
-  // canSign flag means the private key is currently accessible.
-  // if a hardware ledger is not plugged in, we may
-  // see the public keys, but have it "inactive"
-  // as long as this flag is false
-  readonly canSign: boolean;
 }
 
 /*
@@ -48,6 +42,11 @@ export interface KeyringEntry {
 
   // getIdentities returns all identities currently registered
   readonly getIdentities: () => Promise<ReadonlyArray<PublicIdentity>>;
+
+  // canSign flag means the private key material is currently accessible.
+  // If a hardware ledger is not plugged in, we may see the public keys,
+  // but have it "inactive" as long as this flag is false.
+  readonly canSign: boolean;
 
   // createTransactionSignature will return a detached signature for the signable bytes
   // with the private key that matches the given PublicIdentity.


### PR DESCRIPTION
~Converts canSign into BehaviorSubject, which is the _current value + updates_ type (see graphs http://reactivex.io/documentation/subject.html)~

~Based on #91~