### PR TITLE
Revert "root: Reinstate object-literal-shorthand tslint rule"

### DIFF
--- a/packages/iov-keycontrol/src/keyring-entries/ed25519.ts
+++ b/packages/iov-keycontrol/src/keyring-entries/ed25519.ts
@@ -66,7 +66,7 @@ export class Ed25519KeyringEntry implements KeyringEntry {
     this.identities[index] = {
       algo: this.identities[index].algo,
       data: this.identities[index].data,
-      nickname,
+      nickname: nickname,
       canSign: this.identities[index].canSign,
     };
   }

--- a/tslint.json
+++ b/tslint.json
@@ -22,6 +22,7 @@
     "no-parameter-reassignment": true,
     "no-unnecessary-class": ["allow-static-only"],
     "no-var-keyword": true,
+    "object-literal-shorthand": false,
     "object-literal-sort-keys": false,
     "readonly-array": true,
     "readonly-keyword": true,


### PR DESCRIPTION
This reverts commit 2d754917750b1ebfa2494f50d250e2a3bd79e5f8.

object-literal-shorthand is a bad idea for different reasons:
* when creating an object, I want to have key/value mapping consistent for the entire object, not different styles per line
* it mixes internal and external naming. I need to be able to change my internal name at any time without changing the key of the returned object