### PR TITLE
Move maker functions into Slip0010RawIndex

### DIFF
--- a/packages/iov-crypto/src/slip0010.spec.ts
+++ b/packages/iov-crypto/src/slip0010.spec.ts
@@ -16,7 +16,7 @@ describe("Slip0010", () => {
     });
 
     it("can derive path m/0_H", () => {
-      const path: ReadonlyArray<Slip0010RawIndex> = [Slip0010.rawIndexFromHardened(0)];
+      const path: ReadonlyArray<Slip0010RawIndex> = [Slip0010RawIndex.hardened(0)];
       const derived = Slip0010.derivePath(Slip0010Curve.Secp256k1, seed, path);
       expect(derived.chainCode).toEqual(fromHex("47fdacbd0f1097043b78c63c20c34ef4ed9a111d980047ad16282c7ae6236141"));
       expect(derived.privkey).toEqual(fromHex("edb2e14f9ee77d26dd93b4ecede8d16ed408ce149b6cd80b0715a2d911a0afea"));
@@ -45,35 +45,35 @@ describe("Slip0010", () => {
     });
 
     it("can derive path m/0_H", () => {
-      const path: ReadonlyArray<Slip0010RawIndex> = [Slip0010.rawIndexFromHardened(0)];
+      const path: ReadonlyArray<Slip0010RawIndex> = [Slip0010RawIndex.hardened(0)];
       const derived = Slip0010.derivePath(Slip0010Curve.Ed25519, seed, path);
       expect(derived.chainCode).toEqual(fromHex("8b59aa11380b624e81507a27fedda59fea6d0b779a778918a2fd3590e16e9c69"));
       expect(derived.privkey).toEqual(fromHex("68e0fe46dfb67e368c75379acec591dad19df3cde26e63b93a8e704f1dade7a3"));
     });
 
     it("can derive path m/0_H/1_H", () => {
-      const path: ReadonlyArray<Slip0010RawIndex> = [Slip0010.rawIndexFromHardened(0), Slip0010.rawIndexFromHardened(1)];
+      const path: ReadonlyArray<Slip0010RawIndex> = [Slip0010RawIndex.hardened(0), Slip0010RawIndex.hardened(1)];
       const derived = Slip0010.derivePath(Slip0010Curve.Ed25519, seed, path);
       expect(derived.chainCode).toEqual(fromHex("a320425f77d1b5c2505a6b1b27382b37368ee640e3557c315416801243552f14"));
       expect(derived.privkey).toEqual(fromHex("b1d0bad404bf35da785a64ca1ac54b2617211d2777696fbffaf208f746ae84f2"));
     });
 
     it("can derive path m/0_H/1_H/2_H", () => {
-      const path: ReadonlyArray<Slip0010RawIndex> = [Slip0010.rawIndexFromHardened(0), Slip0010.rawIndexFromHardened(1), Slip0010.rawIndexFromHardened(2)];
+      const path: ReadonlyArray<Slip0010RawIndex> = [Slip0010RawIndex.hardened(0), Slip0010RawIndex.hardened(1), Slip0010RawIndex.hardened(2)];
       const derived = Slip0010.derivePath(Slip0010Curve.Ed25519, seed, path);
       expect(derived.chainCode).toEqual(fromHex("2e69929e00b5ab250f49c3fb1c12f252de4fed2c1db88387094a0f8c4c9ccd6c"));
       expect(derived.privkey).toEqual(fromHex("92a5b23c0b8a99e37d07df3fb9966917f5d06e02ddbd909c7e184371463e9fc9"));
     });
 
     it("can derive path m/0_H/1_H/2_H/2_H", () => {
-      const path: ReadonlyArray<Slip0010RawIndex> = [Slip0010.rawIndexFromHardened(0), Slip0010.rawIndexFromHardened(1), Slip0010.rawIndexFromHardened(2), Slip0010.rawIndexFromHardened(2)];
+      const path: ReadonlyArray<Slip0010RawIndex> = [Slip0010RawIndex.hardened(0), Slip0010RawIndex.hardened(1), Slip0010RawIndex.hardened(2), Slip0010RawIndex.hardened(2)];
       const derived = Slip0010.derivePath(Slip0010Curve.Ed25519, seed, path);
       expect(derived.chainCode).toEqual(fromHex("8f6d87f93d750e0efccda017d662a1b31a266e4a6f5993b15f5c1f07f74dd5cc"));
       expect(derived.privkey).toEqual(fromHex("30d1dc7e5fc04c31219ab25a27ae00b50f6fd66622f6e9c913253d6511d1e662"));
     });
 
     it("can derive path m/0_H/1_H/2_H/2_H/1000000000_H", () => {
-      const path: ReadonlyArray<Slip0010RawIndex> = [Slip0010.rawIndexFromHardened(0), Slip0010.rawIndexFromHardened(1), Slip0010.rawIndexFromHardened(2), Slip0010.rawIndexFromHardened(2), Slip0010.rawIndexFromHardened(1000000000)];
+      const path: ReadonlyArray<Slip0010RawIndex> = [Slip0010RawIndex.hardened(0), Slip0010RawIndex.hardened(1), Slip0010RawIndex.hardened(2), Slip0010RawIndex.hardened(2), Slip0010RawIndex.hardened(1000000000)];
       const derived = Slip0010.derivePath(Slip0010Curve.Ed25519, seed, path);
       expect(derived.chainCode).toEqual(fromHex("68789923a0cac2cd5a29172a475fe9e0fb14cd6adb5ad98a3fa70333e7afa230"));
       expect(derived.privkey).toEqual(fromHex("8f94d394a8e8fd6b1bc2f3f49f5c47e385281d5c17e65324b0f62483e37e8793"));
@@ -92,35 +92,35 @@ describe("Slip0010", () => {
     });
 
     it("can derive path m/0_H", () => {
-      const path: ReadonlyArray<Slip0010RawIndex> = [Slip0010.rawIndexFromHardened(0)];
+      const path: ReadonlyArray<Slip0010RawIndex> = [Slip0010RawIndex.hardened(0)];
       const derived = Slip0010.derivePath(Slip0010Curve.Ed25519, seed, path);
       expect(derived.chainCode).toEqual(fromHex("0b78a3226f915c082bf118f83618a618ab6dec793752624cbeb622acb562862d"));
       expect(derived.privkey).toEqual(fromHex("1559eb2bbec5790b0c65d8693e4d0875b1747f4970ae8b650486ed7470845635"));
     });
 
     it("can derive path m/0_H/2147483647_H", () => {
-      const path: ReadonlyArray<Slip0010RawIndex> = [Slip0010.rawIndexFromHardened(0), Slip0010.rawIndexFromHardened(2147483647)];
+      const path: ReadonlyArray<Slip0010RawIndex> = [Slip0010RawIndex.hardened(0), Slip0010RawIndex.hardened(2147483647)];
       const derived = Slip0010.derivePath(Slip0010Curve.Ed25519, seed, path);
       expect(derived.chainCode).toEqual(fromHex("138f0b2551bcafeca6ff2aa88ba8ed0ed8de070841f0c4ef0165df8181eaad7f"));
       expect(derived.privkey).toEqual(fromHex("ea4f5bfe8694d8bb74b7b59404632fd5968b774ed545e810de9c32a4fb4192f4"));
     });
 
     it("can derive path m/0_H/2147483647_H/1_H", () => {
-      const path: ReadonlyArray<Slip0010RawIndex> = [Slip0010.rawIndexFromHardened(0), Slip0010.rawIndexFromHardened(2147483647), Slip0010.rawIndexFromHardened(1)];
+      const path: ReadonlyArray<Slip0010RawIndex> = [Slip0010RawIndex.hardened(0), Slip0010RawIndex.hardened(2147483647), Slip0010RawIndex.hardened(1)];
       const derived = Slip0010.derivePath(Slip0010Curve.Ed25519, seed, path);
       expect(derived.chainCode).toEqual(fromHex("73bd9fff1cfbde33a1b846c27085f711c0fe2d66fd32e139d3ebc28e5a4a6b90"));
       expect(derived.privkey).toEqual(fromHex("3757c7577170179c7868353ada796c839135b3d30554bbb74a4b1e4a5a58505c"));
     });
 
     it("can derive path m/0_H/2147483647_H/1_H/2147483646_H", () => {
-      const path: ReadonlyArray<Slip0010RawIndex> = [Slip0010.rawIndexFromHardened(0), Slip0010.rawIndexFromHardened(2147483647), Slip0010.rawIndexFromHardened(1), Slip0010.rawIndexFromHardened(2147483646)];
+      const path: ReadonlyArray<Slip0010RawIndex> = [Slip0010RawIndex.hardened(0), Slip0010RawIndex.hardened(2147483647), Slip0010RawIndex.hardened(1), Slip0010RawIndex.hardened(2147483646)];
       const derived = Slip0010.derivePath(Slip0010Curve.Ed25519, seed, path);
       expect(derived.chainCode).toEqual(fromHex("0902fe8a29f9140480a00ef244bd183e8a13288e4412d8389d140aac1794825a"));
       expect(derived.privkey).toEqual(fromHex("5837736c89570de861ebc173b1086da4f505d4adb387c6a1b1342d5e4ac9ec72"));
     });
 
     it("can derive path m/0_H/2147483647_H/1_H/2147483646_H/2_H", () => {
-      const path: ReadonlyArray<Slip0010RawIndex> = [Slip0010.rawIndexFromHardened(0), Slip0010.rawIndexFromHardened(2147483647), Slip0010.rawIndexFromHardened(1), Slip0010.rawIndexFromHardened(2147483646), Slip0010.rawIndexFromHardened(2)];
+      const path: ReadonlyArray<Slip0010RawIndex> = [Slip0010RawIndex.hardened(0), Slip0010RawIndex.hardened(2147483647), Slip0010RawIndex.hardened(1), Slip0010RawIndex.hardened(2147483646), Slip0010RawIndex.hardened(2)];
       const derived = Slip0010.derivePath(Slip0010Curve.Ed25519, seed, path);
       expect(derived.chainCode).toEqual(fromHex("5d70af781f3a37b829f0d060924d5e960bdc02e85423494afc0b1a41bbe196d4"));
       expect(derived.privkey).toEqual(fromHex("551d333177df541ad876a60ea71f00447931c0a9da16f227c11ea080d7391b8d"));

--- a/packages/iov-crypto/src/slip0010.ts
+++ b/packages/iov-crypto/src/slip0010.ts
@@ -16,6 +16,14 @@ export enum Slip0010Curve {
 }
 
 export class Slip0010RawIndex extends Uint32 {
+  public static hardened(hardenedIndex: number): Slip0010RawIndex {
+    return new Slip0010RawIndex(hardenedIndex + 2 ** 31);
+  }
+
+  public static normal(normalIndex: number): Slip0010RawIndex {
+    return new Slip0010RawIndex(normalIndex);
+  }
+
   public isHardened(): boolean {
     return this.data >= 2 ** 31;
   }
@@ -35,14 +43,6 @@ export class Slip0010 {
       result = this.child(curve, result.privkey, result.chainCode, rawIndex);
     }
     return result;
-  }
-
-  public static rawIndexFromHardened(hardenedIndex: number): Slip0010RawIndex {
-    return new Slip0010RawIndex(hardenedIndex + 2 ** 31);
-  }
-
-  public static rawIndexFromNormal(normalIndex: number): Slip0010RawIndex {
-    return new Slip0010RawIndex(normalIndex);
   }
 
   private static master(curve: Slip0010Curve, seed: Uint8Array): Slip0010Result {

--- a/packages/iov-crypto/types/slip0010.d.ts
+++ b/packages/iov-crypto/types/slip0010.d.ts
@@ -8,12 +8,12 @@ export declare enum Slip0010Curve {
     Ed25519 = "ed25519 seed",
 }
 export declare class Slip0010RawIndex extends Uint32 {
+    static hardened(hardenedIndex: number): Slip0010RawIndex;
+    static normal(normalIndex: number): Slip0010RawIndex;
     isHardened(): boolean;
 }
 export declare class Slip0010 {
     static derivePath(curve: Slip0010Curve, seed: Uint8Array, path: ReadonlyArray<Slip0010RawIndex>): Slip0010Result;
-    static rawIndexFromHardened(hardenedIndex: number): Slip0010RawIndex;
-    static rawIndexFromNormal(normalIndex: number): Slip0010RawIndex;
     private static master(curve, seed);
     private static child(curve, parentPrivkey, parentChainCode, rawIndex);
     private static childImpl(curve, parentPrivkey, parentChainCode, rawIndex, i);


### PR DESCRIPTION
I guess path creation will get a bit nicer than that as soon as required by Ed25519HdKeyringEntry (maybe even parsed from strings like `m / 44' / 1' / 0' / 1 / 1`).