### PR TITLE
[iov-crypto] Fix no expectations warning

### DIFF
--- a/packages/iov-crypto/src/bip39.spec.ts
+++ b/packages/iov-crypto/src/bip39.spec.ts
@@ -63,9 +63,11 @@ describe("Bip39", () => {
     // tslint:disable:no-unused-expression
 
     it("works for valid inputs", () => {
-      new EnglishMnemonic("abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about");
-      new EnglishMnemonic("abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon agent");
-      new EnglishMnemonic("abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon art");
+      expect(() => {
+        new EnglishMnemonic("abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about");
+        new EnglishMnemonic("abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon agent");
+        new EnglishMnemonic("abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon art");
+      }).not.toThrow();
     });
 
     it("rejects invalid whitespacing", () => {


### PR DESCRIPTION
Without an expectation, we get the following warning when running browser tests:

> ERROR: 'Spec 'Bip39 EnglishMnemonic works for valid inputs' has no expectations.'