### PR TITLE
[build system] Ensure file globbing is performed by JavaScript

### DIFF
--- a/packages/bns-codec/package.json
+++ b/packages/bns-codec/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "lint": "tslint --project .",
-    "format": "prettier --write ./src/**/*.ts",
+    "format": "prettier --write './src/**/*.ts'",
     "test-node": "./jasmine-testrunner.js",
     "test-firefox": "karma start --single-run --browsers Firefox",
     "test-chrome": "karma start --single-run --browsers ChromeHeadless",

--- a/packages/iov-crypto/package.json
+++ b/packages/iov-crypto/package.json
@@ -12,7 +12,7 @@
   },
   "scripts": {
     "lint": "tslint -t verbose --project .",
-    "format": "prettier --write ./src/**/*.ts",
+    "format": "prettier --write './src/**/*.ts'",
     "test-node": "./jasmine-testrunner.js",
     "test-firefox": "yarn build-browser && karma start --single-run --browsers Firefox",
     "test-chrome": "yarn build-browser && karma start --single-run --browsers ChromeHeadless",

--- a/packages/iov-keybase/package.json
+++ b/packages/iov-keybase/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "run-dev": "ts-node",
-    "format": "prettier --write ./src/**/*.ts",
+    "format": "prettier --write './src/**/*.ts'",
     "lint": "tslint -t verbose --project .",
     "lint-fix": "yarn lint --fix",
     "test": "echo 'Info: no test specified'",

--- a/packages/iov-keycontrol/package.json
+++ b/packages/iov-keycontrol/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "run-dev": "ts-node",
-    "format": "prettier --write ./src/**/*.ts",
+    "format": "prettier --write './src/**/*.ts'",
     "lint": "tslint -t verbose --project .",
     "lint-fix": "yarn lint --fix",
     "test-node": "./jasmine-testrunner.js",

--- a/packages/iov-keycontrol/src/keycontroller.d.ts
+++ b/packages/iov-keycontrol/src/keycontroller.d.ts
@@ -98,7 +98,10 @@ export interface Profile {
   readonly createIdentity: () => Promise<ModifyProfileEvent>;
 
   // assigns a new nickname to one of the identities
-  readonly setIdentityNickname: (identity: PublicIdentity, name: string | undefined) => Promise<ModifyProfileEvent>;
+  readonly setIdentityNickname: (
+    identity: PublicIdentity,
+    name: string | undefined,
+  ) => Promise<ModifyProfileEvent>;
 
   readonly getIdentities: () => Promise<ReadonlyArray<LocalIdentity>>;
 

--- a/packages/iov-keycontrol/src/keyring.d.ts
+++ b/packages/iov-keycontrol/src/keyring.d.ts
@@ -1,14 +1,16 @@
 import { ChainId, PublicKeyBundle, SignableBytes, SignatureBytes } from "@iov/types";
 
 // type tagging from https://github.com/Microsoft/TypeScript/issues/4895#issuecomment-399098397
-declare class As<Tag extends string> { private '_ _ _': Tag; }
+declare class As<Tag extends string> {
+  private "_ _ _": Tag;
+}
 
-export type KeyDataString = string & As<'key-data'>;
-export type KeyringName = string & As<'keyring-name'>;
+export type KeyDataString = string & As<"key-data">;
+export type KeyringName = string & As<"keyring-name">;
 
 // PublicIdentity is a public key we can identify with on a blockchain
 export interface PublicIdentity {
-  readonly pubkey: PublicKeyBundle
+  readonly pubkey: PublicKeyBundle;
 }
 
 // LocalIdentity is a local version of a PublicIdentity that contains

--- a/packages/iov-types/package.json
+++ b/packages/iov-types/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "run-dev": "ts-node",
-    "format": "prettier --write ./src/**/*.ts",
+    "format": "prettier --write './src/**/*.ts'",
     "lint": "tslint -t verbose --project .",
     "lint-fix": "yarn lint --fix",
     "test": "echo 'Info: no test specified'",

--- a/packages/tendermint-client/package.json
+++ b/packages/tendermint-client/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "run-dev": "ts-node",
-    "format": "prettier --write ./src/**/*.ts",
+    "format": "prettier --write './src/**/*.ts'",
     "lint": "tslint -t verbose --project .",
     "lint-fix": "yarn lint --fix",
     "test": "echo 'Info: no test specified'",


### PR DESCRIPTION
Before, the globbing was performed by shell and ./src/**/*.ts did not match .ts files in root of ./src.