### PR TITLE
[build system] Re-enable strictFunctionTypes

### DIFF
--- a/packages/iov-keybase/tsconfig.json
+++ b/packages/iov-keybase/tsconfig.json
@@ -3,9 +3,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "outDir": "dist",
-    "rootDir": "src",
-    /* Needed for https://github.com/staltz/xstream/issues/231 */
-    "strictFunctionTypes": false
+    "rootDir": "src"
   },
   "include": [
     "src/**/*"

--- a/packages/iov-keycontrol/tsconfig.json
+++ b/packages/iov-keycontrol/tsconfig.json
@@ -3,9 +3,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "outDir": "build",
-    "rootDir": "src",
-    /* Needed for https://github.com/staltz/xstream/issues/231 */
-    "strictFunctionTypes": false
+    "rootDir": "src"
   },
   "include": [
     "src/**/*.ts"

--- a/packages/iov-types/tsconfig.json
+++ b/packages/iov-types/tsconfig.json
@@ -3,9 +3,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "outDir": "dist",
-    "rootDir": "src",
-    /* Needed for https://github.com/staltz/xstream/issues/231 */
-    "strictFunctionTypes": false
+    "rootDir": "src"
   },
   "include": [
     "src/**/*"

--- a/packages/tendermint-client/tsconfig.json
+++ b/packages/tendermint-client/tsconfig.json
@@ -3,9 +3,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "outDir": "dist",
-    "rootDir": "src",
-    /* Needed for https://github.com/staltz/xstream/issues/231 */
-    "strictFunctionTypes": false
+    "rootDir": "src"
   },
   "include": [
     "src/**/*"


### PR DESCRIPTION
I think https://github.com/staltz/xstream/issues/231 is resolved