### PR TITLE
[iov-keycontrol] Fix Ed25519SimpleAddressKeyringEntry.clone()

### DIFF
--- a/packages/iov-keycontrol/src/keyring-entries/ed25519simpleaddress.spec.ts
+++ b/packages/iov-keycontrol/src/keyring-entries/ed25519simpleaddress.spec.ts
@@ -39,4 +39,12 @@ describe("Ed25519SimpleAddressKeyringEntry", () => {
       });
     });
   });
+
+  it("can be cloned", () => {
+    const original = Ed25519SimpleAddressKeyringEntry.fromEntropy(Encoding.fromHex("51385c41df88cbe7c579e99de04259b1aa264d8e2416f1885228a4d069629fad"));
+    const clone = original.clone();
+    expect(clone).not.toBe(original);
+    expect(clone.serialize()).toEqual(original.serialize());
+    expect(clone.implementationId).toEqual("ed25519simpleaddress");
+  });
 });

--- a/packages/iov-keycontrol/src/keyring-entries/ed25519simpleaddress.ts
+++ b/packages/iov-keycontrol/src/keyring-entries/ed25519simpleaddress.ts
@@ -24,4 +24,8 @@ export class Ed25519SimpleAddressKeyringEntry extends Ed25519HdKeyringEntry {
     ];
     return super.createIdentityWithPath(path);
   }
+
+  public clone(): Ed25519SimpleAddressKeyringEntry {
+    return new Ed25519SimpleAddressKeyringEntry(this.serialize());
+  }
 }


### PR DESCRIPTION
before it returned wrong type Ed25519HdKeyringEntry