### PR TITLE
[iov-keycontrol] Unexport Ed25519HdKeyringEntry serialization format

### DIFF
--- a/packages/iov-keycontrol/src/keyring-entries/ed25519hd.spec.ts
+++ b/packages/iov-keycontrol/src/keyring-entries/ed25519hd.spec.ts
@@ -2,7 +2,7 @@ import { Encoding, Slip0010RawIndex } from "@iov/crypto";
 import { Algorithm, ChainId, SignableBytes } from "@iov/types";
 
 import { KeyringEntrySerializationString } from "../keyring";
-import { Ed25519HdKeyringEntry, Ed25519HdKeyringEntrySerialization } from "./ed25519hd";
+import { Ed25519HdKeyringEntry } from "./ed25519hd";
 
 describe("Ed25519HdKeyringEntry", () => {
   const emptyEntry = '{ "secret": "rhythm they leave position crowd cart pilot student razor indoor gesture thrive", "identities": [] }' as KeyringEntrySerializationString;
@@ -131,7 +131,7 @@ describe("Ed25519HdKeyringEntry", () => {
       expect(serialized).toBeTruthy();
       expect(serialized.length).toBeGreaterThan(100);
 
-      const decodedJson: Ed25519HdKeyringEntrySerialization = JSON.parse(serialized);
+      const decodedJson = JSON.parse(serialized);
       expect(decodedJson).toBeTruthy();
       expect(decodedJson.label).toEqual("entry with 3 identities");
       expect(decodedJson.secret).toMatch(/^[a-z]+( [a-z]+)*$/);

--- a/packages/iov-keycontrol/src/keyring-entries/ed25519hd.ts
+++ b/packages/iov-keycontrol/src/keyring-entries/ed25519hd.ts
@@ -19,24 +19,22 @@ import {
 } from "../keyring";
 import { DefaultValueProducer, ValueAndUpdates } from "../valueandupdates";
 
-export interface PubkeySerialization {
+interface PubkeySerialization {
   readonly algo: string;
   readonly data: string;
 }
 
-export interface LocalIdentitySerialization {
+interface LocalIdentitySerialization {
   readonly pubkey: PubkeySerialization;
   readonly label?: string;
 }
 
-export interface IdentitySerialization {
+interface IdentitySerialization {
   readonly localIdentity: LocalIdentitySerialization;
   readonly privkeyPath: ReadonlyArray<number>;
 }
 
-// Only exported to be used in tests. This is implementation detail
-// for applications and must not be exported outside of the package.
-export interface Ed25519HdKeyringEntrySerialization {
+interface Ed25519HdKeyringEntrySerialization {
   readonly secret: string;
   readonly label: string | undefined;
   readonly identities: ReadonlyArray<IdentitySerialization>;

--- a/packages/iov-keycontrol/src/keyring-entries/ed25519simpleaddress.spec.ts
+++ b/packages/iov-keycontrol/src/keyring-entries/ed25519simpleaddress.spec.ts
@@ -1,7 +1,6 @@
 import { Encoding } from "@iov/crypto";
 
 import { KeyringEntrySerializationString } from "../keyring";
-import { Ed25519HdKeyringEntrySerialization } from "./ed25519hd";
 import { Ed25519SimpleAddressKeyringEntry } from "./ed25519simpleaddress";
 
 describe("Ed25519SimpleAddressKeyringEntry", () => {
@@ -27,7 +26,7 @@ describe("Ed25519SimpleAddressKeyringEntry", () => {
       await entry.createIdentity();
       await entry.createIdentity();
 
-      const decodedJson: Ed25519HdKeyringEntrySerialization = JSON.parse(entry.serialize());
+      const decodedJson = JSON.parse(entry.serialize());
       expect(decodedJson.identities[0].privkeyPath).toEqual([0x80000000 + 4804438, 0x80000000 + 0]);
       expect(decodedJson.identities[1].privkeyPath).toEqual([0x80000000 + 4804438, 0x80000000 + 1]);
       expect(decodedJson.identities[2].privkeyPath).toEqual([0x80000000 + 4804438, 0x80000000 + 2]);


### PR DESCRIPTION
This is internal knowledge that must not be used by callers. If tests really want to make assumptions on the format, they need to take care of that for themselves.

With this PR, Ed25519HdKeyringEntry and Ed25519KeyringEntry behave in the same way