### PR TITLE
Silence prettier output in yarn format

### DIFF
--- a/packages/iov-bns/package.json
+++ b/packages/iov-bns/package.json
@@ -12,7 +12,7 @@
   },
   "scripts": {
     "lint": "tslint -t verbose --project .",
-    "format": "prettier --write './src/**/*.ts' > /dev/null",
+    "format": "prettier --write --loglevel warn './src/**/*.ts'",
     "test-node": "./jasmine-testrunner.js",
     "test-firefox": "yarn build-browser && karma start --single-run --browsers Firefox",
     "test-chrome": "yarn build-browser && karma start --single-run --browsers ChromeHeadless",

--- a/packages/iov-crypto/package.json
+++ b/packages/iov-crypto/package.json
@@ -12,7 +12,7 @@
   },
   "scripts": {
     "lint": "tslint -t verbose --project .",
-    "format": "prettier --write './src/**/*.ts' > /dev/null",
+    "format": "prettier --write --loglevel warn './src/**/*.ts'",
     "test-node": "./jasmine-testrunner.js",
     "test-firefox": "yarn build-browser && karma start --single-run --browsers Firefox",
     "test-chrome": "yarn build-browser && karma start --single-run --browsers ChromeHeadless",

--- a/packages/iov-encoding/package.json
+++ b/packages/iov-encoding/package.json
@@ -12,7 +12,7 @@
   },
   "scripts": {
     "lint": "tslint -t verbose --project .",
-    "format": "prettier --write './src/**/*.ts' > /dev/null",
+    "format": "prettier --write --loglevel warn './src/**/*.ts'",
     "test-node": "./jasmine-testrunner.js",
     "test-firefox": "yarn build-browser && karma start --single-run --browsers Firefox",
     "test-chrome": "yarn build-browser && karma start --single-run --browsers ChromeHeadless",

--- a/packages/iov-keybase/package.json
+++ b/packages/iov-keybase/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "run-dev": "ts-node",
-    "format": "prettier --write './src/**/*.ts' > /dev/null",
+    "format": "prettier --write --loglevel warn './src/**/*.ts'",
     "lint": "tslint -t verbose --project .",
     "lint-fix": "yarn lint --fix",
     "test": "echo 'Info: no test specified'",

--- a/packages/iov-keycontrol/package.json
+++ b/packages/iov-keycontrol/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "run-dev": "ts-node",
-    "format": "prettier --write './src/**/*.ts' > /dev/null",
+    "format": "prettier --write --loglevel warn './src/**/*.ts'",
     "lint": "tslint -t verbose --project .",
     "lint-fix": "yarn lint --fix",
     "test-node": "./jasmine-testrunner.js",

--- a/packages/iov-tendermint-rpc/package.json
+++ b/packages/iov-tendermint-rpc/package.json
@@ -12,7 +12,7 @@
   },
   "scripts": {
     "lint": "tslint -t verbose --project .",
-    "format": "prettier --write './src/**/*.ts' > /dev/null",
+    "format": "prettier --write --loglevel warn './src/**/*.ts'",
     "test-node": "./jasmine-testrunner.js",
     "test-firefox": "yarn build-browser && karma start --single-run --browsers Firefox",
     "test-chrome": "yarn build-browser && karma start --single-run --browsers ChromeHeadless",

--- a/packages/iov-types/package.json
+++ b/packages/iov-types/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "run-dev": "ts-node",
-    "format": "prettier --write './types/**/*.ts' > /dev/null",
+    "format": "prettier --write --loglevel warn './types/**/*.ts'",
     "lint": "tslint -t verbose --project .",
     "lint-fix": "yarn lint --fix",
     "test": "echo 'Info: no test specified'",

--- a/packages/ledger-bns/package.json
+++ b/packages/ledger-bns/package.json
@@ -12,7 +12,7 @@
   },
   "scripts": {
     "lint": "tslint -t verbose --project .",
-    "format": "prettier --write './src/**/*.ts' > /dev/null",
+    "format": "prettier --write --loglevel warn './src/**/*.ts'",
     "test-node": "./jasmine-testrunner.js",
     "test": "yarn build && yarn test-node",
     "prebuild": "yarn format && yarn lint",


### PR DESCRIPTION
So we can see the output of `yarn build` without so much useless info.
(Prettier lists all files it cleans, but this is meaningless. Almost all build errors are from lint or tsc)