### PR TITLE
Simplify abciQuery() response handling

### DIFF
--- a/packages/iov-bns/src/client.ts
+++ b/packages/iov-bns/src/client.ts
@@ -165,9 +165,6 @@ export class Client implements IovReader {
 
   protected async query(path: string, data: Uint8Array): Promise<QueryResponse> {
     const response = await this.tmClient.abciQuery({ path, data });
-    if (!response.key) {
-      return { height: response.height, results: [] };
-    }
     const keys = codecImpl.app.ResultSet.decode(response.key).results;
     const values = codecImpl.app.ResultSet.decode(response.value).results;
     const results: ReadonlyArray<Result> = zip(keys, values);


### PR DESCRIPTION
This is a cleanup resulting from the code review for #230. Since `q.key` was never undefined, this PR changes no logic and cannot be a fix.