### PR TITLE
Make .type work in the repl again

### DIFF
--- a/packages/iov-cli/src/tsrepl.ts
+++ b/packages/iov-cli/src/tsrepl.ts
@@ -55,6 +55,7 @@ export class TsRepl {
 
     // Bookmark the point where we should reset the REPL state.
     const resetEval = this.appendEval("");
+    +"\n";
 
     const reset = (): void => {
       resetEval();
@@ -77,11 +78,13 @@ export class TsRepl {
           return;
         }
 
-        const undo = this.appendEval(identifier);
+        // Had to add one return so appendEval (lineCount) wouldn't panic
+        const undo = this.appendEval(identifier + "\n");
         const { name, comment } = this.typeScriptService.getTypeInfo(
           this.evalData.input,
           this.evalPath,
-          this.evalData.input.length,
+          // Have to subtract one due to the empty return above
+          this.evalData.input.length - 1,
         );
 
         undo();


### PR DESCRIPTION
Testing out the repl, I discovered the useful `.type` command was broken due to some of the refactoring. This is the simplest change to get it to work again.

You can also reject this PR for a better change that addresses the underlying causes.
I was actually taking a short look for #220 to see if I could extend `.type` to show all methods on an object, but then found it wasn't working at all.

I would love `.type UserProfile` to show static methods, and `const foo = new UserProfile(); .type foo` to show all instance methods... but at least seeing `.type toHex` work is a nice start