### PR TITLE
[iov-cli] Fix autocomplete

### DIFF
--- a/packages/iov-cli/src/helpers.spec.ts
+++ b/packages/iov-cli/src/helpers.spec.ts
@@ -1,19 +1,6 @@
-import { lineCount, executeJavaScript } from "./helpers";
+import { executeJavaScript } from "./helpers";
 
 describe("Helpers", () => {
-  it("has working line count", () => {
-    expect(lineCount("")).toEqual(0);
-    expect(lineCount("123\n")).toEqual(1);
-    expect(lineCount("\n")).toEqual(1);
-    expect(lineCount("123\nabc\n")).toEqual(2);
-    expect(lineCount("123\n\nabc\n")).toEqual(3);
-
-    expect(() => lineCount("123")).toThrowError(/final newline missing/);
-    expect(() => lineCount(" ")).toThrowError(/final newline missing/);
-    expect(() => lineCount("123\nabc")).toThrowError(/final newline missing/);
-    expect(() => lineCount("123\n ")).toThrowError(/final newline missing/);
-  });
-
   it("can execute JavaScript", () => {
     expect(executeJavaScript("123", "myfile.js")).toEqual(123);
     expect(executeJavaScript("1+1", "myfile.js")).toEqual(2);

--- a/packages/iov-cli/src/helpers.spec.ts
+++ b/packages/iov-cli/src/helpers.spec.ts
@@ -1,4 +1,4 @@
-import { lineCount } from "./helpers";
+import { lineCount, executeJavaScript } from "./helpers";
 
 describe("Helpers", () => {
   it("has working line count", () => {
@@ -12,5 +12,10 @@ describe("Helpers", () => {
     expect(() => lineCount(" ")).toThrowError(/final newline missing/);
     expect(() => lineCount("123\nabc")).toThrowError(/final newline missing/);
     expect(() => lineCount("123\n ")).toThrowError(/final newline missing/);
+  });
+
+  it("can execute JavaScript", () => {
+    expect(executeJavaScript("123", "myfile.js")).toEqual(123);
+    expect(executeJavaScript("1+1", "myfile.js")).toEqual(2);
   });
 });

--- a/packages/iov-cli/src/helpers.ts
+++ b/packages/iov-cli/src/helpers.ts
@@ -6,14 +6,6 @@ export function executeJavaScript(code: string, filename: string) {
   return script.runInThisContext();
 }
 
-export function lineCount(sourceCode: string) {
-  // Expect POSIX lines (https://stackoverflow.com/a/729795)
-  if (sourceCode.length > 0 && !sourceCode.endsWith("\n")) {
-    throw new Error("final newline missing");
-  }
-  return sourceCode.split("\n").length - 1;
-}
-
 export function isRecoverable(error: TSError) {
   const recoveryCodes: Set<number> = new Set([
     1003, // "Identifier expected."

--- a/packages/iov-cli/src/tsrepl.ts
+++ b/packages/iov-cli/src/tsrepl.ts
@@ -96,8 +96,7 @@ export class TsRepl {
     return repl;
   }
 
-  private compileAndExecute(tsInput: string): any {
-    const isCompletion = !/\n$/.test(tsInput);
+  private compileAndExecute(tsInput: string, isAutocompletionRequest: boolean): any {
     const undo = this.appendTypeScriptInput(tsInput);
     let output: string;
 
@@ -112,7 +111,7 @@ export class TsRepl {
     // Use `diff` to check for new JavaScript to execute.
     const changes = diffLines(this.evalData.output, output);
 
-    if (isCompletion) {
+    if (isAutocompletionRequest) {
       undo();
     } else {
       this.evalData.output = output;
@@ -131,8 +130,10 @@ export class TsRepl {
       return undefined;
     }
 
+    const isAutocompletionRequest = !/\n$/.test(code);
+
     try {
-      const result = this.compileAndExecute(code);
+      const result = this.compileAndExecute(code, isAutocompletionRequest);
       return {
         result: result,
         error: undefined,

--- a/packages/iov-cli/src/tsrepl.ts
+++ b/packages/iov-cli/src/tsrepl.ts
@@ -117,10 +117,13 @@ export class TsRepl {
       this.evalData.output = output;
     }
 
-    const lastResult = changes.reduce((result, change) => {
-      return change.added ? executeJavaScript(change.value, this.evalFilename) : result;
-    }, undefined);
-
+    // Execute new JavaScript. This may not necessarily be at the end only because e.g. an import
+    // statement in TypeScript is compiled to no JavaScript until the imported symbol is used
+    // somewhere. This btw. leads to a different execution order of imports than in the TS source.
+    let lastResult: any = undefined;
+    for (const added of changes.filter(change => change.added)) {
+      lastResult = executeJavaScript(added.value, this.evalFilename);
+    }
     return lastResult;
   }
 

--- a/packages/iov-cli/src/tsrepl.ts
+++ b/packages/iov-cli/src/tsrepl.ts
@@ -97,13 +97,13 @@ export class TsRepl {
   }
 
   private compileAndExecute(tsInput: string): any {
-    const lines = this.evalData.lines;
     const isCompletion = !/\n$/.test(tsInput);
     const undo = this.appendEval(tsInput);
     let output: string;
 
     try {
-      output = this.typeScriptService.compile(this.evalData.input, this.evalPath, -lines);
+      // lineOffset unused at the moment (https://github.com/TypeStrong/ts-node/issues/661)
+      output = this.typeScriptService.compile(this.evalData.input, this.evalPath);
     } catch (err) {
       undo();
       throw err;

--- a/packages/iov-cli/src/tsrepl.ts
+++ b/packages/iov-cli/src/tsrepl.ts
@@ -54,7 +54,7 @@ export class TsRepl {
     });
 
     // Bookmark the point where we should reset the REPL state.
-    const resetEval = this.appendEval("");
+    const resetEval = this.appendTypeScriptInput("");
 
     const reset = (): void => {
       resetEval();
@@ -78,7 +78,7 @@ export class TsRepl {
         }
 
         const identifierTypeScriptCode = `${identifier}\n`;
-        const undo = this.appendEval(identifierTypeScriptCode);
+        const undo = this.appendTypeScriptInput(identifierTypeScriptCode);
         const identifierFirstPosition = this.evalData.input.length - identifierTypeScriptCode.length;
         const { name, comment } = this.typeScriptService.getTypeInfo(
           this.evalData.input,
@@ -98,7 +98,7 @@ export class TsRepl {
 
   private compileAndExecute(tsInput: string): any {
     const isCompletion = !/\n$/.test(tsInput);
-    const undo = this.appendEval(tsInput);
+    const undo = this.appendTypeScriptInput(tsInput);
     let output: string;
 
     try {
@@ -163,7 +163,7 @@ export class TsRepl {
     }
   }
 
-  private appendEval(input: string): () => void {
+  private appendTypeScriptInput(input: string): () => void {
     const oldInput = this.evalData.input;
     const oldOutput = this.evalData.output;
 

--- a/packages/iov-cli/src/tsrepl.ts
+++ b/packages/iov-cli/src/tsrepl.ts
@@ -97,6 +97,13 @@ export class TsRepl {
   }
 
   private compileAndExecute(tsInput: string, isAutocompletionRequest: boolean): any {
+    if (!isAutocompletionRequest) {
+      // Expect POSIX lines (https://stackoverflow.com/a/729795)
+      if (tsInput.length > 0 && !tsInput.endsWith("\n")) {
+        throw new Error("final newline missing");
+      }
+    }
+
     const undo = this.appendTypeScriptInput(tsInput);
     let output: string;
 


### PR DESCRIPTION
This makes basic autocomplete work again

```
>> const profile = new UserProfile();↵
undefined
>> profile.↹↹
profile.__defineGetter__       profile.__defineSetter__       profile.__lookupGetter__       profile.__lookupSetter__
profile.__proto__              profile.constructor            profile.hasOwnProperty         profile.isPrototypeOf
profile.propertyIsEnumerable   profile.toLocaleString         profile.toString               profile.valueOf

profile.addEntry               profile.appendSignature        profile.createIdentity         profile.entryInPrimaryKeyring
profile.getIdentities          profile.lock                   profile.setEntryLabel          profile.setIdentityLabel
profile.signTransaction        profile.storeIn                

profile.createdAt              profile.entriesCount           profile.entriesCountProducer   profile.entryLabels
profile.entryLabelsProducer    profile.keyring                profile.locked                 profile.lockedProducer

