### PR TITLE
Add support for Windows and Edge

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "jasmine2-custom-message": "^0.9.1",
     "karma": "^3",
     "karma-chrome-launcher": "^2.2.0",
+    "karma-edge-launcher": "^0.4.2",
     "karma-firefox-launcher": "^1.1.0",
     "karma-jasmine": "^1.1.2",
     "karma-jasmine-html-reporter": "^1.1.0",

--- a/packages/iov-bcp-types/package.json
+++ b/packages/iov-bcp-types/package.json
@@ -15,13 +15,13 @@
   },
   "scripts": {
     "docs": "rm -rf docs && typedoc --options typedoc.js",
-    "format": "prettier --write --loglevel warn './src/**/*.ts'",
+    "format": "prettier --write --loglevel warn \"./src/**/*.ts\"",
     "lint": "tslint -t verbose --project .",
     "lint-fix": "yarn lint --fix",
     "prebuild": "yarn format && yarn lint",
     "build": "tsc && rm ./types/* && mv build/*.d.ts ./types",
     "build-or-skip": "[ -n \"$SKIP_BUILD\" ] || yarn build",
-    "test": "echo 'Info: no test specified'"
+    "test": "echo \"Info: no test specified\""
   },
   "dependencies": {
     "@iov/tendermint-types": "^0.3.0",

--- a/packages/iov-bns/package.json
+++ b/packages/iov-bns/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "docs": "rm -rf docs && typedoc --options typedoc.js",
     "lint": "tslint -t verbose --project .",
-    "format": "prettier --write --loglevel warn './src/**/*.ts'",
+    "format": "prettier --write --loglevel warn \"./src/**/*.ts\"",
     "test-node": "./jasmine-testrunner.js",
     "test-firefox": "yarn pack-web && karma start --single-run --browsers Firefox",
     "test-chrome": "yarn pack-web && karma start --single-run --browsers ChromeHeadless",

--- a/packages/iov-bns/package.json
+++ b/packages/iov-bns/package.json
@@ -18,6 +18,7 @@
     "lint": "tslint -t verbose --project .",
     "format": "prettier --write --loglevel warn \"./src/**/*.ts\"",
     "test-node": "node jasmine-testrunner.js",
+    "test-edge": "yarn pack-web && karma start --single-run --browsers Edge",
     "test-firefox": "yarn pack-web && karma start --single-run --browsers Firefox",
     "test-chrome": "yarn pack-web && karma start --single-run --browsers ChromeHeadless",
     "test-safari": "yarn pack-web && karma start --single-run --browsers Safari",

--- a/packages/iov-bns/package.json
+++ b/packages/iov-bns/package.json
@@ -17,7 +17,7 @@
     "docs": "rm -rf docs && typedoc --options typedoc.js",
     "lint": "tslint -t verbose --project .",
     "format": "prettier --write --loglevel warn \"./src/**/*.ts\"",
-    "test-node": "./jasmine-testrunner.js",
+    "test-node": "node jasmine-testrunner.js",
     "test-firefox": "yarn pack-web && karma start --single-run --browsers Firefox",
     "test-chrome": "yarn pack-web && karma start --single-run --browsers ChromeHeadless",
     "test-safari": "yarn pack-web && karma start --single-run --browsers Safari",

--- a/packages/iov-cli/package.json
+++ b/packages/iov-cli/package.json
@@ -16,7 +16,7 @@
     "prebuild": "yarn format",
     "build": "tsc",
     "build-or-skip": "[ -n \"$SKIP_BUILD\" ] || yarn build",
-    "test-node": "./jasmine-testrunner.js",
+    "test-node": "node jasmine-testrunner.js",
     "test-bin": "yarn build && ./bin/iov-cli",
     "test": "yarn build-or-skip && yarn test-node"
   },

--- a/packages/iov-cli/package.json
+++ b/packages/iov-cli/package.json
@@ -12,7 +12,7 @@
     "access": "public"
   },
   "scripts": {
-    "format": "prettier --write --loglevel warn './src/**/*.ts'",
+    "format": "prettier --write --loglevel warn \"./src/**/*.ts\"",
     "prebuild": "yarn format",
     "build": "tsc",
     "build-or-skip": "[ -n \"$SKIP_BUILD\" ] || yarn build",

--- a/packages/iov-core/package.json
+++ b/packages/iov-core/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "docs": "rm -rf docs && typedoc --options typedoc.js",
     "lint": "tslint -t verbose --project .",
-    "format": "prettier --write --loglevel warn './src/**/*.ts'",
+    "format": "prettier --write --loglevel warn \"./src/**/*.ts\"",
     "test-node": "./jasmine-testrunner.js",
     "test-firefox": "yarn pack-web && karma start --single-run --browsers Firefox",
     "test-chrome": "yarn pack-web && karma start --single-run --browsers ChromeHeadless",

--- a/packages/iov-core/package.json
+++ b/packages/iov-core/package.json
@@ -18,6 +18,7 @@
     "lint": "tslint -t verbose --project .",
     "format": "prettier --write --loglevel warn \"./src/**/*.ts\"",
     "test-node": "node jasmine-testrunner.js",
+    "test-edge": "yarn pack-web && karma start --single-run --browsers Edge",
     "test-firefox": "yarn pack-web && karma start --single-run --browsers Firefox",
     "test-chrome": "yarn pack-web && karma start --single-run --browsers ChromeHeadless",
     "test-safari": "yarn pack-web && karma start --single-run --browsers Safari",

--- a/packages/iov-core/package.json
+++ b/packages/iov-core/package.json
@@ -17,7 +17,7 @@
     "docs": "rm -rf docs && typedoc --options typedoc.js",
     "lint": "tslint -t verbose --project .",
     "format": "prettier --write --loglevel warn \"./src/**/*.ts\"",
-    "test-node": "./jasmine-testrunner.js",
+    "test-node": "node jasmine-testrunner.js",
     "test-firefox": "yarn pack-web && karma start --single-run --browsers Firefox",
     "test-chrome": "yarn pack-web && karma start --single-run --browsers ChromeHeadless",
     "test-safari": "yarn pack-web && karma start --single-run --browsers Safari",

--- a/packages/iov-crypto/karma.conf.js
+++ b/packages/iov-crypto/karma.conf.js
@@ -16,7 +16,6 @@ module.exports = function(config) {
     client: {
       jasmine: {
         random: false,
-        timeoutInterval: 15*1000,
       }
     },
 

--- a/packages/iov-crypto/karma.conf.js
+++ b/packages/iov-crypto/karma.conf.js
@@ -16,6 +16,7 @@ module.exports = function(config) {
     client: {
       jasmine: {
         random: false,
+        timeoutInverval: 15*1000,
       }
     },
 

--- a/packages/iov-crypto/karma.conf.js
+++ b/packages/iov-crypto/karma.conf.js
@@ -16,7 +16,7 @@ module.exports = function(config) {
     client: {
       jasmine: {
         random: false,
-        timeoutInverval: 15*1000,
+        timeoutInterval: 15*1000,
       }
     },
 

--- a/packages/iov-crypto/package.json
+++ b/packages/iov-crypto/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "docs": "rm -rf docs && typedoc --options typedoc.js",
     "lint": "tslint -t verbose --project .",
-    "format": "prettier --write --loglevel warn './src/**/*.ts'",
+    "format": "prettier --write --loglevel warn \"./src/**/*.ts\"",
     "test-node": "./jasmine-testrunner.js",
     "test-firefox": "yarn pack-web && karma start --single-run --browsers Firefox",
     "test-chrome": "yarn pack-web && karma start --single-run --browsers ChromeHeadless",

--- a/packages/iov-crypto/package.json
+++ b/packages/iov-crypto/package.json
@@ -18,6 +18,7 @@
     "lint": "tslint -t verbose --project .",
     "format": "prettier --write --loglevel warn \"./src/**/*.ts\"",
     "test-node": "node jasmine-testrunner.js",
+    "test-edge": "yarn pack-web && karma start --single-run --browsers Edge",
     "test-firefox": "yarn pack-web && karma start --single-run --browsers Firefox",
     "test-chrome": "yarn pack-web && karma start --single-run --browsers ChromeHeadless",
     "test-safari": "yarn pack-web && karma start --single-run --browsers Safari",

--- a/packages/iov-crypto/package.json
+++ b/packages/iov-crypto/package.json
@@ -17,7 +17,7 @@
     "docs": "rm -rf docs && typedoc --options typedoc.js",
     "lint": "tslint -t verbose --project .",
     "format": "prettier --write --loglevel warn \"./src/**/*.ts\"",
-    "test-node": "./jasmine-testrunner.js",
+    "test-node": "node jasmine-testrunner.js",
     "test-firefox": "yarn pack-web && karma start --single-run --browsers Firefox",
     "test-chrome": "yarn pack-web && karma start --single-run --browsers ChromeHeadless",
     "test-safari": "yarn pack-web && karma start --single-run --browsers Safari",

--- a/packages/iov-crypto/src/bip39.spec.ts
+++ b/packages/iov-crypto/src/bip39.spec.ts
@@ -7,7 +7,7 @@ const fromHex = Encoding.fromHex;
 // Set here for Browsers until this can be configured in Karma
 // https://github.com/karma-runner/karma-jasmine/pull/211
 // tslint:disable-next-line:no-object-mutation
-jasmine.DEFAULT_TIMEOUT_INTERVAL = 30*1000;
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 30 * 1000;
 
 describe("Bip39", () => {
   it("can encode to mnemonic", () => {

--- a/packages/iov-crypto/src/bip39.spec.ts
+++ b/packages/iov-crypto/src/bip39.spec.ts
@@ -226,7 +226,7 @@ describe("Bip39", () => {
     expect(await Bip39.mnemonicToSeed(new EnglishMnemonic("vessel ladder alter error federal sibling chat ability sun glass valve picture"), "TREZOR")).toEqual(fromHex("2aaa9242daafcee6aa9d7269f17d4efe271e1b9a529178d7dc139cd18747090bf9d60295d0ce74309a78852a9caadf0af48aae1c6253839624076224374bc63f"));
     expect(await Bip39.mnemonicToSeed(new EnglishMnemonic("scissors invite lock maple supreme raw rapid void congress muscle digital elegant little brisk hair mango congress clump"), "TREZOR")).toEqual(fromHex("7b4a10be9d98e6cba265566db7f136718e1398c71cb581e1b2f464cac1ceedf4f3e274dc270003c670ad8d02c4558b2f8e39edea2775c9e232c7cb798b069e88"));
     expect(await Bip39.mnemonicToSeed(new EnglishMnemonic("void come effort suffer camp survey warrior heavy shoot primary clutch crush open amazing screen patrol group space point ten exist slush involve unfold"), "TREZOR")).toEqual(fromHex("01f5bced59dec48e362f2c45b5de68b9fd6c92c6634f44d6d40aab69056506f0e35524a518034ddc1192e1dacd32c1ed3eaa3c3b131c88ed8e7e54c49a5d0998"));
-  });
+  }, 30*1000);
 
   it("can calculate seed from mnemonic (no password)", async () => {
     // custom test vectors using
@@ -247,5 +247,5 @@ describe("Bip39", () => {
     expect(await Bip39.mnemonicToSeed(new EnglishMnemonic("robust pipe raise illness symptom crowd trip will slow assault recipe oven"))).toEqual(fromHex("5539eed11e1096e9d52f69f15ad3d7c6547a40a3865b9517dbcbb03c31f231900622f58616d64d2d1cc0440f31d67fb0b2699a5fc885f796c746e0f844477093"));
     expect(await Bip39.mnemonicToSeed(new EnglishMnemonic("pair ethics august street tornado spare present under capital raise cross current main craft stone clutch tray all"))).toEqual(fromHex("1272467e954cec4e0ad720002d037a3aaf795a57ffbeea6aaa0c242d410eb52050292447aa2c68470a07ecc80171edfa9e027793265047be3128d94e867a4f99"));
     expect(await Bip39.mnemonicToSeed(new EnglishMnemonic("allow finger front connect strategy purchase journey distance trouble guitar honey alpha giraffe canal junk vintage chronic blade gate custom soap flip first mix"))).toEqual(fromHex("476a41ac016b5bdf9f114456929975a036ae326e2efdca441ac5a0949ef89ab9246dc9e49a5d2d64d1926eb9dbe17576cb010471c2a821b216202acdf3d7a27b"));
-  });
+  }, 30*1000);
 });

--- a/packages/iov-crypto/src/bip39.spec.ts
+++ b/packages/iov-crypto/src/bip39.spec.ts
@@ -4,6 +4,10 @@ import { Bip39, EnglishMnemonic } from "./bip39";
 
 const fromHex = Encoding.fromHex;
 
+// Set here for Browsers until this can be configured in Karma
+// https://github.com/karma-runner/karma-jasmine/pull/211
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 30*1000;
+
 describe("Bip39", () => {
   it("can encode to mnemonic", () => {
     // Test vectors from
@@ -226,7 +230,7 @@ describe("Bip39", () => {
     expect(await Bip39.mnemonicToSeed(new EnglishMnemonic("vessel ladder alter error federal sibling chat ability sun glass valve picture"), "TREZOR")).toEqual(fromHex("2aaa9242daafcee6aa9d7269f17d4efe271e1b9a529178d7dc139cd18747090bf9d60295d0ce74309a78852a9caadf0af48aae1c6253839624076224374bc63f"));
     expect(await Bip39.mnemonicToSeed(new EnglishMnemonic("scissors invite lock maple supreme raw rapid void congress muscle digital elegant little brisk hair mango congress clump"), "TREZOR")).toEqual(fromHex("7b4a10be9d98e6cba265566db7f136718e1398c71cb581e1b2f464cac1ceedf4f3e274dc270003c670ad8d02c4558b2f8e39edea2775c9e232c7cb798b069e88"));
     expect(await Bip39.mnemonicToSeed(new EnglishMnemonic("void come effort suffer camp survey warrior heavy shoot primary clutch crush open amazing screen patrol group space point ten exist slush involve unfold"), "TREZOR")).toEqual(fromHex("01f5bced59dec48e362f2c45b5de68b9fd6c92c6634f44d6d40aab69056506f0e35524a518034ddc1192e1dacd32c1ed3eaa3c3b131c88ed8e7e54c49a5d0998"));
-  }, 30*1000);
+  });
 
   it("can calculate seed from mnemonic (no password)", async () => {
     // custom test vectors using
@@ -247,5 +251,5 @@ describe("Bip39", () => {
     expect(await Bip39.mnemonicToSeed(new EnglishMnemonic("robust pipe raise illness symptom crowd trip will slow assault recipe oven"))).toEqual(fromHex("5539eed11e1096e9d52f69f15ad3d7c6547a40a3865b9517dbcbb03c31f231900622f58616d64d2d1cc0440f31d67fb0b2699a5fc885f796c746e0f844477093"));
     expect(await Bip39.mnemonicToSeed(new EnglishMnemonic("pair ethics august street tornado spare present under capital raise cross current main craft stone clutch tray all"))).toEqual(fromHex("1272467e954cec4e0ad720002d037a3aaf795a57ffbeea6aaa0c242d410eb52050292447aa2c68470a07ecc80171edfa9e027793265047be3128d94e867a4f99"));
     expect(await Bip39.mnemonicToSeed(new EnglishMnemonic("allow finger front connect strategy purchase journey distance trouble guitar honey alpha giraffe canal junk vintage chronic blade gate custom soap flip first mix"))).toEqual(fromHex("476a41ac016b5bdf9f114456929975a036ae326e2efdca441ac5a0949ef89ab9246dc9e49a5d2d64d1926eb9dbe17576cb010471c2a821b216202acdf3d7a27b"));
-  }, 30*1000);
+  });
 });

--- a/packages/iov-crypto/src/bip39.spec.ts
+++ b/packages/iov-crypto/src/bip39.spec.ts
@@ -6,6 +6,7 @@ const fromHex = Encoding.fromHex;
 
 // Set here for Browsers until this can be configured in Karma
 // https://github.com/karma-runner/karma-jasmine/pull/211
+// tslint:disable-next-line:no-object-mutation
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 30*1000;
 
 describe("Bip39", () => {

--- a/packages/iov-encoding/package.json
+++ b/packages/iov-encoding/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "docs": "rm -rf docs && typedoc --options typedoc.js",
     "lint": "tslint -t verbose --project .",
-    "format": "prettier --write --loglevel warn './src/**/*.ts'",
+    "format": "prettier --write --loglevel warn \"./src/**/*.ts\"",
     "test-node": "./jasmine-testrunner.js",
     "test-firefox": "yarn pack-web && karma start --single-run --browsers Firefox",
     "test-chrome": "yarn pack-web && karma start --single-run --browsers ChromeHeadless",

--- a/packages/iov-encoding/package.json
+++ b/packages/iov-encoding/package.json
@@ -18,6 +18,7 @@
     "lint": "tslint -t verbose --project .",
     "format": "prettier --write --loglevel warn \"./src/**/*.ts\"",
     "test-node": "node jasmine-testrunner.js",
+    "test-edge": "yarn pack-web && karma start --single-run --browsers Edge",
     "test-firefox": "yarn pack-web && karma start --single-run --browsers Firefox",
     "test-chrome": "yarn pack-web && karma start --single-run --browsers ChromeHeadless",
     "test-safari": "yarn pack-web && karma start --single-run --browsers Safari",

--- a/packages/iov-encoding/package.json
+++ b/packages/iov-encoding/package.json
@@ -17,7 +17,7 @@
     "docs": "rm -rf docs && typedoc --options typedoc.js",
     "lint": "tslint -t verbose --project .",
     "format": "prettier --write --loglevel warn \"./src/**/*.ts\"",
-    "test-node": "./jasmine-testrunner.js",
+    "test-node": "node jasmine-testrunner.js",
     "test-firefox": "yarn pack-web && karma start --single-run --browsers Firefox",
     "test-chrome": "yarn pack-web && karma start --single-run --browsers ChromeHeadless",
     "test-safari": "yarn pack-web && karma start --single-run --browsers Safari",

--- a/packages/iov-encoding/src/encoding.ts
+++ b/packages/iov-encoding/src/encoding.ts
@@ -162,6 +162,6 @@ export class Encoding {
 
   private static isValidUtf8(data: Uint8Array): boolean {
     const toStringAndBack = Buffer.from(Buffer.from(data).toString("utf8"), "utf8");
-    return Buffer.compare(data, toStringAndBack) === 0;
+    return Buffer.compare(Buffer.from(data), toStringAndBack) === 0;
   }
 }

--- a/packages/iov-keycontrol/package.json
+++ b/packages/iov-keycontrol/package.json
@@ -15,7 +15,7 @@
   },
   "scripts": {
     "docs": "rm -rf docs && typedoc --options typedoc.js",
-    "format": "prettier --write --loglevel warn './src/**/*.ts'",
+    "format": "prettier --write --loglevel warn \"./src/**/*.ts\"",
     "lint": "tslint -t verbose --project .",
     "lint-fix": "yarn lint --fix",
     "test-node": "./jasmine-testrunner.js",

--- a/packages/iov-keycontrol/package.json
+++ b/packages/iov-keycontrol/package.json
@@ -18,7 +18,7 @@
     "format": "prettier --write --loglevel warn \"./src/**/*.ts\"",
     "lint": "tslint -t verbose --project .",
     "lint-fix": "yarn lint --fix",
-    "test-node": "./jasmine-testrunner.js",
+    "test-node": "node jasmine-testrunner.js",
     "test-firefox": "yarn pack-web && karma start --single-run --browsers Firefox",
     "test-chrome": "yarn pack-web && karma start --single-run --browsers ChromeHeadless",
     "test-safari": "yarn pack-web && karma start --single-run --browsers Safari",

--- a/packages/iov-keycontrol/package.json
+++ b/packages/iov-keycontrol/package.json
@@ -19,6 +19,7 @@
     "lint": "tslint -t verbose --project .",
     "lint-fix": "yarn lint --fix",
     "test-node": "node jasmine-testrunner.js",
+    "test-edge": "yarn pack-web && karma start --single-run --browsers Edge",
     "test-firefox": "yarn pack-web && karma start --single-run --browsers Firefox",
     "test-chrome": "yarn pack-web && karma start --single-run --browsers ChromeHeadless",
     "test-safari": "yarn pack-web && karma start --single-run --browsers Safari",

--- a/packages/iov-keycontrol/src/keyring-entries/ed25519hd.spec.ts
+++ b/packages/iov-keycontrol/src/keyring-entries/ed25519hd.spec.ts
@@ -9,7 +9,7 @@ import { Ed25519HdKeyringEntry } from "./ed25519hd";
 // Set here for Browsers until this can be configured in Karma
 // https://github.com/karma-runner/karma-jasmine/pull/211
 // tslint:disable-next-line:no-object-mutation
-jasmine.DEFAULT_TIMEOUT_INTERVAL = 30*1000;
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 30 * 1000;
 
 describe("Ed25519HdKeyringEntry", () => {
   const emptyEntry = '{ "secret": "rhythm they leave position crowd cart pilot student razor indoor gesture thrive", "identities": [] }' as KeyringEntrySerializationString;

--- a/packages/iov-keycontrol/src/keyring-entries/ed25519hd.spec.ts
+++ b/packages/iov-keycontrol/src/keyring-entries/ed25519hd.spec.ts
@@ -6,6 +6,10 @@ import { Algorithm, ChainId } from "@iov/tendermint-types";
 import { KeyringEntrySerializationString } from "../keyring";
 import { Ed25519HdKeyringEntry } from "./ed25519hd";
 
+// Set here for Browsers until this can be configured in Karma
+// https://github.com/karma-runner/karma-jasmine/pull/211
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 30*1000;
+
 describe("Ed25519HdKeyringEntry", () => {
   const emptyEntry = '{ "secret": "rhythm they leave position crowd cart pilot student razor indoor gesture thrive", "identities": [] }' as KeyringEntrySerializationString;
 

--- a/packages/iov-keycontrol/src/keyring-entries/ed25519hd.spec.ts
+++ b/packages/iov-keycontrol/src/keyring-entries/ed25519hd.spec.ts
@@ -8,6 +8,7 @@ import { Ed25519HdKeyringEntry } from "./ed25519hd";
 
 // Set here for Browsers until this can be configured in Karma
 // https://github.com/karma-runner/karma-jasmine/pull/211
+// tslint:disable-next-line:no-object-mutation
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 30*1000;
 
 describe("Ed25519HdKeyringEntry", () => {

--- a/packages/iov-ledger-bns/package.json
+++ b/packages/iov-ledger-bns/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "docs": "rm -rf docs && typedoc --options typedoc.js",
     "lint": "tslint -t verbose --project .",
-    "format": "prettier --write --loglevel warn './src/**/*.ts'",
+    "format": "prettier --write --loglevel warn \"./src/**/*.ts\"",
     "test-node": "./jasmine-testrunner.js",
     "test": "yarn build-or-skip && yarn test-node",
     "prebuild": "yarn format && yarn lint",

--- a/packages/iov-ledger-bns/package.json
+++ b/packages/iov-ledger-bns/package.json
@@ -17,7 +17,7 @@
     "docs": "rm -rf docs && typedoc --options typedoc.js",
     "lint": "tslint -t verbose --project .",
     "format": "prettier --write --loglevel warn \"./src/**/*.ts\"",
-    "test-node": "./jasmine-testrunner.js",
+    "test-node": "node jasmine-testrunner.js",
     "test": "yarn build-or-skip && yarn test-node",
     "prebuild": "yarn format && yarn lint",
     "build": "tsc && rm ./types/* && mv build/*.d.ts ./types",

--- a/packages/iov-tendermint-rpc/package.json
+++ b/packages/iov-tendermint-rpc/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "docs": "rm -rf docs && typedoc --options typedoc.js",
     "lint": "tslint -t verbose --project .",
-    "format": "prettier --write --loglevel warn './src/**/*.ts'",
+    "format": "prettier --write --loglevel warn \"./src/**/*.ts\"",
     "test-node": "./jasmine-testrunner.js",
     "test-firefox": "yarn pack-web && karma start --single-run --browsers Firefox",
     "test-chrome": "yarn pack-web && karma start --single-run --browsers ChromeHeadless",

--- a/packages/iov-tendermint-rpc/package.json
+++ b/packages/iov-tendermint-rpc/package.json
@@ -18,6 +18,7 @@
     "lint": "tslint -t verbose --project .",
     "format": "prettier --write --loglevel warn \"./src/**/*.ts\"",
     "test-node": "node jasmine-testrunner.js",
+    "test-edge": "yarn pack-web && karma start --single-run --browsers Edge",
     "test-firefox": "yarn pack-web && karma start --single-run --browsers Firefox",
     "test-chrome": "yarn pack-web && karma start --single-run --browsers ChromeHeadless",
     "test-safari": "yarn pack-web && karma start --single-run --browsers Safari",

--- a/packages/iov-tendermint-rpc/package.json
+++ b/packages/iov-tendermint-rpc/package.json
@@ -17,7 +17,7 @@
     "docs": "rm -rf docs && typedoc --options typedoc.js",
     "lint": "tslint -t verbose --project .",
     "format": "prettier --write --loglevel warn \"./src/**/*.ts\"",
-    "test-node": "./jasmine-testrunner.js",
+    "test-node": "node jasmine-testrunner.js",
     "test-firefox": "yarn pack-web && karma start --single-run --browsers Firefox",
     "test-chrome": "yarn pack-web && karma start --single-run --browsers ChromeHeadless",
     "test-safari": "yarn pack-web && karma start --single-run --browsers Safari",

--- a/packages/iov-tendermint-types/package.json
+++ b/packages/iov-tendermint-types/package.json
@@ -15,13 +15,13 @@
   },
   "scripts": {
     "docs": "rm -rf docs && typedoc --options typedoc.js",
-    "format": "prettier --write --loglevel warn './src/**/*.ts'",
+    "format": "prettier --write --loglevel warn \"./src/**/*.ts\"",
     "lint": "tslint -t verbose --project .",
     "lint-fix": "yarn lint --fix",
     "prebuild": "yarn format && yarn lint",
     "build": "tsc && rm ./types/* && mv build/*.d.ts ./types",
     "build-or-skip": "[ -n \"$SKIP_BUILD\" ] || yarn build",
-    "test": "echo 'Info: no test specified'"
+    "test": "echo \"Info: no test specified\""
   },
   "dependencies": {
     "@types/long": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2132,6 +2132,10 @@ ecc-jsbn@~0.1.1:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
 
+edge-launcher@1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/edge-launcher/-/edge-launcher-1.2.2.tgz#eb40aafbd067a6ea76efffab0647bcd5509b37b2"
+
 ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
@@ -3354,6 +3358,12 @@ karma-chrome-launcher@^2.2.0:
   dependencies:
     fs-access "^1.0.0"
     which "^1.2.1"
+
+karma-edge-launcher@^0.4.2:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/karma-edge-launcher/-/karma-edge-launcher-0.4.2.tgz#3d9529b09b13c909c5f3ceee12d00e7f9a989b3d"
+  dependencies:
+    edge-launcher "1.2.2"
 
 karma-firefox-launcher@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
With this I can build and run tests on Node, Firefox and Edge on Windows locally.

This already found a bug for us (1395c9b8f2f685905a0173f3a8e0eb4a77e81003)

See #158