### PR TITLE
Run nodejs tests on Windows using AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,26 @@
+# whitelist long living branches
+branches:
+  only:
+    - master
+
+environment:
+  matrix:
+    - nodejs_version: "8"
+    - nodejs_version: "9"
+    - nodejs_version: "10"
+
+install:
+  - ps: Install-Product node $env:nodejs_version
+  - node --version
+  - npm --version
+  - yarn --version
+  - yarn install
+
+build_script:
+  - yarn build
+
+test_script:
+  - yarn test
+
+  # Edge is not available on Windows Server
+  # - yarn run lerna run test-edge


### PR DESCRIPTION
No Edge browser available but at least our build system and some additional nodejs versions are checked