### PR TITLE
Remove nodejs 9 test in AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,6 @@ branches:
 environment:
   matrix:
     - nodejs_version: "8"
-    - nodejs_version: "9"
     - nodejs_version: "10"
 
 install:


### PR DESCRIPTION
to speed up CI