### PR TITLE
Expose subscriptions in @iov/bns.Client

### DIFF
--- a/packages/iov-bcp-types/src/bcp.ts
+++ b/packages/iov-bcp-types/src/bcp.ts
@@ -49,6 +49,7 @@ export interface BcpTransactionResponse {
   readonly metadata: {
     // status says if it succeeds
     readonly status: boolean;
+    readonly height?: number;
   };
   readonly data: {
     readonly message: string;

--- a/packages/iov-bcp-types/src/bcp.ts
+++ b/packages/iov-bcp-types/src/bcp.ts
@@ -128,7 +128,7 @@ export interface IovReader {
 }
 
 export interface ConfirmedTransaction extends SignedTransaction {
-  readonly height: number; // the block it was writen to
+  readonly height: number; // the block it was written to
   // TODO: TxData (result, code, tags...)
   // readonly tags: ReadonlyArray<Tag>;
   // readonly result?: Uint8Array;

--- a/packages/iov-bcp-types/types/bcp.d.ts
+++ b/packages/iov-bcp-types/types/bcp.d.ts
@@ -1,4 +1,5 @@
-import { ChainId, PostableBytes, PublicKeyBundle, TxQuery } from "@iov/tendermint-types";
+import { Stream } from "xstream";
+import { ChainId, PostableBytes, PublicKeyBundle, Tag, TxQuery } from "@iov/tendermint-types";
 import { Address, SignedTransaction } from "./signables";
 import { Nonce, TokenTicker } from "./transactions";
 export interface BcpQueryEnvelope<T extends BcpData> {
@@ -47,14 +48,21 @@ export interface BcpValueNameQuery {
 export declare type BcpAccountQuery = BcpAddressQuery | BcpValueNameQuery;
 export interface IovReader {
     readonly disconnect: () => void;
+    readonly chainId: () => Promise<ChainId>;
+    readonly height: () => Promise<number>;
     readonly postTx: (tx: PostableBytes) => Promise<BcpTransactionResponse>;
     readonly getTicker: (ticker: TokenTicker) => Promise<BcpQueryEnvelope<BcpTicker>>;
     readonly getAllTickers: () => Promise<BcpQueryEnvelope<BcpTicker>>;
     readonly getAccount: (account: BcpAccountQuery) => Promise<BcpQueryEnvelope<BcpAccount>>;
     readonly getNonce: (account: BcpAccountQuery) => Promise<BcpQueryEnvelope<BcpNonce>>;
-    readonly chainId: () => Promise<ChainId>;
-    readonly height: () => Promise<number>;
+    readonly changeBalance: (addr: Address) => Stream<number>;
+    readonly changeNonce: (addr: Address) => Stream<number>;
+    readonly changeBlock: () => Stream<number>;
+    readonly watchAccount: (account: BcpAccountQuery) => Stream<BcpAccount | undefined>;
+    readonly watchNonce: (account: BcpAccountQuery) => Stream<BcpNonce | undefined>;
     readonly searchTx: (query: TxQuery) => Promise<ReadonlyArray<ConfirmedTransaction>>;
+    readonly listenTx: (tags: ReadonlyArray<Tag>) => Stream<ConfirmedTransaction>;
+    readonly liveTx: (txQuery: TxQuery) => Stream<ConfirmedTransaction>;
 }
 export interface ConfirmedTransaction extends SignedTransaction {
     readonly height: number;

--- a/packages/iov-bcp-types/types/bcp.d.ts
+++ b/packages/iov-bcp-types/types/bcp.d.ts
@@ -32,6 +32,7 @@ export interface BcpTicker {
 export interface BcpTransactionResponse {
     readonly metadata: {
         readonly status: boolean;
+        readonly height?: number;
     };
     readonly data: {
         readonly message: string;

--- a/packages/iov-bns/src/client.spec.ts
+++ b/packages/iov-bns/src/client.spec.ts
@@ -281,6 +281,7 @@ describe("Integration tests with bov+tendermint", () => {
 
     // disconnect the client, so all the live streams complete,
     // and promises resolve
+    await sleep(50);
     client.disconnect();
     // this should grab the tx before it started, as well as the one after
     expect(await countLive).toEqual(2);
@@ -314,6 +315,7 @@ describe("Integration tests with bov+tendermint", () => {
 
     // disconnect the client, so all the live streams complete,
     // and promises resolve
+    await sleep(50);
     client.disconnect();
 
     // both should show up on the balance changes

--- a/packages/iov-bns/src/client.spec.ts
+++ b/packages/iov-bns/src/client.spec.ts
@@ -35,7 +35,7 @@ describe("Integration tests with bov+tendermint", () => {
 
   // TODO: had issues with websockets? check again later, maybe they need to close at end?
   // max open connections??? (but 900 by default)
-  const tendermintUrl = "http://localhost:22345";
+  const tendermintUrl = "ws://localhost:22345";
 
   const userProfile = async (): Promise<UserProfile> => {
     const profile = new UserProfile();
@@ -87,6 +87,8 @@ describe("Integration tests with bov+tendermint", () => {
     // we expect some block to have been created
     const height = await client.height();
     expect(height).toBeGreaterThan(1);
+
+    client.disconnect();
   });
 
   it("can disconnect from tendermint", async () => {
@@ -107,6 +109,8 @@ describe("Integration tests with bov+tendermint", () => {
     expect(ticker.tokenTicker).toEqual(cash);
     expect(ticker.tokenName).toEqual("Main token of this chain");
     expect(ticker.sigFigs).toEqual(6);
+
+    client.disconnect();
   });
 
   it("Can query accounts", async () => {
@@ -140,6 +144,8 @@ describe("Integration tests with bov+tendermint", () => {
     const empty = await client.getAccount({ address: rcptAddr });
     expect(empty).toBeTruthy();
     expect(empty.data.length).toEqual(0);
+
+    client.disconnect();
   });
 
   it("Can query empty nonce", async () => {
@@ -153,6 +159,8 @@ describe("Integration tests with bov+tendermint", () => {
     // can get the faucet by address (there is money)
     const nonce = await getNonce(client, rcptAddr);
     expect(nonce.toInt()).toEqual(0);
+
+    client.disconnect();
   });
 
   it("Can send transaction", async () => {
@@ -220,6 +228,8 @@ describe("Integration tests with bov+tendermint", () => {
     const tx = mine.transaction;
     expect(tx.kind).toEqual(sendTx.kind);
     expect(tx).toEqual(sendTx);
+
+    client.disconnect();
   });
 
   const sendCash = async (

--- a/packages/iov-bns/src/index.ts
+++ b/packages/iov-bns/src/index.ts
@@ -1,2 +1,3 @@
 export { bnsCodec } from "./bnscodec";
 export { Client } from "./client";
+export { asArray, countStream, lastValue, Reducer } from "./stream";

--- a/packages/iov-bns/src/stream.spec.ts
+++ b/packages/iov-bns/src/stream.spec.ts
@@ -1,0 +1,38 @@
+// tslint:disable:readonly-array
+import { Stream } from "xstream";
+import { countStream, readIntoArray, streamPromise } from "./stream";
+
+describe("Test stream helpers", () => {
+  it("readIntoArray returns input", async () => {
+    const input = [1, 6, 92, 2, 9];
+    const stream = Stream.fromArray(input);
+    const result = await readIntoArray<number>(stream);
+    expect(result).toEqual(input);
+  });
+
+  it("readIntoArray throws error", async () => {
+    const stream = Stream.throw("error");
+    try {
+      await readIntoArray<number>(stream);
+      fail("This should have thrown an error");
+    } catch (err) {
+      expect(err).toEqual("error");
+    }
+  });
+
+  it("streamPromise will send many values on a stream", async () => {
+    const input = ["a", "fd", "fvss", "gs"];
+    const prom = new Promise<ReadonlyArray<string>>(resolve => resolve(input));
+    const stream = streamPromise(prom);
+    const read = await countStream(stream);
+    expect(read).toEqual(input.length);
+  });
+
+  it("streamPromise will send proper values", async () => {
+    const input = ["let", "us", "say", "something"];
+    const prom = new Promise<ReadonlyArray<string>>(resolve => resolve(input));
+    const stream = streamPromise(prom);
+    const read = await readIntoArray(stream);
+    expect(read).toEqual(input);
+  });
+});

--- a/packages/iov-bns/src/stream.spec.ts
+++ b/packages/iov-bns/src/stream.spec.ts
@@ -1,19 +1,21 @@
 // tslint:disable:readonly-array
 import { Stream } from "xstream";
-import { countStream, readIntoArray, streamPromise } from "./stream";
+import { asArray, countStream, streamPromise } from "./stream";
 
 describe("Test stream helpers", () => {
   it("readIntoArray returns input", async () => {
     const input = [1, 6, 92, 2, 9];
     const stream = Stream.fromArray(input);
-    const result = await readIntoArray<number>(stream);
-    expect(result).toEqual(input);
+    const result = asArray<number>(stream);
+    await result.finished();
+    expect(result.value()).toEqual(input);
   });
 
-  it("readIntoArray throws error", async () => {
+  it("Reducer.finished throws error on stream error", async () => {
     const stream = Stream.throw("error");
     try {
-      await readIntoArray<number>(stream);
+      const result = asArray<number>(stream);
+      await result.finished();
       fail("This should have thrown an error");
     } catch (err) {
       expect(err).toEqual("error");
@@ -21,18 +23,25 @@ describe("Test stream helpers", () => {
   });
 
   it("streamPromise will send many values on a stream", async () => {
+    // create a promise that will resolve to an array of strings
     const input = ["a", "fd", "fvss", "gs"];
     const prom = new Promise<ReadonlyArray<string>>(resolve => resolve(input));
     const stream = streamPromise(prom);
-    const read = await countStream(stream);
-    expect(read).toEqual(input.length);
+
+    // materialize stream into a counter, and wait for stream to complete
+    const counter = countStream(stream);
+    await counter.finished();
+    expect(counter.value()).toEqual(input.length);
   });
 
   it("streamPromise will send proper values", async () => {
     const input = ["let", "us", "say", "something"];
     const prom = new Promise<ReadonlyArray<string>>(resolve => resolve(input));
     const stream = streamPromise(prom);
-    const read = await readIntoArray(stream);
-    expect(read).toEqual(input);
+
+    // materialize stream into an array, and wait for stream to complete
+    const read = asArray<string>(stream);
+    await read.finished();
+    expect(read.value()).toEqual(input);
   });
 });

--- a/packages/iov-bns/src/stream.ts
+++ b/packages/iov-bns/src/stream.ts
@@ -1,0 +1,55 @@
+import { InternalListener, InternalProducer, Stream } from "xstream";
+
+// streamPromise takes a Promsie that returns an array
+// and emits one event for each element of the array
+export function streamPromise<T>(promise: Promise<ReadonlyArray<T>>): Stream<T> {
+  return new Stream<T>(new StreamPromise<T>(promise));
+}
+
+// Heavily based on xstream's FromPromise implementation
+// https://github.com/staltz/xstream/blob/master/src/index.ts#L436-L467
+class StreamPromise<T> implements InternalProducer<T> {
+  public readonly type = "streamPromise";
+  public readonly p: PromiseLike<ReadonlyArray<T>>;
+  // tslint:disable-next-line:readonly-keyword
+  public on: boolean;
+
+  constructor(p: PromiseLike<ReadonlyArray<T>>) {
+    this.on = false;
+    this.p = p;
+  }
+
+  public _start(out: InternalListener<T>): void {
+    // tslint:disable-next-line:no-this-assignment
+    const that = this;
+    // tslint:disable-next-line:no-object-mutation
+    this.on = true;
+    this.p
+      .then(
+        (vs: ReadonlyArray<T>) => {
+          if (that.on) {
+            for (const v of vs) {
+              out._n(v);
+            }
+            out._c();
+          }
+        },
+        (e: any) => {
+          out._e(e);
+        },
+      )
+      .then(
+        () => 0,
+        (err: any) => {
+          setTimeout(() => {
+            throw err;
+          });
+        },
+      );
+  }
+
+  public _stop(): void {
+    // tslint:disable-next-line:no-object-mutation
+    this.on = false;
+  }
+}

--- a/packages/iov-bns/src/stream.ts
+++ b/packages/iov-bns/src/stream.ts
@@ -6,6 +6,31 @@ export function streamPromise<T>(promise: Promise<ReadonlyArray<T>>): Stream<T> 
   return new Stream<T>(new StreamPromise<T>(promise));
 }
 
+export async function readIntoArray<T>(stream: Stream<T>): Promise<ReadonlyArray<T>> {
+  const concat = (acc: ReadonlyArray<T>, val: T) => acc.concat(val);
+  const result = stream.fold(concat, []).last();
+  return new Promise<ReadonlyArray<T>>((resolve, reject) => {
+    result.addListener({
+      next: (val: ReadonlyArray<T>) => resolve(val),
+      error: (err: any) => reject(err),
+    });
+  });
+}
+
+export async function countStream<T>(stream: Stream<T>): Promise<number> {
+  // tslint:disable-next-line:no-let
+  let count = 0;
+  return new Promise<number>((resolve, reject) => {
+    stream.addListener({
+      next: () => {
+        count++;
+      },
+      error: (err: any) => reject(err),
+      complete: () => resolve(count),
+    });
+  });
+}
+
 // Heavily based on xstream's FromPromise implementation
 // https://github.com/staltz/xstream/blob/master/src/index.ts#L436-L467
 class StreamPromise<T> implements InternalProducer<T> {

--- a/packages/iov-bns/types/client.d.ts
+++ b/packages/iov-bns/types/client.d.ts
@@ -6,6 +6,7 @@ import { InitData } from "./normalize";
 import { Result } from "./types";
 export declare class Client implements IovReader {
     static fromOrToTag(addr: Address): Tag;
+    static nonceTag(addr: Address): Tag;
     static connect(url: string): Promise<Client>;
     protected readonly tmClient: TendermintClient;
     protected readonly codec: TxReadCodec;
@@ -19,11 +20,14 @@ export declare class Client implements IovReader {
     getTicker(ticker: TokenTicker): Promise<BcpQueryEnvelope<BcpTicker>>;
     getAllTickers(): Promise<BcpQueryEnvelope<BcpTicker>>;
     getAccount(account: BcpAccountQuery): Promise<BcpQueryEnvelope<BcpAccount>>;
-    watchAccount(account: BcpAccountQuery): Stream<BcpQueryEnvelope<BcpAccount>>;
     getNonce(account: BcpAccountQuery): Promise<BcpQueryEnvelope<BcpNonce>>;
     searchTx(txQuery: TxQuery): Promise<ReadonlyArray<ConfirmedTransaction>>;
     listenTx(tags: ReadonlyArray<Tag>): Stream<ConfirmedTransaction>;
     liveTx(txQuery: TxQuery): Stream<ConfirmedTransaction>;
+    changeFeed(tags: ReadonlyArray<Tag>): Stream<number>;
+    changeBalance(addr: Address): Stream<number>;
+    changeNonce(addr: Address): Stream<number>;
+    watchAccount(account: BcpAccountQuery): Stream<BcpQueryEnvelope<BcpAccount>>;
     protected initialize(): Promise<InitData>;
     protected query(path: string, data: Uint8Array): Promise<QueryResponse>;
 }

--- a/packages/iov-bns/types/client.d.ts
+++ b/packages/iov-bns/types/client.d.ts
@@ -24,10 +24,12 @@ export declare class Client implements IovReader {
     searchTx(txQuery: TxQuery): Promise<ReadonlyArray<ConfirmedTransaction>>;
     listenTx(tags: ReadonlyArray<Tag>): Stream<ConfirmedTransaction>;
     liveTx(txQuery: TxQuery): Stream<ConfirmedTransaction>;
-    changeFeed(tags: ReadonlyArray<Tag>): Stream<number>;
+    changeBlock(): Stream<number>;
+    changeTx(tags: ReadonlyArray<Tag>): Stream<number>;
     changeBalance(addr: Address): Stream<number>;
     changeNonce(addr: Address): Stream<number>;
     watchAccount(account: BcpAccountQuery): Stream<BcpAccount | undefined>;
+    watchNonce(account: BcpAccountQuery): Stream<BcpNonce | undefined>;
     protected initialize(): Promise<InitData>;
     protected query(path: string, data: Uint8Array): Promise<QueryResponse>;
 }

--- a/packages/iov-bns/types/client.d.ts
+++ b/packages/iov-bns/types/client.d.ts
@@ -1,3 +1,4 @@
+import { Stream } from "xstream";
 import { Address, BcpAccount, BcpAccountQuery, BcpNonce, BcpQueryEnvelope, BcpTicker, BcpTransactionResponse, ConfirmedTransaction, IovReader, TokenTicker, TxReadCodec } from "@iov/bcp-types";
 import { Client as TendermintClient, StatusResponse } from "@iov/tendermint-rpc";
 import { ChainId, PostableBytes, Tag, TxQuery } from "@iov/tendermint-types";
@@ -18,6 +19,7 @@ export declare class Client implements IovReader {
     getTicker(ticker: TokenTicker): Promise<BcpQueryEnvelope<BcpTicker>>;
     getAllTickers(): Promise<BcpQueryEnvelope<BcpTicker>>;
     getAccount(account: BcpAccountQuery): Promise<BcpQueryEnvelope<BcpAccount>>;
+    watchAccount(account: BcpAccountQuery): Stream<BcpQueryEnvelope<BcpAccount>>;
     getNonce(account: BcpAccountQuery): Promise<BcpQueryEnvelope<BcpNonce>>;
     searchTx(txQuery: TxQuery): Promise<ReadonlyArray<ConfirmedTransaction>>;
     protected initialize(): Promise<InitData>;

--- a/packages/iov-bns/types/client.d.ts
+++ b/packages/iov-bns/types/client.d.ts
@@ -22,6 +22,8 @@ export declare class Client implements IovReader {
     watchAccount(account: BcpAccountQuery): Stream<BcpQueryEnvelope<BcpAccount>>;
     getNonce(account: BcpAccountQuery): Promise<BcpQueryEnvelope<BcpNonce>>;
     searchTx(txQuery: TxQuery): Promise<ReadonlyArray<ConfirmedTransaction>>;
+    listenTx(tags: ReadonlyArray<Tag>): Stream<ConfirmedTransaction>;
+    liveTx(txQuery: TxQuery): Stream<ConfirmedTransaction>;
     protected initialize(): Promise<InitData>;
     protected query(path: string, data: Uint8Array): Promise<QueryResponse>;
 }

--- a/packages/iov-bns/types/client.d.ts
+++ b/packages/iov-bns/types/client.d.ts
@@ -27,7 +27,7 @@ export declare class Client implements IovReader {
     changeFeed(tags: ReadonlyArray<Tag>): Stream<number>;
     changeBalance(addr: Address): Stream<number>;
     changeNonce(addr: Address): Stream<number>;
-    watchAccount(account: BcpAccountQuery): Stream<BcpQueryEnvelope<BcpAccount>>;
+    watchAccount(account: BcpAccountQuery): Stream<BcpAccount | undefined>;
     protected initialize(): Promise<InitData>;
     protected query(path: string, data: Uint8Array): Promise<QueryResponse>;
 }

--- a/packages/iov-bns/types/index.d.ts
+++ b/packages/iov-bns/types/index.d.ts
@@ -1,2 +1,3 @@
 export { bnsCodec } from "./bnscodec";
 export { Client } from "./client";
+export { asArray, countStream, lastValue, Reducer } from "./stream";

--- a/packages/iov-bns/types/stream.d.ts
+++ b/packages/iov-bns/types/stream.d.ts
@@ -1,0 +1,2 @@
+import { Stream } from "xstream";
+export declare function streamPromise<T>(promise: Promise<ReadonlyArray<T>>): Stream<T>;

--- a/packages/iov-bns/types/stream.d.ts
+++ b/packages/iov-bns/types/stream.d.ts
@@ -1,4 +1,18 @@
 import { Stream } from "xstream";
+export declare type ReducerFunc<T, U> = (acc: U, evt: T) => U;
+export declare const counter: ReducerFunc<any, number>;
+export declare function append<T>(list: ReadonlyArray<T>, evt: T): ReadonlyArray<T>;
+export declare function last<T>(_: any, evt: T): T;
+export declare class Reducer<T, U> {
+    private readonly stream;
+    private readonly reducer;
+    private state;
+    private readonly completed;
+    constructor(stream: Stream<T>, reducer: ReducerFunc<T, U>, initState: U);
+    value(): U;
+    finished(): Promise<void>;
+}
+export declare function countStream<T>(stream: Stream<T>): Reducer<T, number>;
+export declare function asArray<T>(stream: Stream<T>): Reducer<T, ReadonlyArray<T>>;
+export declare function lastValue<T>(stream: Stream<T>): Reducer<T, T | undefined>;
 export declare function streamPromise<T>(promise: Promise<ReadonlyArray<T>>): Stream<T>;
-export declare function readIntoArray<T>(stream: Stream<T>): Promise<ReadonlyArray<T>>;
-export declare function countStream<T>(stream: Stream<T>): Promise<number>;

--- a/packages/iov-bns/types/stream.d.ts
+++ b/packages/iov-bns/types/stream.d.ts
@@ -1,2 +1,4 @@
 import { Stream } from "xstream";
 export declare function streamPromise<T>(promise: Promise<ReadonlyArray<T>>): Stream<T>;
+export declare function readIntoArray<T>(stream: Stream<T>): Promise<ReadonlyArray<T>>;
+export declare function countStream<T>(stream: Stream<T>): Promise<number>;

--- a/packages/iov-tendermint-rpc/src/responses.ts
+++ b/packages/iov-tendermint-rpc/src/responses.ts
@@ -132,6 +132,10 @@ export interface TxEvent {
   };
 }
 
+export const getTxEventHeight = (event: TxEvent): number => event.height;
+export const getHeaderEventHeight = (event: NewBlockHeaderEvent): number => event.height;
+export const getBlockEventHeight = (event: NewBlockEvent): number => event.header.height;
+
 /**** Helper items used above ******/
 
 export interface Tag {


### PR DESCRIPTION
We can subscribe to transactions with tendermint-rpc. Now, let us expose this with bcp types as Streams not just promises (to mirror the getXyz methods)

- [x] watch account balance (like getAccount)
- [x] watch account nonce? (like getNonce)
- [x] watch tx (parallel to searchTx, with tags)

Do we also need for tickers? blocks???
And we should add this to IovReader interface?