### PR TITLE
Fix websocket handling trailing slashes in uri

### DIFF
--- a/packages/iov-tendermint-rpc/src/rpcclient.spec.ts
+++ b/packages/iov-tendermint-rpc/src/rpcclient.spec.ts
@@ -52,6 +52,22 @@ describe("RpcClient", () => {
     expect(instanceOfRpcStreamingClient(new WebsocketClient(tendermintUrl))).toEqual(true);
   });
 
+  it("should also work with trailing slashes", async () => {
+    pendingWithoutTendermint();
+
+    const status = jsonRpcWith(Method.STATUS);
+
+    const http = new HttpClient(tendermintUrl + "/");
+    expect(await http.execute(status)).toBeDefined();
+
+    const uri = new HttpUriClient(tendermintUrl + "/");
+    expect(await uri.execute(status)).toBeDefined();
+
+    const ws = new WebsocketClient(tendermintUrl + "/");
+    expect(await ws.execute(status)).toBeDefined();
+    ws.disconnect();
+  });
+
   describe("HttpClient", () => {
     it("can make a simple call", async () => {
       pendingWithoutTendermint();

--- a/packages/iov-tendermint-rpc/src/rpcclient.ts
+++ b/packages/iov-tendermint-rpc/src/rpcclient.ts
@@ -131,7 +131,8 @@ export class WebsocketClient implements RpcStreamingClient {
 
   constructor(baseUrl: string = "ws://localhost:46657", onError: (err: any) => void = defaultErrorHandler) {
     // accept host.name:port and assume ws protocol
-    const path = "/websocket";
+    // make sure we don't end up with ...//websocket
+    const path = baseUrl.endsWith("/") ? "websocket" : "/websocket";
     const cleanBaseUrl = hasProtocol(baseUrl) ? baseUrl : "ws://" + baseUrl;
     this.url = cleanBaseUrl + path;
 


### PR DESCRIPTION
This issue came up during manual testing. That `wss://bov.friendnet-fast.iov.one/` broke, while `wss://bov.friendnet-fast.iov.one` worked. Here is a fix client side, so we are not so fragile