### PR TITLE
Add identifiers to many exported objects

### DIFF
--- a/packages/iov-keycontrol/package.json
+++ b/packages/iov-keycontrol/package.json
@@ -37,8 +37,10 @@
     "@iov/encoding": "^0.5.0",
     "@iov/tendermint-types": "^0.5.1",
     "@types/node": "^9.6.6",
+    "@types/random-js": "^1.0.31",
     "levelup": "^3.1.0",
     "long": "^4.0.0",
+    "random-js": "^1.0.8",
     "readonly-date": "^1.0.0",
     "type-tagger": "^1.0.0",
     "xstream": "^11.4.0"

--- a/packages/iov-keycontrol/src/keyring-entries/ed25519.spec.ts
+++ b/packages/iov-keycontrol/src/keyring-entries/ed25519.spec.ts
@@ -54,6 +54,10 @@ describe("Ed25519KeyringEntry", () => {
     const pubkeySet = new Set([newIdentity1, newIdentity2, newIdentity3, newIdentity4, newIdentity5].map(i => toHex(i.pubkey.data)));
     expect(pubkeySet.size).toEqual(5);
 
+    // all localidentity.ids must be different
+    const idSet = new Set([newIdentity1, newIdentity2, newIdentity3, newIdentity4, newIdentity5].map(i => i.id));
+    expect(idSet.size).toEqual(5);
+
     expect(keyringEntry.getIdentities().length).toEqual(5);
 
     const firstIdentity = keyringEntry.getIdentities()[0];

--- a/packages/iov-keycontrol/src/keyring-entries/ed25519.ts
+++ b/packages/iov-keycontrol/src/keyring-entries/ed25519.ts
@@ -1,3 +1,5 @@
+import PseudoRandom from "random-js";
+
 import { PrehashType, SignableBytes } from "@iov/bcp-types";
 import { Ed25519, Ed25519Keypair, Random } from "@iov/crypto";
 import { Encoding } from "@iov/encoding";
@@ -35,6 +37,8 @@ interface Ed25519KeyringEntrySerialization {
 }
 
 export class Ed25519KeyringEntry implements KeyringEntry {
+  private static readonly prng: PseudoRandom.Engine = PseudoRandom.engines.mt19937().seed(12345678);
+
   private static identityId(identity: PublicIdentity): string {
     return identity.pubkey.algo + "|" + Encoding.toHex(identity.pubkey.data);
   }
@@ -196,8 +200,7 @@ export class Ed25519KeyringEntry implements KeyringEntry {
 
   private randomId(): string {
     // this can be pseudo-random, just used for internal book-keeping
-    const index = Math.random() * 1000000000;
-    // appends random 9-digit number
-    return "ed25519:" + Math.floor(index).toString(10);
+    const code = PseudoRandom.string()(Ed25519KeyringEntry.prng, 10);
+    return "ed25519:" + code;
   }
 }

--- a/packages/iov-keycontrol/src/keyring-entries/ed25519simpleaddress.spec.ts
+++ b/packages/iov-keycontrol/src/keyring-entries/ed25519simpleaddress.spec.ts
@@ -16,12 +16,14 @@ describe("Ed25519SimpleAddressKeyringEntry", () => {
     const entry = Ed25519SimpleAddressKeyringEntry.fromEntropy(Encoding.fromHex("51385c41df88cbe7c579e99de04259b1aa264d8e2416f1885228a4d069629fad"));
     expect(entry).toEqual(jasmine.any(Ed25519SimpleAddressKeyringEntry));
     expect(entry.implementationId).toEqual("ed25519-simpleaddress");
+    expect(entry.id.startsWith("ed25519-simpleaddress")).toBeTruthy();
   });
 
   it("returns the concrete type when creating from mnemonic", () => {
     const entry = Ed25519SimpleAddressKeyringEntry.fromMnemonic("execute wheel pupil bachelor crystal short domain faculty shrimp focus swap hazard");
     expect(entry).toEqual(jasmine.any(Ed25519SimpleAddressKeyringEntry));
     expect(entry.implementationId).toEqual("ed25519-simpleaddress");
+    expect(entry.id.startsWith("ed25519-simpleaddress")).toBeTruthy();
   });
 
   it("creates correct paths", async () => {
@@ -43,5 +45,6 @@ describe("Ed25519SimpleAddressKeyringEntry", () => {
     expect(clone).not.toBe(original);
     expect(clone.serialize()).toEqual(original.serialize());
     expect(clone.implementationId).toEqual("ed25519-simpleaddress");
+    expect(clone.id.startsWith("ed25519-simpleaddress")).toBeTruthy();
   });
 });

--- a/packages/iov-keycontrol/src/keyring-entries/ed25519simpleaddress.ts
+++ b/packages/iov-keycontrol/src/keyring-entries/ed25519simpleaddress.ts
@@ -1,22 +1,33 @@
 import { Slip10Curve, Slip10RawIndex } from "@iov/crypto";
 
-import { KeyringEntryImplementationIdString, LocalIdentity } from "../keyring";
+import {
+  KeyringEntryImplementationIdString,
+  KeyringEntrySerializationString,
+  LocalIdentity,
+} from "../keyring";
 import { Slip10KeyringEntry } from "./slip10";
 
 export class Ed25519SimpleAddressKeyringEntry extends Slip10KeyringEntry {
   // simple wrappers to cast return type
   public static fromEntropy(bip39Entropy: Uint8Array): Ed25519SimpleAddressKeyringEntry {
-    return super.fromEntropyWithCurve(Slip10Curve.Ed25519, bip39Entropy) as Ed25519SimpleAddressKeyringEntry;
+    return super.fromEntropyWithCurve(
+      Slip10Curve.Ed25519,
+      bip39Entropy,
+      Ed25519SimpleAddressKeyringEntry,
+    ) as Ed25519SimpleAddressKeyringEntry;
   }
 
   public static fromMnemonic(mnemonicString: string): Ed25519SimpleAddressKeyringEntry {
     return super.fromMnemonicWithCurve(
       Slip10Curve.Ed25519,
       mnemonicString,
+      Ed25519SimpleAddressKeyringEntry,
     ) as Ed25519SimpleAddressKeyringEntry;
   }
 
-  public readonly implementationId = "ed25519-simpleaddress" as KeyringEntryImplementationIdString;
+  constructor(data: KeyringEntrySerializationString) {
+    super(data, "ed25519-simpleaddress" as KeyringEntryImplementationIdString);
+  }
 
   public createIdentity(): Promise<LocalIdentity> {
     const nextIndex = super.getIdentities().length;

--- a/packages/iov-keycontrol/src/keyring-entries/slip10.ts
+++ b/packages/iov-keycontrol/src/keyring-entries/slip10.ts
@@ -11,7 +11,7 @@ import {
   Slip10RawIndex,
 } from "@iov/crypto";
 import { Encoding } from "@iov/encoding";
-import { Algorithm, ChainId, PublicKeyBytes, SignatureBytes } from "@iov/tendermint-types";
+import { Algorithm, ChainId, PublicKeyBundle, PublicKeyBytes, SignatureBytes } from "@iov/tendermint-types";
 
 import {
   KeyringEntry,
@@ -120,18 +120,14 @@ export class Slip10KeyringEntry implements KeyringEntry {
         );
       }
 
-      const identity: LocalIdentity = {
-        pubkey: {
-          algo: algorithm,
-          data: Encoding.fromHex(record.localIdentity.pubkey.data) as PublicKeyBytes,
-        },
-        label: record.localIdentity.label,
-      };
+      const identity = this.buildLocalIdentity(
+        Encoding.fromHex(record.localIdentity.pubkey.data) as PublicKeyBytes,
+        record.localIdentity.label,
+      );
       const privkeyPath: ReadonlyArray<Slip10RawIndex> = record.privkeyPath.map(n => new Slip10RawIndex(n));
 
-      const identityId = Slip10KeyringEntry.identityId(identity);
       identities.push(identity);
-      privkeyPaths.set(identityId, privkeyPath);
+      privkeyPaths.set(identity.id, privkeyPath);
     }
 
     this.identities = identities;
@@ -169,16 +165,8 @@ export class Slip10KeyringEntry implements KeyringEntry {
         throw new Error("Unknown curve");
     }
 
-    const newIdentity = {
-      pubkey: {
-        algo: Slip10KeyringEntry.algorithmFromCurve(this.curve),
-        data: pubkeyBytes,
-      },
-      label: undefined,
-    };
-    const newIdentityId = Slip10KeyringEntry.identityId(newIdentity);
-
-    this.privkeyPaths.set(newIdentityId, path);
+    const newIdentity = this.buildLocalIdentity(pubkeyBytes, undefined);
+    this.privkeyPaths.set(newIdentity.id, path);
     this.identities.push(newIdentity);
 
     return newIdentity;
@@ -260,5 +248,18 @@ export class Slip10KeyringEntry implements KeyringEntry {
     const derivationResult = Slip10.derivePath(Slip10Curve.Ed25519, seed, privkeyPath);
     const keypair = await Ed25519.makeKeypair(derivationResult.privkey);
     return keypair;
+  }
+
+  private buildLocalIdentity(bytes: PublicKeyBytes, label: string | undefined): LocalIdentity {
+    const algorithm = Slip10KeyringEntry.algorithmFromCurve(this.curve);
+    const pubkey: PublicKeyBundle = {
+      algo: algorithm,
+      data: bytes,
+    };
+    return {
+      pubkey,
+      label,
+      id: Slip10KeyringEntry.identityId({ pubkey }),
+    };
   }
 }

--- a/packages/iov-keycontrol/src/keyring.ts
+++ b/packages/iov-keycontrol/src/keyring.ts
@@ -132,7 +132,7 @@ export interface KeyringEntry {
   // id is a unique identifier based on the content of the keyring
   // the same implementation with same seed/secret should have same identifier
   // otherwise, they will be different
-  readonly id: string;
+  // readonly id: string;
 
   // Sets a label associated with the keyring entry to be displayed in the UI.
   // To clear the label, set it to undefined.

--- a/packages/iov-keycontrol/src/keyring.ts
+++ b/packages/iov-keycontrol/src/keyring.ts
@@ -132,7 +132,7 @@ export interface KeyringEntry {
   // id is a unique identifier based on the content of the keyring
   // the same implementation with same seed/secret should have same identifier
   // otherwise, they will be different
-  // readonly id: string;
+  readonly id: string;
 
   // Sets a label associated with the keyring entry to be displayed in the UI.
   // To clear the label, set it to undefined.

--- a/packages/iov-keycontrol/src/keyring.ts
+++ b/packages/iov-keycontrol/src/keyring.ts
@@ -18,6 +18,9 @@ export interface PublicIdentity {
 // LocalIdentity is a local version of a PublicIdentity that contains
 // additional local information
 export interface LocalIdentity extends PublicIdentity {
+  // immutible id string based on pubkey
+  readonly id: string;
+
   // An optional, local label.
   // This is not exposed to other people or other devices. Use BNS registration for that.
   readonly label?: string;
@@ -125,6 +128,11 @@ https://github.com/MetaMask/KeyringController/blob/master/docs/keyring.md
 */
 export interface KeyringEntry {
   readonly label: ValueAndUpdates<string | undefined>;
+
+  // id is a unique identifier based on the content of the keyring
+  // the same implementation with same seed/secret should have same identifier
+  // otherwise, they will be different
+  readonly id: string;
 
   // Sets a label associated with the keyring entry to be displayed in the UI.
   // To clear the label, set it to undefined.

--- a/packages/iov-keycontrol/types/keyring-entries/ed25519.d.ts
+++ b/packages/iov-keycontrol/types/keyring-entries/ed25519.d.ts
@@ -3,6 +3,7 @@ import { ChainId, SignatureBytes } from "@iov/tendermint-types";
 import { KeyringEntry, KeyringEntryImplementationIdString, KeyringEntrySerializationString, LocalIdentity, PublicIdentity } from "../keyring";
 import { ValueAndUpdates } from "../valueandupdates";
 export declare class Ed25519KeyringEntry implements KeyringEntry {
+    private static readonly prng;
     private static identityId;
     private static algorithmFromString;
     readonly label: ValueAndUpdates<string | undefined>;

--- a/packages/iov-keycontrol/types/keyring-entries/ed25519.d.ts
+++ b/packages/iov-keycontrol/types/keyring-entries/ed25519.d.ts
@@ -20,4 +20,5 @@ export declare class Ed25519KeyringEntry implements KeyringEntry {
     serialize(): KeyringEntrySerializationString;
     clone(): Ed25519KeyringEntry;
     private privateKeyForIdentity;
+    private buildLocalIdentity;
 }

--- a/packages/iov-keycontrol/types/keyring-entries/ed25519.d.ts
+++ b/packages/iov-keycontrol/types/keyring-entries/ed25519.d.ts
@@ -8,6 +8,7 @@ export declare class Ed25519KeyringEntry implements KeyringEntry {
     readonly label: ValueAndUpdates<string | undefined>;
     readonly canSign: ValueAndUpdates<boolean>;
     readonly implementationId: KeyringEntryImplementationIdString;
+    readonly id: string;
     private readonly identities;
     private readonly privkeys;
     private readonly labelProducer;
@@ -21,4 +22,5 @@ export declare class Ed25519KeyringEntry implements KeyringEntry {
     clone(): Ed25519KeyringEntry;
     private privateKeyForIdentity;
     private buildLocalIdentity;
+    private randomId;
 }

--- a/packages/iov-keycontrol/types/keyring-entries/ed25519simpleaddress.d.ts
+++ b/packages/iov-keycontrol/types/keyring-entries/ed25519simpleaddress.d.ts
@@ -1,9 +1,9 @@
-import { KeyringEntryImplementationIdString, LocalIdentity } from "../keyring";
+import { KeyringEntrySerializationString, LocalIdentity } from "../keyring";
 import { Slip10KeyringEntry } from "./slip10";
 export declare class Ed25519SimpleAddressKeyringEntry extends Slip10KeyringEntry {
     static fromEntropy(bip39Entropy: Uint8Array): Ed25519SimpleAddressKeyringEntry;
     static fromMnemonic(mnemonicString: string): Ed25519SimpleAddressKeyringEntry;
-    readonly implementationId: KeyringEntryImplementationIdString;
+    constructor(data: KeyringEntrySerializationString);
     createIdentity(): Promise<LocalIdentity>;
     clone(): Ed25519SimpleAddressKeyringEntry;
 }

--- a/packages/iov-keycontrol/types/keyring-entries/slip10.d.ts
+++ b/packages/iov-keycontrol/types/keyring-entries/slip10.d.ts
@@ -3,9 +3,12 @@ import { Slip10Curve, Slip10RawIndex } from "@iov/crypto";
 import { ChainId, SignatureBytes } from "@iov/tendermint-types";
 import { KeyringEntry, KeyringEntryImplementationIdString, KeyringEntrySerializationString, LocalIdentity, PublicIdentity } from "../keyring";
 import { ValueAndUpdates } from "../valueandupdates";
+interface Slip10KeyringEntryConstructor {
+    new (data: KeyringEntrySerializationString): Slip10KeyringEntry;
+}
 export declare class Slip10KeyringEntry implements KeyringEntry {
-    static fromEntropyWithCurve(curve: Slip10Curve, bip39Entropy: Uint8Array): Slip10KeyringEntry;
-    static fromMnemonicWithCurve(curve: Slip10Curve, mnemonicString: string): Slip10KeyringEntry;
+    static fromEntropyWithCurve(curve: Slip10Curve, bip39Entropy: Uint8Array, cls?: Slip10KeyringEntryConstructor): Slip10KeyringEntry;
+    static fromMnemonicWithCurve(curve: Slip10Curve, mnemonicString: string, cls?: Slip10KeyringEntryConstructor): Slip10KeyringEntry;
     private static identityId;
     private static algorithmFromCurve;
     private static algorithmFromString;
@@ -18,7 +21,7 @@ export declare class Slip10KeyringEntry implements KeyringEntry {
     private readonly identities;
     private readonly privkeyPaths;
     private readonly labelProducer;
-    constructor(data: KeyringEntrySerializationString);
+    constructor(data: KeyringEntrySerializationString, implementationId?: KeyringEntryImplementationIdString);
     setLabel(label: string | undefined): void;
     createIdentity(): Promise<LocalIdentity>;
     createIdentityWithPath(path: ReadonlyArray<Slip10RawIndex>): Promise<LocalIdentity>;
@@ -32,3 +35,4 @@ export declare class Slip10KeyringEntry implements KeyringEntry {
     private buildLocalIdentity;
     private calculateId;
 }
+export {};

--- a/packages/iov-keycontrol/types/keyring-entries/slip10.d.ts
+++ b/packages/iov-keycontrol/types/keyring-entries/slip10.d.ts
@@ -12,6 +12,7 @@ export declare class Slip10KeyringEntry implements KeyringEntry {
     readonly label: ValueAndUpdates<string | undefined>;
     readonly canSign: ValueAndUpdates<boolean>;
     readonly implementationId: KeyringEntryImplementationIdString;
+    readonly id: string;
     private readonly secret;
     private readonly curve;
     private readonly identities;
@@ -29,4 +30,5 @@ export declare class Slip10KeyringEntry implements KeyringEntry {
     private privkeyPathForIdentity;
     private privkeyForIdentity;
     private buildLocalIdentity;
+    private calculateId;
 }

--- a/packages/iov-keycontrol/types/keyring-entries/slip10.d.ts
+++ b/packages/iov-keycontrol/types/keyring-entries/slip10.d.ts
@@ -28,4 +28,5 @@ export declare class Slip10KeyringEntry implements KeyringEntry {
     clone(): Slip10KeyringEntry;
     private privkeyPathForIdentity;
     private privkeyForIdentity;
+    private buildLocalIdentity;
 }

--- a/packages/iov-keycontrol/types/keyring.d.ts
+++ b/packages/iov-keycontrol/types/keyring.d.ts
@@ -33,6 +33,7 @@ export declare class Keyring {
 }
 export interface KeyringEntry {
     readonly label: ValueAndUpdates<string | undefined>;
+    readonly id: string;
     readonly setLabel: (label: string | undefined) => void;
     readonly createIdentity: () => Promise<LocalIdentity>;
     readonly setIdentityLabel: (identity: PublicIdentity, label: string | undefined) => void;

--- a/packages/iov-keycontrol/types/keyring.d.ts
+++ b/packages/iov-keycontrol/types/keyring.d.ts
@@ -9,6 +9,7 @@ export interface PublicIdentity {
     readonly pubkey: PublicKeyBundle;
 }
 export interface LocalIdentity extends PublicIdentity {
+    readonly id: string;
     readonly label?: string;
 }
 export interface KeyringEntrySerialization {

--- a/packages/iov-ledger-bns/src/ledgersimpleaddresskeyringentry.ts
+++ b/packages/iov-ledger-bns/src/ledgersimpleaddresskeyringentry.ts
@@ -79,7 +79,7 @@ export class LedgerSimpleAddressKeyringEntry implements KeyringEntry {
     this.canSign = new ValueAndUpdates(this.canSignProducer);
 
     this.deviceTracker.state.updates.subscribe({
-      next: value => {
+      next: (value: LedgerState) => {
         this.canSignProducer.update(value === LedgerState.IovAppOpen);
       },
     });

--- a/packages/iov-ledger-bns/types/ledgersimpleaddresskeyringentry.d.ts
+++ b/packages/iov-ledger-bns/types/ledgersimpleaddresskeyringentry.d.ts
@@ -6,11 +6,11 @@ export declare class LedgerSimpleAddressKeyringEntry implements KeyringEntry {
     static readonly implementationId: KeyringEntryImplementationIdString;
     static registerWithKeyring(): void;
     private static identityId;
-    private static algorithmFromString;
     readonly label: ValueAndUpdates<string | undefined>;
     readonly canSign: ValueAndUpdates<boolean>;
     readonly implementationId: KeyringEntryImplementationIdString;
     readonly deviceState: ValueAndUpdates<LedgerState>;
+    id: string;
     private readonly deviceTracker;
     private readonly labelProducer;
     private readonly canSignProducer;
@@ -27,4 +27,5 @@ export declare class LedgerSimpleAddressKeyringEntry implements KeyringEntry {
     serialize(): KeyringEntrySerializationString;
     clone(): KeyringEntry;
     private simpleAddressIndex;
+    private buildLocalIdentity;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -675,6 +675,10 @@
   version "9.6.30"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-9.6.30.tgz#1ecf83eaf7ac2d0dada7a9d61a1e4e7a6183ac06"
 
+"@types/random-js@^1.0.31":
+  version "1.0.31"
+  resolved "https://registry.yarnpkg.com/@types/random-js/-/random-js-1.0.31.tgz#18a8bcc075afa504421e638fcbe021f27e802941"
+
 "@types/shelljs@^0.8.0":
   version "0.8.0"
   resolved "https://registry.yarnpkg.com/@types/shelljs/-/shelljs-0.8.0.tgz#0caa56b68baae4f68f44e0dd666ab30b098e3632"
@@ -4909,6 +4913,10 @@ querystring@0.2.0:
 quick-lru@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-1.1.0.tgz#4360b17c61136ad38078397ff11416e186dcfbb8"
+
+random-js@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/random-js/-/random-js-1.0.8.tgz#968fd689a6f25d6c0aac766283de2f688c9c190a"
 
 randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5:
   version "2.0.6"


### PR DESCRIPTION
Resolved #331 

This is useful when a consumer wants to check for identity and de-duplicate indexes without needed understanding of the embedded types. It is also import for any object that is exposed by react in a list.

Add `.id: string` to the following objects:

- [x] LocalIdentity
- [x] KeyringEntry (and all implementations in iov-keycontrol)
- [x] Ledger-bns keyring entry
- [ ] UserProfile
- [ ] IovWriter (?)

After implementing the LocalIdentity and Keyring parts, I realize there is no clear way to provide a unique idenitity to a UserProfile.

If we add a KeyringEntry it must remain the same id.
However, if id is related to the secrets contained, then two UserProfiles both containing a KeyringEntry with id `x` should have the same id, right?

```
const a = new UserProfile();
const b = new UserProfile();

a.addKeyringEntry(entry);
expect(a.id).not.toEqual(b.id);
b.addKeyringEntry(entry);
expect(a.id).toEqual(b.id);
```

Or should I just give them all some pseudo-random id?
At least the slip10 based keyring entries and the local identities have a immuitible id tied to their data.