### PR TITLE
Support ids as parameters

### DIFF
--- a/packages/iov-bns/src/client.spec.ts
+++ b/packages/iov-bns/src/client.spec.ts
@@ -303,6 +303,8 @@ describe("Integration tests with bov+tendermint", () => {
     const firstId = post.data.txid;
     expect(firstId).toBeDefined();
 
+    // hmmm... there seems to be a lag here when Travis CI is heavily loaded...
+    await sleep(50);
     const middleSearch = await client.searchTx(query);
     expect(middleSearch.length).toEqual(1);
 
@@ -315,6 +317,8 @@ describe("Integration tests with bov+tendermint", () => {
     expect(secondId).toBeDefined();
 
     // now, let's make sure it is picked up in the search
+    // hmmm... there seems to be a lag here when Travis CI is heavily loaded...
+    await sleep(50);
     const afterSearch = await client.searchTx(query);
     expect(afterSearch.length).toEqual(2);
     // make sure we have unique, defined txids

--- a/packages/iov-core/src/writer.spec.ts
+++ b/packages/iov-core/src/writer.spec.ts
@@ -58,6 +58,9 @@ describe("IovWriter", () => {
       pendingWithoutBov();
 
       const profile = await userProfile();
+      const entryId = profile.entryIds.value[0];
+      expect(entryId).toBeTruthy();
+
       const writer = new IovWriter(profile);
       await writer.addChain(bnsConnector(bovUrl));
       expect(writer.chainIds().length).toEqual(1);
@@ -81,7 +84,7 @@ describe("IovWriter", () => {
           tokenTicker: cash,
         },
       };
-      const res = await writer.signAndCommit(sendTx, 0);
+      const res = await writer.signAndCommit(sendTx, entryId);
       expect(res.metadata.status).toEqual(true);
 
       // we should be a little bit richer

--- a/packages/iov-core/src/writer.ts
+++ b/packages/iov-core/src/writer.ts
@@ -61,7 +61,10 @@ export class IovWriter {
   // the transaction and look up the private key for this public key
   // in the given keyring.
   // It finds the nonce, signs properly, and posts the tx to the blockchain.
-  public async signAndCommit(tx: UnsignedTransaction, keyring: number): Promise<BcpTransactionResponse> {
+  public async signAndCommit(
+    tx: UnsignedTransaction,
+    keyring: number | string,
+  ): Promise<BcpTransactionResponse> {
     const chainId = tx.chainId;
     const { client, codec } = this.getChain(chainId);
 

--- a/packages/iov-core/types/writer.d.ts
+++ b/packages/iov-core/types/writer.d.ts
@@ -11,7 +11,7 @@ export declare class IovWriter {
     addChain(connector: ChainConnector): Promise<void>;
     keyToAddress(chainId: ChainId, key: PublicKeyBundle): Address;
     getNonce(chainId: ChainId, addr: Address): Promise<Nonce>;
-    signAndCommit(tx: UnsignedTransaction, keyring: number): Promise<BcpTransactionResponse>;
+    signAndCommit(tx: UnsignedTransaction, keyring: number | string): Promise<BcpTransactionResponse>;
     private getChain;
 }
 export interface ChainConnector {

--- a/packages/iov-keycontrol/src/keyring.ts
+++ b/packages/iov-keycontrol/src/keyring.ts
@@ -95,6 +95,11 @@ export class Keyring {
     return this.entries;
   }
 
+  // if you stored the immutible keyring entry reference, you can get the object back here
+  public getEntryById(id: string): KeyringEntry | undefined {
+    return this.entries.filter(e => e.id === id)[0];
+  }
+
   // serialize will produce a representation that can be writen to disk.
   // this will contain secret info, so handle securely!
   public serialize(): KeyringSerializationString {

--- a/packages/iov-keycontrol/src/keyring.ts
+++ b/packages/iov-keycontrol/src/keyring.ts
@@ -97,7 +97,12 @@ export class Keyring {
 
   // if you stored the immutible keyring entry reference, you can get the object back here
   public getEntryById(id: string): KeyringEntry | undefined {
-    return this.entries.filter(e => e.id === id)[0];
+    return this.entries.find(e => e.id === id);
+  }
+
+  // if you stored the immutible keyring entry reference, you can get the object back here
+  public getEntryByIndex(n: number): KeyringEntry | undefined {
+    return this.entries.find((_, index) => index === n);
   }
 
   // serialize will produce a representation that can be writen to disk.

--- a/packages/iov-keycontrol/src/userprofile.spec.ts
+++ b/packages/iov-keycontrol/src/userprofile.spec.ts
@@ -140,6 +140,45 @@ describe("UserProfile", () => {
     expect(profile.entryLabels.value).toEqual([undefined, undefined]);
   });
 
+  it("accessors also work with id instead of number", async () => {
+    const profile = new UserProfile();
+
+    const entry1 = Ed25519SimpleAddressKeyringEntry.fromMnemonic("perfect clump orphan margin memory amazing morning use snap skate erosion civil");
+    profile.addEntry(entry1);
+    const id1 = entry1.id;
+
+    const entry2 = Ed25519SimpleAddressKeyringEntry.fromMnemonic("degree tackle suggest window test behind mesh extra cover prepare oak script");
+    profile.addEntry(entry2);
+    const id2 = entry2.id;
+
+    // set the labels two different ways
+    profile.setEntryLabel(0, "first");
+    profile.setEntryLabel(id2, "second");
+    expect(profile.entryLabels.value).toEqual(["first", "second"]);
+
+    // make some new ids
+    await profile.createIdentity(id1);
+    const key = await profile.createIdentity(id2);
+    await profile.createIdentity(1);
+    expect(profile.getIdentities(0).length).toEqual(1);
+    expect(profile.getIdentities(id2).length).toEqual(2);
+
+    // set an identity label
+    profile.setIdentityLabel(1, key, "foobar");
+    const labels = profile.getIdentities(id2).map(x => x.label);
+    expect(labels).toEqual(["foobar", undefined]);
+  });
+
+  it("throws for non-existent id or index", () => {
+    const profile = new UserProfile();
+
+    const entry1 = Ed25519SimpleAddressKeyringEntry.fromMnemonic("perfect clump orphan margin memory amazing morning use snap skate erosion civil");
+    profile.addEntry(entry1);
+
+    expect(() => profile.getIdentities(2)).toThrowError(/Entry of index 2 does not exist in keyring/);
+    expect(() => profile.getIdentities("balloon")).toThrowError(/Entry of id balloon does not exist in keyring/);
+  });
+
   it("added entry can not be manipulated from outside", async () => {
     const profile = new UserProfile();
     const newEntry = Ed25519SimpleAddressKeyringEntry.fromMnemonic("melt wisdom mesh wash item catalog talk enjoy gaze hat brush wash");

--- a/packages/iov-keycontrol/src/userprofile.spec.ts
+++ b/packages/iov-keycontrol/src/userprofile.spec.ts
@@ -147,9 +147,15 @@ describe("UserProfile", () => {
     profile.addEntry(entry1);
     const id1 = entry1.id;
 
+    // make sure we can query the ids if we didn't save them from creation
+    expect(profile.entryIds.value).toEqual([id1]);
+
     const entry2 = Ed25519SimpleAddressKeyringEntry.fromMnemonic("degree tackle suggest window test behind mesh extra cover prepare oak script");
     profile.addEntry(entry2);
     const id2 = entry2.id;
+
+    // make sure we can query the ids if we didn't save them from creation
+    expect(profile.entryIds.value).toEqual([id1, id2]);
 
     // set the labels two different ways
     profile.setEntryLabel(0, "first");

--- a/packages/iov-keycontrol/src/userprofile.ts
+++ b/packages/iov-keycontrol/src/userprofile.ts
@@ -162,8 +162,8 @@ export class UserProfile {
   }
 
   // sets the label of the n-th keyring entry of the primary keyring
-  public setEntryLabel(n: number, label: string | undefined): void {
-    const entry = this.entryInPrimaryKeyring(n);
+  public setEntryLabel(id: number | string, label: string | undefined): void {
+    const entry = this.entryInPrimaryKeyring(id);
     entry.setLabel(label);
 
     if (!this.keyring) {
@@ -173,32 +173,32 @@ export class UserProfile {
   }
 
   // creates an identitiy in the n-th keyring entry of the primary keyring
-  public async createIdentity(n: number): Promise<LocalIdentity> {
-    const entry = this.entryInPrimaryKeyring(n);
+  public async createIdentity(id: number | string): Promise<LocalIdentity> {
+    const entry = this.entryInPrimaryKeyring(id);
     return entry.createIdentity();
   }
 
   // assigns a new label to one of the identities
   // in the n-th keyring entry of the primary keyring
-  public setIdentityLabel(n: number, identity: PublicIdentity, label: string | undefined): void {
-    const entry = this.entryInPrimaryKeyring(n);
+  public setIdentityLabel(id: number | string, identity: PublicIdentity, label: string | undefined): void {
+    const entry = this.entryInPrimaryKeyring(id);
     entry.setIdentityLabel(identity, label);
   }
 
   // get identities of the n-th keyring entry of the primary keyring
-  public getIdentities(n: number): ReadonlyArray<LocalIdentity> {
-    const entry = this.entryInPrimaryKeyring(n);
+  public getIdentities(id: number | string): ReadonlyArray<LocalIdentity> {
+    const entry = this.entryInPrimaryKeyring(id);
     return entry.getIdentities();
   }
 
   public async signTransaction(
-    n: number,
+    id: number | string,
     identity: PublicIdentity,
     transaction: UnsignedTransaction,
     codec: TxCodec,
     nonce: Nonce,
   ): Promise<SignedTransaction> {
-    const entry = this.entryInPrimaryKeyring(n);
+    const entry = this.entryInPrimaryKeyring(id);
 
     const { bytes, prehashType } = codec.bytesToSign(transaction, nonce);
     const signature: FullSignature = {
@@ -215,13 +215,13 @@ export class UserProfile {
   }
 
   public async appendSignature(
-    n: number,
+    id: number | string,
     identity: PublicIdentity,
     originalTransaction: SignedTransaction,
     codec: TxCodec,
     nonce: Nonce,
   ): Promise<SignedTransaction> {
-    const entry = this.entryInPrimaryKeyring(n);
+    const entry = this.entryInPrimaryKeyring(id);
 
     const { bytes, prehashType } = codec.bytesToSign(originalTransaction.transaction, nonce);
     const newSignature: FullSignature = {
@@ -241,14 +241,16 @@ export class UserProfile {
     };
   }
 
-  private entryInPrimaryKeyring(n: number): KeyringEntry {
+  private entryInPrimaryKeyring(id: number | string): KeyringEntry {
     if (!this.keyring) {
       throw new Error("UserProfile is currently locked");
     }
 
-    const entry = this.keyring.getEntries().find((_, index) => index === n);
+    const entry = typeof id === "number" ? this.keyring.getEntryByIndex(id) : this.keyring.getEntryById(id);
+
     if (!entry) {
-      throw new Error("Entry of index " + n + " does not exist in keyring");
+      const kind = typeof id === "number" ? "index" : "id";
+      throw new Error(`Entry of ${kind} ${id} does not exist in keyring`);
     }
 
     return entry;

--- a/packages/iov-keycontrol/src/userprofile.ts
+++ b/packages/iov-keycontrol/src/userprofile.ts
@@ -82,10 +82,15 @@ export class UserProfile {
     return entries.map(e => e.label.value) as ReadonlyArray<string | undefined>;
   }
 
+  private static ids(entries: ReadonlyArray<KeyringEntry>): ReadonlyArray<string> {
+    return entries.map(e => e.id);
+  }
+
   public readonly createdAt: ReadonlyDate;
   public readonly locked: ValueAndUpdates<boolean>;
   public readonly entriesCount: ValueAndUpdates<number>;
   public readonly entryLabels: ValueAndUpdates<ReadonlyArray<string | undefined>>;
+  public readonly entryIds: ValueAndUpdates<ReadonlyArray<string>>;
 
   // Never pass the keyring reference to ensure the keyring is not retained after lock()
   // tslint:disable-next-line:readonly-keyword
@@ -93,6 +98,7 @@ export class UserProfile {
   private readonly lockedProducer: DefaultValueProducer<boolean>;
   private readonly entriesCountProducer: DefaultValueProducer<number>;
   private readonly entryLabelsProducer: DefaultValueProducer<ReadonlyArray<string | undefined>>;
+  private readonly entryIdsProducer: DefaultValueProducer<ReadonlyArray<string>>;
 
   // Stores a copy of keyring
   constructor(options?: UserProfileOptions) {
@@ -106,10 +112,14 @@ export class UserProfile {
 
     this.lockedProducer = new DefaultValueProducer(false);
     this.locked = new ValueAndUpdates(this.lockedProducer);
+    // TODO: we really need to clean this up and rethink what we expose where
+    // but that would be a breaking change... let's aim for 0.6
     this.entriesCountProducer = new DefaultValueProducer(this.keyring.getEntries().length);
     this.entriesCount = new ValueAndUpdates(this.entriesCountProducer);
     this.entryLabelsProducer = new DefaultValueProducer(UserProfile.labels(this.keyring.getEntries()));
     this.entryLabels = new ValueAndUpdates(this.entryLabelsProducer);
+    this.entryIdsProducer = new DefaultValueProducer(UserProfile.ids(this.keyring.getEntries()));
+    this.entryIds = new ValueAndUpdates(this.entryIdsProducer);
   }
 
   // this will clear everything in the database and store the user profile
@@ -159,6 +169,7 @@ export class UserProfile {
     this.keyring.add(copy);
     this.entriesCountProducer.update(this.keyring.getEntries().length);
     this.entryLabelsProducer.update(UserProfile.labels(this.keyring.getEntries()));
+    this.entryIdsProducer.update(UserProfile.ids(this.keyring.getEntries()));
   }
 
   // sets the label of the n-th keyring entry of the primary keyring

--- a/packages/iov-keycontrol/types/keyring.d.ts
+++ b/packages/iov-keycontrol/types/keyring.d.ts
@@ -28,6 +28,7 @@ export declare class Keyring {
     constructor(data?: KeyringSerializationString);
     add(entry: KeyringEntry): void;
     getEntries(): ReadonlyArray<KeyringEntry>;
+    getEntryById(id: string): KeyringEntry | undefined;
     serialize(): KeyringSerializationString;
     clone(): Keyring;
 }

--- a/packages/iov-keycontrol/types/keyring.d.ts
+++ b/packages/iov-keycontrol/types/keyring.d.ts
@@ -29,6 +29,7 @@ export declare class Keyring {
     add(entry: KeyringEntry): void;
     getEntries(): ReadonlyArray<KeyringEntry>;
     getEntryById(id: string): KeyringEntry | undefined;
+    getEntryByIndex(n: number): KeyringEntry | undefined;
     serialize(): KeyringSerializationString;
     clone(): Keyring;
 }

--- a/packages/iov-keycontrol/types/userprofile.d.ts
+++ b/packages/iov-keycontrol/types/userprofile.d.ts
@@ -12,14 +12,17 @@ export declare class UserProfile {
     static loadFrom(db: LevelUp<AbstractLevelDOWN<string, string>>, password: string): Promise<UserProfile>;
     private static makeNonce;
     private static labels;
+    private static ids;
     readonly createdAt: ReadonlyDate;
     readonly locked: ValueAndUpdates<boolean>;
     readonly entriesCount: ValueAndUpdates<number>;
     readonly entryLabels: ValueAndUpdates<ReadonlyArray<string | undefined>>;
+    readonly entryIds: ValueAndUpdates<ReadonlyArray<string>>;
     private keyring;
     private readonly lockedProducer;
     private readonly entriesCountProducer;
     private readonly entryLabelsProducer;
+    private readonly entryIdsProducer;
     constructor(options?: UserProfileOptions);
     storeIn(db: LevelUp<AbstractLevelDOWN<string, string>>, password: string): Promise<void>;
     lock(): void;

--- a/packages/iov-keycontrol/types/userprofile.d.ts
+++ b/packages/iov-keycontrol/types/userprofile.d.ts
@@ -24,11 +24,11 @@ export declare class UserProfile {
     storeIn(db: LevelUp<AbstractLevelDOWN<string, string>>, password: string): Promise<void>;
     lock(): void;
     addEntry(entry: KeyringEntry): void;
-    setEntryLabel(n: number, label: string | undefined): void;
-    createIdentity(n: number): Promise<LocalIdentity>;
-    setIdentityLabel(n: number, identity: PublicIdentity, label: string | undefined): void;
-    getIdentities(n: number): ReadonlyArray<LocalIdentity>;
-    signTransaction(n: number, identity: PublicIdentity, transaction: UnsignedTransaction, codec: TxCodec, nonce: Nonce): Promise<SignedTransaction>;
-    appendSignature(n: number, identity: PublicIdentity, originalTransaction: SignedTransaction, codec: TxCodec, nonce: Nonce): Promise<SignedTransaction>;
+    setEntryLabel(id: number | string, label: string | undefined): void;
+    createIdentity(id: number | string): Promise<LocalIdentity>;
+    setIdentityLabel(id: number | string, identity: PublicIdentity, label: string | undefined): void;
+    getIdentities(id: number | string): ReadonlyArray<LocalIdentity>;
+    signTransaction(id: number | string, identity: PublicIdentity, transaction: UnsignedTransaction, codec: TxCodec, nonce: Nonce): Promise<SignedTransaction>;
+    appendSignature(id: number | string, identity: PublicIdentity, originalTransaction: SignedTransaction, codec: TxCodec, nonce: Nonce): Promise<SignedTransaction>;
     private entryInPrimaryKeyring;
 }


### PR DESCRIPTION
After returning ids on keyringentry and localidentity as part of #332, this prs allows us to use them as arguements to UserProfile, instead of only relying on indices. The first argument is now `number | string` instead of `number`. We can later refine it to `number | IovId` or `number | KeyringEntryId` something else as better names arrive