### PR TITLE
Force republish v0.5.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test": "lerna run test",
     "build": "lerna run build",
     "docs": "lerna run docs",
-    "release": "lerna publish",
+    "release": "lerna run build && lerna publish",
     "clean": "rm -rf ./packages/*/docs/"
   },
   "devDependencies": {

--- a/packages/iov-bcp-types/README.md
+++ b/packages/iov-bcp-types/README.md
@@ -2,6 +2,9 @@
 
 [![npm version](https://img.shields.io/npm/v/@iov/bcp-types.svg)](https://www.npmjs.com/package/@iov/bcp-types)
 
+@iov/bcp-types holds all types needed to properly implement the generic BCP interfaces.
+It includes lower-level [@iov/tendermint-types](../iov-tendermint-types) for things such as TransactionId, etc.
+
 ## API Documentation
 
 [https://iov-one.github.io/iov-core-docs/latest/iov-bcp-types/](https://iov-one.github.io/iov-core-docs/latest/iov-bcp-types/)

--- a/packages/iov-bns/README.md
+++ b/packages/iov-bns/README.md
@@ -2,12 +2,13 @@
 
 [![npm version](https://img.shields.io/npm/v/@iov/bns.svg)](https://www.npmjs.com/package/@iov/bns)
 
-This package is an implementation of the IovReader
-interface for the BNS blockchain
+This package is an implementation of the IovReader interface for the BNS blockchain
 (currently just as [bcp-demo](https://github.com/iov-one/bcp-demo) prototype).
-It should be able to adapt this code
-fairly easily to support any other [weave](https://github.com/confio/weave)
-based blockchain as well.
+It should be able to adapt this code fairly easily to support any other
+[weave](https://github.com/confio/weave) based blockchain as well.
+
+This provides a reference implementation of the full feature set of `IovReader`, so
+it is also a good read when starting support of another blockchain.
 
 Simplest usage, to use auto-detecting tendermint client and standard
 bns transaction parser:

--- a/packages/iov-core/README.md
+++ b/packages/iov-core/README.md
@@ -25,6 +25,10 @@ functions and experimentally in the [@iov/cli](https://github.com/iov-one/iov-co
 (All imports are done for you in the REPL as well, so you can skip the import
 statements. They are provided for guidance when integrating into your own codebase).
 
+Before starting, either run from source in `../iov-cli` via `yarn test-bin`
+or install from npm via `npm install -g @iov/cli; iov-cli`.
+Inside the cli the remaining code should work verbatim.
+
 ### Key Management
 
 Create a random mnemonic:

--- a/packages/iov-crypto/README.md
+++ b/packages/iov-crypto/README.md
@@ -2,6 +2,11 @@
 
 [![npm version](https://img.shields.io/npm/v/@iov/crypto.svg)](https://www.npmjs.com/package/@iov/crypto)
 
+@iov/crypto contains low-level cryptographic functionality used in other @iov libraries.
+Little of it is implemented here, but mainly it is a curation of external libraries along
+with correctness tests. We add type-safety, some more checks, and a simple API to these libraries.
+This can also be freely imported outside of @iov/core based applications.
+
 ## API Documentation
 
 [https://iov-one.github.io/iov-core-docs/latest/iov-crypto/](https://iov-one.github.io/iov-core-docs/latest/iov-crypto/)

--- a/packages/iov-encoding/README.md
+++ b/packages/iov-encoding/README.md
@@ -3,7 +3,9 @@
 [![npm version](https://img.shields.io/npm/v/@iov/encoding.svg)](https://www.npmjs.com/package/@iov/encoding)
 
 This package is an extension to the JavaScript standard library that is not
-bound to IOV products.
+bound to IOV products. It provides basic hex/base64/ascii/integer encoding to
+Uint8Array that doesn't rely on Buffer and also provides better error messages
+on invalid input.
 
 ## API Documentation
 

--- a/packages/iov-keycontrol/README.md
+++ b/packages/iov-keycontrol/README.md
@@ -6,6 +6,10 @@ Keycontrol manages all private keys and keeps them safe.
 
 ![KeyBase Diagram](https://raw.githubusercontent.com/iov-one/iov-core/master/docs/KeyBaseDiagram.png)
 
+Please stick to using the [public API](https://iov-one.github.io/iov-core-docs/latest/iov-keycontrol/classes/userprofile.html)
+even if you are importing from javascript, where `private` is not enforces. There are plans to wrap
+objects in closures to provide run-time protection of secrets like private keys and mneumonic seeds.
+
 Simplest usage:
 
 ```

--- a/packages/iov-ledger-bns/README.md
+++ b/packages/iov-ledger-bns/README.md
@@ -6,6 +6,9 @@ This package provides an adaptor to use the bns ledger app as a keyring entry.
 The app is still in dev mode and not available in the ledger store, so
 this is really for cutting edge devs now.
 
+It should also demonstrate how to implement an additional KeyringEntry outside of @iov/keycontrol
+that can be dynamically loaded by any app in initialization.
+
 ## Getting started
 
 Create a LedgerSimpleAddressKeyringEntry for signing with a Ledger. All

--- a/packages/iov-tendermint-rpc/README.md
+++ b/packages/iov-tendermint-rpc/README.md
@@ -14,6 +14,11 @@ automatically, and call:
 const client = await Client.connect('wss://bov.wolfnet.iov.one');
 ```
 
+Supported tendermint versions:
+* v0.20.x
+* v0.21.x
+(help welcome to extend this list)
+
 ## Code Overview
 
 The main entry point is the [Client](https://iov-one.github.io/iov-core-docs/latest/iov-tendermint-rpc/classes/_client_.client.html).

--- a/packages/iov-tendermint-types/README.md
+++ b/packages/iov-tendermint-types/README.md
@@ -2,6 +2,10 @@
 
 [![npm version](https://img.shields.io/npm/v/@iov/tendermint-types.svg)](https://www.npmjs.com/package/@iov/tendermint-types)
 
+@iov/tendermint-types is a set of types needed to define the @iov/tendermint-rpc, and likely many other
+blockchain rpc adapters (so we may need to change it's name). It is relatively low-level, sticking with
+the types on the wire, while [@iov/bcp-types](../iov-bcp-types) deals with higher-level constructs for the bcp api.
+
 ## API Documentation
 
 [https://iov-one.github.io/iov-core-docs/latest/iov-tendermint-types/](https://iov-one.github.io/iov-core-docs/latest/iov-tendermint-types/)


### PR DESCRIPTION
I forgot to `yarn build` before `lerna publish` and pushed the old javascript, even when tagging v0.5.2 with the typescript. This now builds automatically on `yarn release` and I update packages to allow a proper v0.5.3 release.