### PR TITLE
Add keyring id types

### DIFF
--- a/packages/iov-core/src/writer.ts
+++ b/packages/iov-core/src/writer.ts
@@ -9,7 +9,7 @@ import {
   UnsignedTransaction,
 } from "@iov/bcp-types";
 import { bnsCodec, Client as BnsClient } from "@iov/bns";
-import { PublicIdentity, UserProfile } from "@iov/keycontrol";
+import { KeyringEntryId, PublicIdentity, UserProfile } from "@iov/keycontrol";
 import { ChainId, PublicKeyBundle } from "@iov/tendermint-types";
 
 /*
@@ -63,7 +63,7 @@ export class IovWriter {
   // It finds the nonce, signs properly, and posts the tx to the blockchain.
   public async signAndCommit(
     tx: UnsignedTransaction,
-    keyring: number | string,
+    keyring: number | KeyringEntryId,
   ): Promise<BcpTransactionResponse> {
     const chainId = tx.chainId;
     const { client, codec } = this.getChain(chainId);

--- a/packages/iov-core/types/writer.d.ts
+++ b/packages/iov-core/types/writer.d.ts
@@ -1,6 +1,6 @@
 import { Address, BcpTransactionResponse, IovReader, Nonce, TxCodec, UnsignedTransaction } from "@iov/bcp-types";
 import { Client as BnsClient } from "@iov/bns";
-import { UserProfile } from "@iov/keycontrol";
+import { KeyringEntryId, UserProfile } from "@iov/keycontrol";
 import { ChainId, PublicKeyBundle } from "@iov/tendermint-types";
 export declare class IovWriter {
     readonly profile: UserProfile;
@@ -11,7 +11,7 @@ export declare class IovWriter {
     addChain(connector: ChainConnector): Promise<void>;
     keyToAddress(chainId: ChainId, key: PublicKeyBundle): Address;
     getNonce(chainId: ChainId, addr: Address): Promise<Nonce>;
-    signAndCommit(tx: UnsignedTransaction, keyring: number | string): Promise<BcpTransactionResponse>;
+    signAndCommit(tx: UnsignedTransaction, keyring: number | KeyringEntryId): Promise<BcpTransactionResponse>;
     private getChain;
 }
 export interface ChainConnector {

--- a/packages/iov-keycontrol/src/index.ts
+++ b/packages/iov-keycontrol/src/index.ts
@@ -2,9 +2,11 @@ export { Ed25519SimpleAddressKeyringEntry } from "./keyring-entries";
 export {
   Keyring,
   KeyringEntry,
+  KeyringEntryId,
   KeyringEntryImplementationIdString,
   KeyringEntrySerializationString,
   LocalIdentity,
+  LocalIdentityId,
   PublicIdentity,
 } from "./keyring";
 export { UserProfile } from "./userprofile";

--- a/packages/iov-keycontrol/src/keyring-entries/slip10.ts
+++ b/packages/iov-keycontrol/src/keyring-entries/slip10.ts
@@ -16,9 +16,11 @@ import { Algorithm, ChainId, PublicKeyBundle, PublicKeyBytes, SignatureBytes } f
 
 import {
   KeyringEntry,
+  KeyringEntryId,
   KeyringEntryImplementationIdString,
   KeyringEntrySerializationString,
   LocalIdentity,
+  LocalIdentityId,
   PublicIdentity,
 } from "../keyring";
 import { prehash } from "../prehashing";
@@ -74,8 +76,9 @@ export class Slip10KeyringEntry implements KeyringEntry {
     return new cls(JSON.stringify(data) as KeyringEntrySerializationString);
   }
 
-  private static identityId(identity: PublicIdentity): string {
-    return identity.pubkey.algo + "|" + Encoding.toHex(identity.pubkey.data);
+  private static identityId(identity: PublicIdentity): LocalIdentityId {
+    const id = identity.pubkey.algo + "|" + Encoding.toHex(identity.pubkey.data);
+    return id as LocalIdentityId;
   }
 
   private static algorithmFromCurve(curve: Slip10Curve): Algorithm {
@@ -103,7 +106,7 @@ export class Slip10KeyringEntry implements KeyringEntry {
   public readonly label: ValueAndUpdates<string | undefined>;
   public readonly canSign = new ValueAndUpdates(new DefaultValueProducer(true));
   public readonly implementationId = "override me!" as KeyringEntryImplementationIdString;
-  public readonly id: string;
+  public readonly id: KeyringEntryId;
 
   private readonly secret: EnglishMnemonic;
   private readonly curve: Slip10Curve;
@@ -296,13 +299,13 @@ export class Slip10KeyringEntry implements KeyringEntry {
 
   // calculate id returns the tripple sha256 hash of the bip39 entropy as hex-string
   // prepended by implementationId of the concrete class (to differentiate eg. secp256k1 and ed25519 keyrings)
-  private calculateId(): string {
+  private calculateId(): KeyringEntryId {
     /* tslint:disable:no-let */
     let data = Bip39.decode(this.secret);
     for (let i = 0; i < 3; i++) {
       data = new Sha256(data).digest();
     }
     const hex = Encoding.toHex(data);
-    return `${this.implementationId}:${hex}`;
+    return `${this.implementationId}:${hex}` as KeyringEntryId;
   }
 }

--- a/packages/iov-keycontrol/src/keyring.ts
+++ b/packages/iov-keycontrol/src/keyring.ts
@@ -10,6 +10,9 @@ export type KeyringEntrySerializationString = string & As<"keyring-entry-seriali
 export type KeyringSerializationString = string & As<"keyring-serialization">;
 export type KeyringEntryImplementationIdString = string & As<"keyring-entry-implementation-id">;
 
+export type LocalIdentityId = string & As<"local-identity-id">;
+export type KeyringEntryId = string & As<"keyring-entry-id">;
+
 // PublicIdentity is a public key we can identify with on a blockchain
 export interface PublicIdentity {
   readonly pubkey: PublicKeyBundle;
@@ -19,7 +22,7 @@ export interface PublicIdentity {
 // additional local information
 export interface LocalIdentity extends PublicIdentity {
   // immutible id string based on pubkey
-  readonly id: string;
+  readonly id: LocalIdentityId;
 
   // An optional, local label.
   // This is not exposed to other people or other devices. Use BNS registration for that.
@@ -142,7 +145,7 @@ export interface KeyringEntry {
   // id is a unique identifier based on the content of the keyring
   // the same implementation with same seed/secret should have same identifier
   // otherwise, they will be different
-  readonly id: string;
+  readonly id: KeyringEntryId;
 
   // Sets a label associated with the keyring entry to be displayed in the UI.
   // To clear the label, set it to undefined.

--- a/packages/iov-keycontrol/src/userprofile.spec.ts
+++ b/packages/iov-keycontrol/src/userprofile.spec.ts
@@ -6,7 +6,7 @@ import { ReadonlyDate } from "readonly-date";
 import { Address, Nonce, PrehashType, SendTx, SignableBytes, SignedTransaction, SigningJob, TokenTicker, TransactionIdBytes, TransactionKind, TxCodec } from "@iov/bcp-types";
 import { Algorithm, ChainId, PostableBytes, PublicKeyBytes, SignatureBytes } from "@iov/tendermint-types";
 
-import { Keyring } from "./keyring";
+import { Keyring, KeyringEntryId } from "./keyring";
 import { Ed25519SimpleAddressKeyringEntry } from "./keyring-entries";
 import { UserProfile } from "./userprofile";
 
@@ -182,7 +182,7 @@ describe("UserProfile", () => {
     profile.addEntry(entry1);
 
     expect(() => profile.getIdentities(2)).toThrowError(/Entry of index 2 does not exist in keyring/);
-    expect(() => profile.getIdentities("balloon")).toThrowError(/Entry of id balloon does not exist in keyring/);
+    expect(() => profile.getIdentities("balloon" as KeyringEntryId)).toThrowError(/Entry of id balloon does not exist in keyring/);
   });
 
   it("added entry can not be manipulated from outside", async () => {

--- a/packages/iov-keycontrol/src/userprofile.ts
+++ b/packages/iov-keycontrol/src/userprofile.ts
@@ -15,7 +15,14 @@ import {
 } from "@iov/crypto";
 import { Encoding } from "@iov/encoding";
 
-import { Keyring, KeyringEntry, KeyringSerializationString, LocalIdentity, PublicIdentity } from "./keyring";
+import {
+  Keyring,
+  KeyringEntry,
+  KeyringEntryId,
+  KeyringSerializationString,
+  LocalIdentity,
+  PublicIdentity,
+} from "./keyring";
 import { DatabaseUtils } from "./utils";
 import { DefaultValueProducer, ValueAndUpdates } from "./valueandupdates";
 
@@ -82,7 +89,7 @@ export class UserProfile {
     return entries.map(e => e.label.value) as ReadonlyArray<string | undefined>;
   }
 
-  private static ids(entries: ReadonlyArray<KeyringEntry>): ReadonlyArray<string> {
+  private static ids(entries: ReadonlyArray<KeyringEntry>): ReadonlyArray<KeyringEntryId> {
     return entries.map(e => e.id);
   }
 
@@ -90,7 +97,7 @@ export class UserProfile {
   public readonly locked: ValueAndUpdates<boolean>;
   public readonly entriesCount: ValueAndUpdates<number>;
   public readonly entryLabels: ValueAndUpdates<ReadonlyArray<string | undefined>>;
-  public readonly entryIds: ValueAndUpdates<ReadonlyArray<string>>;
+  public readonly entryIds: ValueAndUpdates<ReadonlyArray<KeyringEntryId>>;
 
   // Never pass the keyring reference to ensure the keyring is not retained after lock()
   // tslint:disable-next-line:readonly-keyword
@@ -98,7 +105,7 @@ export class UserProfile {
   private readonly lockedProducer: DefaultValueProducer<boolean>;
   private readonly entriesCountProducer: DefaultValueProducer<number>;
   private readonly entryLabelsProducer: DefaultValueProducer<ReadonlyArray<string | undefined>>;
-  private readonly entryIdsProducer: DefaultValueProducer<ReadonlyArray<string>>;
+  private readonly entryIdsProducer: DefaultValueProducer<ReadonlyArray<KeyringEntryId>>;
 
   // Stores a copy of keyring
   constructor(options?: UserProfileOptions) {
@@ -173,7 +180,7 @@ export class UserProfile {
   }
 
   // sets the label of the n-th keyring entry of the primary keyring
-  public setEntryLabel(id: number | string, label: string | undefined): void {
+  public setEntryLabel(id: number | KeyringEntryId, label: string | undefined): void {
     const entry = this.entryInPrimaryKeyring(id);
     entry.setLabel(label);
 
@@ -184,26 +191,30 @@ export class UserProfile {
   }
 
   // creates an identitiy in the n-th keyring entry of the primary keyring
-  public async createIdentity(id: number | string): Promise<LocalIdentity> {
+  public async createIdentity(id: number | KeyringEntryId): Promise<LocalIdentity> {
     const entry = this.entryInPrimaryKeyring(id);
     return entry.createIdentity();
   }
 
   // assigns a new label to one of the identities
   // in the n-th keyring entry of the primary keyring
-  public setIdentityLabel(id: number | string, identity: PublicIdentity, label: string | undefined): void {
+  public setIdentityLabel(
+    id: number | KeyringEntryId,
+    identity: PublicIdentity,
+    label: string | undefined,
+  ): void {
     const entry = this.entryInPrimaryKeyring(id);
     entry.setIdentityLabel(identity, label);
   }
 
   // get identities of the n-th keyring entry of the primary keyring
-  public getIdentities(id: number | string): ReadonlyArray<LocalIdentity> {
+  public getIdentities(id: number | KeyringEntryId): ReadonlyArray<LocalIdentity> {
     const entry = this.entryInPrimaryKeyring(id);
     return entry.getIdentities();
   }
 
   public async signTransaction(
-    id: number | string,
+    id: number | KeyringEntryId,
     identity: PublicIdentity,
     transaction: UnsignedTransaction,
     codec: TxCodec,
@@ -226,7 +237,7 @@ export class UserProfile {
   }
 
   public async appendSignature(
-    id: number | string,
+    id: number | KeyringEntryId,
     identity: PublicIdentity,
     originalTransaction: SignedTransaction,
     codec: TxCodec,
@@ -252,7 +263,7 @@ export class UserProfile {
     };
   }
 
-  private entryInPrimaryKeyring(id: number | string): KeyringEntry {
+  private entryInPrimaryKeyring(id: number | KeyringEntryId): KeyringEntry {
     if (!this.keyring) {
       throw new Error("UserProfile is currently locked");
     }

--- a/packages/iov-keycontrol/types/index.d.ts
+++ b/packages/iov-keycontrol/types/index.d.ts
@@ -1,4 +1,4 @@
 export { Ed25519SimpleAddressKeyringEntry } from "./keyring-entries";
-export { Keyring, KeyringEntry, KeyringEntryImplementationIdString, KeyringEntrySerializationString, LocalIdentity, PublicIdentity, } from "./keyring";
+export { Keyring, KeyringEntry, KeyringEntryId, KeyringEntryImplementationIdString, KeyringEntrySerializationString, LocalIdentity, LocalIdentityId, PublicIdentity, } from "./keyring";
 export { UserProfile } from "./userprofile";
 export { DefaultValueProducer, ValueAndUpdates } from "./valueandupdates";

--- a/packages/iov-keycontrol/types/keyring-entries/ed25519.d.ts
+++ b/packages/iov-keycontrol/types/keyring-entries/ed25519.d.ts
@@ -1,6 +1,6 @@
 import { PrehashType, SignableBytes } from "@iov/bcp-types";
 import { ChainId, SignatureBytes } from "@iov/tendermint-types";
-import { KeyringEntry, KeyringEntryImplementationIdString, KeyringEntrySerializationString, LocalIdentity, PublicIdentity } from "../keyring";
+import { KeyringEntry, KeyringEntryId, KeyringEntryImplementationIdString, KeyringEntrySerializationString, LocalIdentity, PublicIdentity } from "../keyring";
 import { ValueAndUpdates } from "../valueandupdates";
 export declare class Ed25519KeyringEntry implements KeyringEntry {
     private static readonly prng;
@@ -9,7 +9,7 @@ export declare class Ed25519KeyringEntry implements KeyringEntry {
     readonly label: ValueAndUpdates<string | undefined>;
     readonly canSign: ValueAndUpdates<boolean>;
     readonly implementationId: KeyringEntryImplementationIdString;
-    readonly id: string;
+    readonly id: KeyringEntryId;
     private readonly identities;
     private readonly privkeys;
     private readonly labelProducer;

--- a/packages/iov-keycontrol/types/keyring-entries/slip10.d.ts
+++ b/packages/iov-keycontrol/types/keyring-entries/slip10.d.ts
@@ -1,7 +1,7 @@
 import { PrehashType, SignableBytes } from "@iov/bcp-types";
 import { Slip10Curve, Slip10RawIndex } from "@iov/crypto";
 import { ChainId, SignatureBytes } from "@iov/tendermint-types";
-import { KeyringEntry, KeyringEntryImplementationIdString, KeyringEntrySerializationString, LocalIdentity, PublicIdentity } from "../keyring";
+import { KeyringEntry, KeyringEntryId, KeyringEntryImplementationIdString, KeyringEntrySerializationString, LocalIdentity, PublicIdentity } from "../keyring";
 import { ValueAndUpdates } from "../valueandupdates";
 interface Slip10KeyringEntryConstructor {
     new (data: KeyringEntrySerializationString): Slip10KeyringEntry;
@@ -15,7 +15,7 @@ export declare class Slip10KeyringEntry implements KeyringEntry {
     readonly label: ValueAndUpdates<string | undefined>;
     readonly canSign: ValueAndUpdates<boolean>;
     readonly implementationId: KeyringEntryImplementationIdString;
-    readonly id: string;
+    readonly id: KeyringEntryId;
     private readonly secret;
     private readonly curve;
     private readonly identities;

--- a/packages/iov-keycontrol/types/keyring.d.ts
+++ b/packages/iov-keycontrol/types/keyring.d.ts
@@ -5,11 +5,13 @@ import { ValueAndUpdates } from "./valueandupdates";
 export declare type KeyringEntrySerializationString = string & As<"keyring-entry-serialization">;
 export declare type KeyringSerializationString = string & As<"keyring-serialization">;
 export declare type KeyringEntryImplementationIdString = string & As<"keyring-entry-implementation-id">;
+export declare type LocalIdentityId = string & As<"local-identity-id">;
+export declare type KeyringEntryId = string & As<"keyring-entry-id">;
 export interface PublicIdentity {
     readonly pubkey: PublicKeyBundle;
 }
 export interface LocalIdentity extends PublicIdentity {
-    readonly id: string;
+    readonly id: LocalIdentityId;
     readonly label?: string;
 }
 export interface KeyringEntrySerialization {
@@ -35,7 +37,7 @@ export declare class Keyring {
 }
 export interface KeyringEntry {
     readonly label: ValueAndUpdates<string | undefined>;
-    readonly id: string;
+    readonly id: KeyringEntryId;
     readonly setLabel: (label: string | undefined) => void;
     readonly createIdentity: () => Promise<LocalIdentity>;
     readonly setIdentityLabel: (identity: PublicIdentity, label: string | undefined) => void;

--- a/packages/iov-keycontrol/types/userprofile.d.ts
+++ b/packages/iov-keycontrol/types/userprofile.d.ts
@@ -2,7 +2,7 @@ import { AbstractLevelDOWN } from "abstract-leveldown";
 import { LevelUp } from "levelup";
 import { ReadonlyDate } from "readonly-date";
 import { Nonce, SignedTransaction, TxCodec, UnsignedTransaction } from "@iov/bcp-types";
-import { Keyring, KeyringEntry, LocalIdentity, PublicIdentity } from "./keyring";
+import { Keyring, KeyringEntry, KeyringEntryId, LocalIdentity, PublicIdentity } from "./keyring";
 import { ValueAndUpdates } from "./valueandupdates";
 export interface UserProfileOptions {
     readonly createdAt: ReadonlyDate;
@@ -17,7 +17,7 @@ export declare class UserProfile {
     readonly locked: ValueAndUpdates<boolean>;
     readonly entriesCount: ValueAndUpdates<number>;
     readonly entryLabels: ValueAndUpdates<ReadonlyArray<string | undefined>>;
-    readonly entryIds: ValueAndUpdates<ReadonlyArray<string>>;
+    readonly entryIds: ValueAndUpdates<ReadonlyArray<KeyringEntryId>>;
     private keyring;
     private readonly lockedProducer;
     private readonly entriesCountProducer;
@@ -27,11 +27,11 @@ export declare class UserProfile {
     storeIn(db: LevelUp<AbstractLevelDOWN<string, string>>, password: string): Promise<void>;
     lock(): void;
     addEntry(entry: KeyringEntry): void;
-    setEntryLabel(id: number | string, label: string | undefined): void;
-    createIdentity(id: number | string): Promise<LocalIdentity>;
-    setIdentityLabel(id: number | string, identity: PublicIdentity, label: string | undefined): void;
-    getIdentities(id: number | string): ReadonlyArray<LocalIdentity>;
-    signTransaction(id: number | string, identity: PublicIdentity, transaction: UnsignedTransaction, codec: TxCodec, nonce: Nonce): Promise<SignedTransaction>;
-    appendSignature(id: number | string, identity: PublicIdentity, originalTransaction: SignedTransaction, codec: TxCodec, nonce: Nonce): Promise<SignedTransaction>;
+    setEntryLabel(id: number | KeyringEntryId, label: string | undefined): void;
+    createIdentity(id: number | KeyringEntryId): Promise<LocalIdentity>;
+    setIdentityLabel(id: number | KeyringEntryId, identity: PublicIdentity, label: string | undefined): void;
+    getIdentities(id: number | KeyringEntryId): ReadonlyArray<LocalIdentity>;
+    signTransaction(id: number | KeyringEntryId, identity: PublicIdentity, transaction: UnsignedTransaction, codec: TxCodec, nonce: Nonce): Promise<SignedTransaction>;
+    appendSignature(id: number | KeyringEntryId, identity: PublicIdentity, originalTransaction: SignedTransaction, codec: TxCodec, nonce: Nonce): Promise<SignedTransaction>;
     private entryInPrimaryKeyring;
 }

--- a/packages/iov-ledger-bns/src/ledgersimpleaddresskeyringentry.ts
+++ b/packages/iov-ledger-bns/src/ledgersimpleaddresskeyringentry.ts
@@ -5,9 +5,11 @@ import {
   DefaultValueProducer,
   Keyring,
   KeyringEntry,
+  KeyringEntryId,
   KeyringEntryImplementationIdString,
   KeyringEntrySerializationString,
   LocalIdentity,
+  LocalIdentityId,
   PublicIdentity,
   ValueAndUpdates,
 } from "@iov/keycontrol";
@@ -39,7 +41,7 @@ interface LedgerKeyringEntrySerialization {
 }
 
 // this is the id of any LedgerSimpleAddressKeyringEntry until it connects with the app
-const defaultId = "uninitialized";
+const defaultId = "uninitialized" as KeyringEntryId;
 
 export class LedgerSimpleAddressKeyringEntry implements KeyringEntry {
   public static readonly implementationId = "ledger-simpleaddress" as KeyringEntryImplementationIdString;
@@ -54,8 +56,9 @@ export class LedgerSimpleAddressKeyringEntry implements KeyringEntry {
     });
   }
 
-  private static identityId(identity: PublicIdentity): string {
-    return identity.pubkey.algo + "|" + Encoding.toHex(identity.pubkey.data);
+  private static identityId(identity: PublicIdentity): LocalIdentityId {
+    const id = identity.pubkey.algo + "|" + Encoding.toHex(identity.pubkey.data);
+    return id as LocalIdentityId;
   }
 
   public readonly label: ValueAndUpdates<string | undefined>;
@@ -64,7 +67,7 @@ export class LedgerSimpleAddressKeyringEntry implements KeyringEntry {
   public readonly deviceState: ValueAndUpdates<LedgerState>;
   // id will be set the first time the keyring connects to a given device, "uninitialized" until then
   // tslint:disable-next-line:readonly-keyword
-  public id: string;
+  public id: KeyringEntryId;
 
   private readonly deviceTracker = new StateTracker();
   private readonly labelProducer: DefaultValueProducer<string | undefined>;
@@ -88,7 +91,7 @@ export class LedgerSimpleAddressKeyringEntry implements KeyringEntry {
     // tslint:disable-next-line:no-let
     let label: string | undefined;
     // tslint:disable-next-line:no-let
-    let id: string = defaultId;
+    let id = defaultId;
     const identities: LocalIdentity[] = [];
     const simpleAddressIndices = new Map<string, number>();
 
@@ -97,7 +100,7 @@ export class LedgerSimpleAddressKeyringEntry implements KeyringEntry {
 
       // label
       label = decodedData.label;
-      id = decodedData.id;
+      id = decodedData.id as KeyringEntryId;
 
       // identities
       for (const record of decodedData.identities) {

--- a/packages/iov-ledger-bns/types/ledgersimpleaddresskeyringentry.d.ts
+++ b/packages/iov-ledger-bns/types/ledgersimpleaddresskeyringentry.d.ts
@@ -1,5 +1,5 @@
 import { PrehashType, SignableBytes } from "@iov/bcp-types";
-import { KeyringEntry, KeyringEntryImplementationIdString, KeyringEntrySerializationString, LocalIdentity, PublicIdentity, ValueAndUpdates } from "@iov/keycontrol";
+import { KeyringEntry, KeyringEntryId, KeyringEntryImplementationIdString, KeyringEntrySerializationString, LocalIdentity, PublicIdentity, ValueAndUpdates } from "@iov/keycontrol";
 import { ChainId, SignatureBytes } from "@iov/tendermint-types";
 import { LedgerState } from "./statetracker";
 export declare class LedgerSimpleAddressKeyringEntry implements KeyringEntry {
@@ -10,7 +10,7 @@ export declare class LedgerSimpleAddressKeyringEntry implements KeyringEntry {
     readonly canSign: ValueAndUpdates<boolean>;
     readonly implementationId: KeyringEntryImplementationIdString;
     readonly deviceState: ValueAndUpdates<LedgerState>;
-    id: string;
+    id: KeyringEntryId;
     private readonly deviceTracker;
     private readonly labelProducer;
     private readonly canSignProducer;


### PR DESCRIPTION
Make KeyringEntryId and LocalIdentityId explicit specializations of string to provide a cleaner API surface.