### PR TITLE
Refactor keyring entry ID generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.6.0
+
+* @iov/core: expose Ed25519KeyringEntry
+* @iov/keycontrol: refactor entry ID generation
+
+Breaking changes
+
+* Due to updates in the Keyring serialization, UserProfiles stored with
+  earlier versions of IOV-Core cannot be opened with 0.6.0. To migrate to
+  the new version, extract the secret data using an older version and
+  create a new UserProfile in 0.6.0.
+
 ## 0.5.4
 
 * @iov/cli: fix global installation support

--- a/packages/iov-cli/src/cli.ts
+++ b/packages/iov-cli/src/cli.ts
@@ -47,7 +47,6 @@ export const main = (originalArgs: string[]): void => {
   console.log(colors.yellow("    - bnsConnector"));
   console.log(colors.yellow("    - bnsFromOrToTag"));
   console.log(colors.yellow("    - ChainId"));
-  console.log(colors.yellow("    - Ed25519KeyringEntry"));
   console.log(colors.yellow("    - Ed25519SimpleAddressKeyringEntry"));
   console.log(colors.yellow("    - Keyring"));
   console.log(colors.yellow("    - KeyringEntry"));
@@ -87,7 +86,6 @@ export const main = (originalArgs: string[]): void => {
       bnsConnector,
       bnsFromOrToTag,
       ChainId,
-      Ed25519KeyringEntry,
       Ed25519SimpleAddressKeyringEntry,
       Keyring,
       KeyringEntry,

--- a/packages/iov-cli/src/cli.ts
+++ b/packages/iov-cli/src/cli.ts
@@ -47,6 +47,7 @@ export const main = (originalArgs: string[]): void => {
   console.log(colors.yellow("    - bnsConnector"));
   console.log(colors.yellow("    - bnsFromOrToTag"));
   console.log(colors.yellow("    - ChainId"));
+  console.log(colors.yellow("    - Ed25519KeyringEntry"));
   console.log(colors.yellow("    - Ed25519SimpleAddressKeyringEntry"));
   console.log(colors.yellow("    - Keyring"));
   console.log(colors.yellow("    - KeyringEntry"));
@@ -86,6 +87,7 @@ export const main = (originalArgs: string[]): void => {
       bnsConnector,
       bnsFromOrToTag,
       ChainId,
+      Ed25519KeyringEntry,
       Ed25519SimpleAddressKeyringEntry,
       Keyring,
       KeyringEntry,

--- a/packages/iov-core/src/index.ts
+++ b/packages/iov-core/src/index.ts
@@ -5,6 +5,7 @@
 
 export { Address, Nonce, SendTx, SetNameTx, TokenTicker, TransactionKind } from "@iov/bcp-types";
 export {
+  Ed25519KeyringEntry,
   Ed25519SimpleAddressKeyringEntry,
   Keyring,
   KeyringEntry,

--- a/packages/iov-core/types/index.d.ts
+++ b/packages/iov-core/types/index.d.ts
@@ -1,4 +1,4 @@
 export { Address, Nonce, SendTx, SetNameTx, TokenTicker, TransactionKind } from "@iov/bcp-types";
-export { Ed25519SimpleAddressKeyringEntry, Keyring, KeyringEntry, KeyringEntryImplementationIdString, KeyringEntrySerializationString, UserProfile, } from "@iov/keycontrol";
+export { Ed25519KeyringEntry, Ed25519SimpleAddressKeyringEntry, Keyring, KeyringEntry, KeyringEntryImplementationIdString, KeyringEntrySerializationString, UserProfile, } from "@iov/keycontrol";
 export { ChainId } from "@iov/tendermint-types";
 export { bnsConnector, bnsFromOrToTag, IovWriter } from "./writer";

--- a/packages/iov-keycontrol/src/index.ts
+++ b/packages/iov-keycontrol/src/index.ts
@@ -1,4 +1,4 @@
-export { Ed25519SimpleAddressKeyringEntry } from "./keyring-entries";
+export { Ed25519KeyringEntry, Ed25519SimpleAddressKeyringEntry } from "./keyring-entries";
 export {
   Keyring,
   KeyringEntry,

--- a/packages/iov-keycontrol/src/keyring-entries/ed25519.spec.ts
+++ b/packages/iov-keycontrol/src/keyring-entries/ed25519.spec.ts
@@ -89,7 +89,7 @@ describe("Ed25519KeyringEntry", () => {
   it("generates unique ids", async () => {
     const keyringEntry = new Ed25519KeyringEntry();
     const originalId = keyringEntry.id;
-    expect(originalId).toBeTruthy();
+    expect(originalId).toMatch(/^[-_:a-zA-Z0-9]+$/);
 
     const id1 = await keyringEntry.createIdentity();
     expect(id1).toBeTruthy();

--- a/packages/iov-keycontrol/src/keyring-entries/ed25519.ts
+++ b/packages/iov-keycontrol/src/keyring-entries/ed25519.ts
@@ -39,7 +39,7 @@ interface Ed25519KeyringEntrySerialization {
 }
 
 export class Ed25519KeyringEntry implements KeyringEntry {
-  private static readonly prng: PseudoRandom.Engine = PseudoRandom.engines.mt19937().seed(12345678);
+  private static readonly prng: PseudoRandom.Engine = PseudoRandom.engines.mt19937().autoSeed();
 
   private static identityId(identity: PublicIdentity): LocalIdentityId {
     const id = identity.pubkey.algo + "|" + Encoding.toHex(identity.pubkey.data);

--- a/packages/iov-keycontrol/src/keyring-entries/ed25519.ts
+++ b/packages/iov-keycontrol/src/keyring-entries/ed25519.ts
@@ -72,12 +72,11 @@ export class Ed25519KeyringEntry implements KeyringEntry {
 
   constructor(data?: KeyringEntrySerializationString) {
     // tslint:disable-next-line:no-let
+    let id: KeyringEntryId;
+    // tslint:disable-next-line:no-let
     let label: string | undefined;
     const identities: LocalIdentity[] = [];
     const privkeys = new Map<string, Ed25519Keypair>();
-
-    // tslint:disable-next-line:no-let
-    let id = this.randomId();
 
     if (data) {
       const decodedData: Ed25519KeyringEntrySerialization = JSON.parse(data);
@@ -102,6 +101,8 @@ export class Ed25519KeyringEntry implements KeyringEntry {
         identities.push(identity);
         privkeys.set(identity.id, keypair);
       }
+    } else {
+      id = this.randomId();
     }
 
     this.identities = identities;

--- a/packages/iov-keycontrol/src/keyring-entries/ed25519.ts
+++ b/packages/iov-keycontrol/src/keyring-entries/ed25519.ts
@@ -39,7 +39,7 @@ interface Ed25519KeyringEntrySerialization {
 }
 
 export class Ed25519KeyringEntry implements KeyringEntry {
-  private static readonly prng: PseudoRandom.Engine = PseudoRandom.engines.mt19937().autoSeed();
+  private static readonly idsPrng: PseudoRandom.Engine = PseudoRandom.engines.mt19937().autoSeed();
 
   private static identityId(identity: PublicIdentity): LocalIdentityId {
     const id = identity.pubkey.algo + "|" + Encoding.toHex(identity.pubkey.data);
@@ -203,7 +203,7 @@ export class Ed25519KeyringEntry implements KeyringEntry {
 
   private randomId(): KeyringEntryId {
     // this can be pseudo-random, just used for internal book-keeping
-    const code = PseudoRandom.string()(Ed25519KeyringEntry.prng, 10);
+    const code = PseudoRandom.string()(Ed25519KeyringEntry.idsPrng, 10);
     return `ed25519:${code}` as KeyringEntryId;
   }
 }

--- a/packages/iov-keycontrol/src/keyring-entries/ed25519.ts
+++ b/packages/iov-keycontrol/src/keyring-entries/ed25519.ts
@@ -41,6 +41,12 @@ interface Ed25519KeyringEntrySerialization {
 export class Ed25519KeyringEntry implements KeyringEntry {
   private static readonly idsPrng: PseudoRandom.Engine = PseudoRandom.engines.mt19937().autoSeed();
 
+  private static generateId(): KeyringEntryId {
+    // this can be pseudo-random, just used for internal book-keeping
+    const code = PseudoRandom.string()(Ed25519KeyringEntry.idsPrng, 16);
+    return code as KeyringEntryId;
+  }
+
   private static identityId(identity: PublicIdentity): LocalIdentityId {
     const id = identity.pubkey.algo + "|" + Encoding.toHex(identity.pubkey.data);
     return id as LocalIdentityId;
@@ -102,7 +108,7 @@ export class Ed25519KeyringEntry implements KeyringEntry {
         privkeys.set(identity.id, keypair);
       }
     } else {
-      id = this.randomId();
+      id = Ed25519KeyringEntry.generateId();
     }
 
     this.identities = identities;
@@ -200,11 +206,5 @@ export class Ed25519KeyringEntry implements KeyringEntry {
       label,
       id: Ed25519KeyringEntry.identityId({ pubkey }),
     };
-  }
-
-  private randomId(): KeyringEntryId {
-    // this can be pseudo-random, just used for internal book-keeping
-    const code = PseudoRandom.string()(Ed25519KeyringEntry.idsPrng, 10);
-    return `ed25519:${code}` as KeyringEntryId;
   }
 }

--- a/packages/iov-keycontrol/src/keyring-entries/ed25519simpleaddress.spec.ts
+++ b/packages/iov-keycontrol/src/keyring-entries/ed25519simpleaddress.spec.ts
@@ -16,14 +16,12 @@ describe("Ed25519SimpleAddressKeyringEntry", () => {
     const entry = Ed25519SimpleAddressKeyringEntry.fromEntropy(Encoding.fromHex("51385c41df88cbe7c579e99de04259b1aa264d8e2416f1885228a4d069629fad"));
     expect(entry).toEqual(jasmine.any(Ed25519SimpleAddressKeyringEntry));
     expect(entry.implementationId).toEqual("ed25519-simpleaddress");
-    expect(entry.id.startsWith("ed25519-simpleaddress")).toBeTruthy();
   });
 
   it("returns the concrete type when creating from mnemonic", () => {
     const entry = Ed25519SimpleAddressKeyringEntry.fromMnemonic("execute wheel pupil bachelor crystal short domain faculty shrimp focus swap hazard");
     expect(entry).toEqual(jasmine.any(Ed25519SimpleAddressKeyringEntry));
     expect(entry.implementationId).toEqual("ed25519-simpleaddress");
-    expect(entry.id.startsWith("ed25519-simpleaddress")).toBeTruthy();
   });
 
   it("creates correct paths", async () => {
@@ -45,6 +43,5 @@ describe("Ed25519SimpleAddressKeyringEntry", () => {
     expect(clone).not.toBe(original);
     expect(clone.serialize()).toEqual(original.serialize());
     expect(clone.implementationId).toEqual("ed25519-simpleaddress");
-    expect(clone.id.startsWith("ed25519-simpleaddress")).toBeTruthy();
   });
 });

--- a/packages/iov-keycontrol/src/keyring-entries/ed25519simpleaddress.ts
+++ b/packages/iov-keycontrol/src/keyring-entries/ed25519simpleaddress.ts
@@ -1,10 +1,6 @@
 import { Slip10Curve, Slip10RawIndex } from "@iov/crypto";
 
-import {
-  KeyringEntryImplementationIdString,
-  KeyringEntrySerializationString,
-  LocalIdentity,
-} from "../keyring";
+import { KeyringEntryImplementationIdString, LocalIdentity } from "../keyring";
 import { Slip10KeyringEntry } from "./slip10";
 
 export class Ed25519SimpleAddressKeyringEntry extends Slip10KeyringEntry {
@@ -25,9 +21,7 @@ export class Ed25519SimpleAddressKeyringEntry extends Slip10KeyringEntry {
     ) as Ed25519SimpleAddressKeyringEntry;
   }
 
-  constructor(data: KeyringEntrySerializationString) {
-    super(data, "ed25519-simpleaddress" as KeyringEntryImplementationIdString);
-  }
+  public readonly implementationId = "ed25519-simpleaddress" as KeyringEntryImplementationIdString;
 
   public createIdentity(): Promise<LocalIdentity> {
     const nextIndex = super.getIdentities().length;

--- a/packages/iov-keycontrol/src/keyring-entries/slip10.spec.ts
+++ b/packages/iov-keycontrol/src/keyring-entries/slip10.spec.ts
@@ -16,6 +16,7 @@ jasmine.DEFAULT_TIMEOUT_INTERVAL = 30 * 1000;
 describe("Slip10KeyringEntry", () => {
   const emptyEntry = `
     {
+      "id": "aX-_oHf",
       "secret": "rhythm they leave position crowd cart pilot student razor indoor gesture thrive",
       "curve": "ed25519 seed",
       "identities": []
@@ -24,6 +25,7 @@ describe("Slip10KeyringEntry", () => {
 
   const emptySecp256k1Entry = `
     {
+      "id": "2h3487-_h",
       "secret": "rhythm they leave position crowd cart pilot student razor indoor gesture thrive",
       "curve": "Bitcoin seed",
       "identities": []
@@ -283,13 +285,11 @@ describe("Slip10KeyringEntry", () => {
   });
 
   it("can deserialize", () => {
-    // tslint:disable-next-line:no-let
-    let id: string = "";
-
     {
       // empty
       const entry = new Slip10KeyringEntry(`
         {
+          "id": "eMpTy",
           "secret": "rhythm they leave position crowd cart pilot student razor indoor gesture thrive",
           "curve": "ed25519 seed",
           "identities": []
@@ -297,14 +297,14 @@ describe("Slip10KeyringEntry", () => {
         ` as KeyringEntrySerializationString);
       expect(entry).toBeTruthy();
       expect(entry.getIdentities().length).toEqual(0);
-      expect(entry.id).toBeTruthy();
-      id = entry.id;
+      expect(entry.id).toEqual("eMpTy");
     }
 
     {
       // one element
       const serialized = `
         {
+          "id": "1elemenT",
           "secret": "rhythm they leave position crowd cart pilot student razor indoor gesture thrive",
           "curve": "ed25519 seed",
           "identities": [
@@ -323,7 +323,7 @@ describe("Slip10KeyringEntry", () => {
         ` as KeyringEntrySerializationString;
       const entry = new Slip10KeyringEntry(serialized);
       expect(entry).toBeTruthy();
-      expect(entry.id).toEqual(id);
+      expect(entry.id).toEqual("1elemenT");
       expect(entry.getIdentities().length).toEqual(1);
       expect(entry.getIdentities()[0].pubkey.algo).toEqual("ed25519");
       expect(entry.getIdentities()[0].pubkey.data).toEqual(Encoding.fromHex("aabbccdd"));
@@ -334,6 +334,7 @@ describe("Slip10KeyringEntry", () => {
       // two elements
       const serialized = `
         {
+          "id": "2elemeNT",
           "secret": "rhythm they leave position crowd cart pilot student razor indoor gesture thrive",
           "curve": "ed25519 seed",
           "identities": [
@@ -361,7 +362,7 @@ describe("Slip10KeyringEntry", () => {
         }` as KeyringEntrySerializationString;
       const entry = new Slip10KeyringEntry(serialized);
       expect(entry).toBeTruthy();
-      expect(entry.id).toEqual(id);
+      expect(entry.id).toEqual("2elemeNT");
       expect(entry.getIdentities().length).toEqual(2);
       expect(entry.getIdentities()[0].pubkey.algo).toEqual("ed25519");
       expect(entry.getIdentities()[0].pubkey.data).toEqual(Encoding.fromHex("aabbccdd"));
@@ -406,5 +407,11 @@ describe("Slip10KeyringEntry", () => {
     expect(clone.id).toEqual(original.id);
     expect(clone.label.value).toEqual(original.label.value);
     expect(clone.getIdentities().length).toEqual(original.getIdentities().length);
+  });
+
+  it("generates different IDs for the same mnemonic", () => {
+    const entry1 = Slip10KeyringEntry.fromMnemonicWithCurve(Slip10Curve.Ed25519, "accident situate kitten crunch frog lobster horror hen wife gold extra athlete");
+    const entry2 = Slip10KeyringEntry.fromMnemonicWithCurve(Slip10Curve.Ed25519, "accident situate kitten crunch frog lobster horror hen wife gold extra athlete");
+    expect(entry1.id).not.toEqual(entry2.id);
   });
 });

--- a/packages/iov-keycontrol/src/keyring-entries/slip10.ts
+++ b/packages/iov-keycontrol/src/keyring-entries/slip10.ts
@@ -84,7 +84,7 @@ export class Slip10KeyringEntry implements KeyringEntry {
   private static generateId(): KeyringEntryId {
     // this can be pseudo-random, just used for internal book-keeping
     const code = PseudoRandom.string()(Slip10KeyringEntry.idsPrng, 16);
-    return `${code}` as KeyringEntryId;
+    return code as KeyringEntryId;
   }
 
   private static identityId(identity: PublicIdentity): LocalIdentityId {

--- a/packages/iov-keycontrol/src/keyring-entries/slip10.ts
+++ b/packages/iov-keycontrol/src/keyring-entries/slip10.ts
@@ -125,20 +125,7 @@ export class Slip10KeyringEntry implements KeyringEntry {
   private readonly privkeyPaths: Map<string, ReadonlyArray<Slip10RawIndex>>;
   private readonly labelProducer: DefaultValueProducer<string | undefined>;
 
-  constructor(data: KeyringEntrySerializationString, implementationId?: KeyringEntryImplementationIdString) {
-    /*
-      We need to set implementationId here, as we use it to construct the id below.
-      The default auto-generated constructor earlier looked like this:
-        constructor() {
-          super(...arguments);
-          this.implementationId = "ed25519-simpleaddress";
-        }
-      And we always got "override me!" as the beginning of the id.
-    */
-    if (implementationId) {
-      this.implementationId = implementationId;
-    }
-
+  constructor(data: KeyringEntrySerializationString) {
     const decodedData: Slip10KeyringEntrySerialization = JSON.parse(data);
 
     // id
@@ -177,8 +164,6 @@ export class Slip10KeyringEntry implements KeyringEntry {
 
     this.identities = identities;
     this.privkeyPaths = privkeyPaths;
-
-    // id depends on the secret and the subclass implementation
   }
 
   public setLabel(label: string | undefined): void {

--- a/packages/iov-keycontrol/types/index.d.ts
+++ b/packages/iov-keycontrol/types/index.d.ts
@@ -1,4 +1,4 @@
-export { Ed25519SimpleAddressKeyringEntry } from "./keyring-entries";
+export { Ed25519KeyringEntry, Ed25519SimpleAddressKeyringEntry } from "./keyring-entries";
 export { Keyring, KeyringEntry, KeyringEntryId, KeyringEntryImplementationIdString, KeyringEntrySerializationString, LocalIdentity, LocalIdentityId, PublicIdentity, } from "./keyring";
 export { UserProfile } from "./userprofile";
 export { DefaultValueProducer, ValueAndUpdates } from "./valueandupdates";

--- a/packages/iov-keycontrol/types/keyring-entries/ed25519.d.ts
+++ b/packages/iov-keycontrol/types/keyring-entries/ed25519.d.ts
@@ -3,7 +3,7 @@ import { ChainId, SignatureBytes } from "@iov/tendermint-types";
 import { KeyringEntry, KeyringEntryId, KeyringEntryImplementationIdString, KeyringEntrySerializationString, LocalIdentity, PublicIdentity } from "../keyring";
 import { ValueAndUpdates } from "../valueandupdates";
 export declare class Ed25519KeyringEntry implements KeyringEntry {
-    private static readonly prng;
+    private static readonly idsPrng;
     private static identityId;
     private static algorithmFromString;
     readonly label: ValueAndUpdates<string | undefined>;

--- a/packages/iov-keycontrol/types/keyring-entries/ed25519.d.ts
+++ b/packages/iov-keycontrol/types/keyring-entries/ed25519.d.ts
@@ -4,6 +4,7 @@ import { KeyringEntry, KeyringEntryId, KeyringEntryImplementationIdString, Keyri
 import { ValueAndUpdates } from "../valueandupdates";
 export declare class Ed25519KeyringEntry implements KeyringEntry {
     private static readonly idsPrng;
+    private static generateId;
     private static identityId;
     private static algorithmFromString;
     readonly label: ValueAndUpdates<string | undefined>;
@@ -23,5 +24,4 @@ export declare class Ed25519KeyringEntry implements KeyringEntry {
     clone(): Ed25519KeyringEntry;
     private privateKeyForIdentity;
     private buildLocalIdentity;
-    private randomId;
 }

--- a/packages/iov-keycontrol/types/keyring-entries/ed25519simpleaddress.d.ts
+++ b/packages/iov-keycontrol/types/keyring-entries/ed25519simpleaddress.d.ts
@@ -1,9 +1,9 @@
-import { KeyringEntrySerializationString, LocalIdentity } from "../keyring";
+import { KeyringEntryImplementationIdString, LocalIdentity } from "../keyring";
 import { Slip10KeyringEntry } from "./slip10";
 export declare class Ed25519SimpleAddressKeyringEntry extends Slip10KeyringEntry {
     static fromEntropy(bip39Entropy: Uint8Array): Ed25519SimpleAddressKeyringEntry;
     static fromMnemonic(mnemonicString: string): Ed25519SimpleAddressKeyringEntry;
-    constructor(data: KeyringEntrySerializationString);
+    readonly implementationId: KeyringEntryImplementationIdString;
     createIdentity(): Promise<LocalIdentity>;
     clone(): Ed25519SimpleAddressKeyringEntry;
 }

--- a/packages/iov-keycontrol/types/keyring-entries/slip10.d.ts
+++ b/packages/iov-keycontrol/types/keyring-entries/slip10.d.ts
@@ -23,7 +23,7 @@ export declare class Slip10KeyringEntry implements KeyringEntry {
     private readonly identities;
     private readonly privkeyPaths;
     private readonly labelProducer;
-    constructor(data: KeyringEntrySerializationString, implementationId?: KeyringEntryImplementationIdString);
+    constructor(data: KeyringEntrySerializationString);
     setLabel(label: string | undefined): void;
     createIdentity(): Promise<LocalIdentity>;
     createIdentityWithPath(path: ReadonlyArray<Slip10RawIndex>): Promise<LocalIdentity>;

--- a/packages/iov-keycontrol/types/keyring-entries/slip10.d.ts
+++ b/packages/iov-keycontrol/types/keyring-entries/slip10.d.ts
@@ -9,6 +9,8 @@ interface Slip10KeyringEntryConstructor {
 export declare class Slip10KeyringEntry implements KeyringEntry {
     static fromEntropyWithCurve(curve: Slip10Curve, bip39Entropy: Uint8Array, cls?: Slip10KeyringEntryConstructor): Slip10KeyringEntry;
     static fromMnemonicWithCurve(curve: Slip10Curve, mnemonicString: string, cls?: Slip10KeyringEntryConstructor): Slip10KeyringEntry;
+    private static readonly idsPrng;
+    private static generateId;
     private static identityId;
     private static algorithmFromCurve;
     private static algorithmFromString;
@@ -33,6 +35,5 @@ export declare class Slip10KeyringEntry implements KeyringEntry {
     private privkeyPathForIdentity;
     private privkeyForIdentity;
     private buildLocalIdentity;
-    private calculateId;
 }
 export {};


### PR DESCRIPTION
Using a static seed, the sequence of IDs was always identical, leading to the same first ID for every new process. E.g.

```
// process 1
>> new Ed25519KeyringEntry().id
'ed25519:ZIFeXqRVH4'
>> new Ed25519KeyringEntry().id
'ed25519:VclMgX__bi'
>> new Ed25519KeyringEntry().id
'ed25519:NZ6HCT22pU'

// process 2
>> new Ed25519KeyringEntry().id
'ed25519:ZIFeXqRVH4'
>> new Ed25519KeyringEntry().id
'ed25519:VclMgX__bi'
>> new Ed25519KeyringEntry().id
'ed25519:NZ6HCT22pU'
```

This was fixed by using auto seeding (implemented as time in milliseconds + 16 calls of Math.random()).

Also, it was not possible before to create two different entries with the same mnemonic because both got the same ID. This led to an incomplete and misleading idea of equality. Now HD entries also get random IDs that are serialized and preserved when cloning and storing.