### PR TITLE
Fix beginning and end in toMatch expressions

### DIFF
--- a/packages/iov-keycontrol/src/keyring-entries/ed25519.spec.ts
+++ b/packages/iov-keycontrol/src/keyring-entries/ed25519.spec.ts
@@ -169,19 +169,19 @@ describe("Ed25519KeyringEntry", () => {
     expect(decoded.identities.length).toEqual(3);
     expect(decoded.identities[0].localIdentity).toBeTruthy();
     expect(decoded.identities[0].localIdentity.pubkey.algo).toEqual("ed25519");
-    expect(decoded.identities[0].localIdentity.pubkey.data).toMatch(/[0-9a-f]{64}/);
+    expect(decoded.identities[0].localIdentity.pubkey.data).toMatch(/^[0-9a-f]{64}$/);
     expect(decoded.identities[0].localIdentity.label).toBeUndefined();
-    expect(decoded.identities[0].privkey).toMatch(/[0-9a-f]{64}/);
+    expect(decoded.identities[0].privkey).toMatch(/^[0-9a-f]{64}$/);
     expect(decoded.identities[1].localIdentity).toBeTruthy();
     expect(decoded.identities[1].localIdentity.pubkey.algo).toEqual("ed25519");
-    expect(decoded.identities[1].localIdentity.pubkey.data).toMatch(/[0-9a-f]{64}/);
+    expect(decoded.identities[1].localIdentity.pubkey.data).toMatch(/^[0-9a-f]{64}$/);
     expect(decoded.identities[1].localIdentity.label).toEqual("");
-    expect(decoded.identities[1].privkey).toMatch(/[0-9a-f]{64}/);
+    expect(decoded.identities[1].privkey).toMatch(/^[0-9a-f]{64}$/);
     expect(decoded.identities[2].localIdentity).toBeTruthy();
     expect(decoded.identities[2].localIdentity.pubkey.algo).toEqual("ed25519");
-    expect(decoded.identities[2].localIdentity.pubkey.data).toMatch(/[0-9a-f]{64}/);
+    expect(decoded.identities[2].localIdentity.pubkey.data).toMatch(/^[0-9a-f]{64}$/);
     expect(decoded.identities[2].localIdentity.label).toEqual("foo");
-    expect(decoded.identities[2].privkey).toMatch(/[0-9a-f]{64}/);
+    expect(decoded.identities[2].privkey).toMatch(/^[0-9a-f]{64}$/);
 
     // keys are different
     expect(decoded.identities[0].localIdentity.pubkey.data).not.toEqual(decoded.identities[1].localIdentity.pubkey.data);

--- a/packages/iov-keycontrol/src/keyring-entries/slip10.spec.ts
+++ b/packages/iov-keycontrol/src/keyring-entries/slip10.spec.ts
@@ -259,17 +259,17 @@ describe("Slip10KeyringEntry", () => {
     expect(decodedJson.identities.length).toEqual(3);
     expect(decodedJson.identities[0].localIdentity).toBeTruthy();
     expect(decodedJson.identities[0].localIdentity.pubkey.algo).toEqual("ed25519");
-    expect(decodedJson.identities[0].localIdentity.pubkey.data).toMatch(/[0-9a-f]{64}/);
+    expect(decodedJson.identities[0].localIdentity.pubkey.data).toMatch(/^[0-9a-f]{64}$/);
     expect(decodedJson.identities[0].localIdentity.label).toBeUndefined();
     expect(decodedJson.identities[0].privkeyPath).toEqual([0x80000000 + 0]);
     expect(decodedJson.identities[1].localIdentity).toBeTruthy();
     expect(decodedJson.identities[1].localIdentity.pubkey.algo).toEqual("ed25519");
-    expect(decodedJson.identities[1].localIdentity.pubkey.data).toMatch(/[0-9a-f]{64}/);
+    expect(decodedJson.identities[1].localIdentity.pubkey.data).toMatch(/^[0-9a-f]{64}$/);
     expect(decodedJson.identities[1].localIdentity.label).toEqual("");
     expect(decodedJson.identities[1].privkeyPath).toEqual([0x80000000 + 1]);
     expect(decodedJson.identities[2].localIdentity).toBeTruthy();
     expect(decodedJson.identities[2].localIdentity.pubkey.algo).toEqual("ed25519");
-    expect(decodedJson.identities[2].localIdentity.pubkey.data).toMatch(/[0-9a-f]{64}/);
+    expect(decodedJson.identities[2].localIdentity.pubkey.data).toMatch(/^[0-9a-f]{64}$/);
     expect(decodedJson.identities[2].localIdentity.label).toEqual("foo");
     expect(decodedJson.identities[2].privkeyPath).toEqual([0x80000000 + 2, 0x80000000 + 0]);
 

--- a/packages/iov-keycontrol/src/userprofile.spec.ts
+++ b/packages/iov-keycontrol/src/userprofile.spec.ts
@@ -208,7 +208,7 @@ describe("UserProfile", () => {
 
     await profile.storeIn(db, defaultEncryptionPassword);
     expect(await db.get("created_at", { asBuffer: false })).toEqual("1985-04-12T23:20:50.521Z");
-    expect(await db.get("keyring", { asBuffer: false })).toMatch(/^[0-9a-f]+$/);
+    expect(await db.get("keyring", { asBuffer: false })).toMatch(/^[-_/=a-zA-Z0-9+]+$/);
 
     await db.close();
   });

--- a/packages/iov-keycontrol/src/userprofile.spec.ts
+++ b/packages/iov-keycontrol/src/userprofile.spec.ts
@@ -208,7 +208,7 @@ describe("UserProfile", () => {
 
     await profile.storeIn(db, defaultEncryptionPassword);
     expect(await db.get("created_at", { asBuffer: false })).toEqual("1985-04-12T23:20:50.521Z");
-    expect(await db.get("keyring", { asBuffer: false })).toMatch(/[0-9a-f]+/);
+    expect(await db.get("keyring", { asBuffer: false })).toMatch(/^[0-9a-f]+$/);
 
     await db.close();
   });

--- a/packages/iov-ledger-bns/src/ledgersimpleaddresskeyringentry.spec.ts
+++ b/packages/iov-ledger-bns/src/ledgersimpleaddresskeyringentry.spec.ts
@@ -231,17 +231,17 @@ describe("LedgerSimpleAddressKeyringEntry", () => {
     expect(decodedJson.identities.length).toEqual(3);
     expect(decodedJson.identities[0].localIdentity).toBeTruthy();
     expect(decodedJson.identities[0].localIdentity.pubkey.algo).toEqual("ed25519");
-    expect(decodedJson.identities[0].localIdentity.pubkey.data).toMatch(/[0-9a-f]{64}/);
+    expect(decodedJson.identities[0].localIdentity.pubkey.data).toMatch(/^[0-9a-f]{64}$/);
     expect(decodedJson.identities[0].localIdentity.label).toBeUndefined();
     expect(decodedJson.identities[0].simpleAddressIndex).toEqual(0);
     expect(decodedJson.identities[1].localIdentity).toBeTruthy();
     expect(decodedJson.identities[1].localIdentity.pubkey.algo).toEqual("ed25519");
-    expect(decodedJson.identities[1].localIdentity.pubkey.data).toMatch(/[0-9a-f]{64}/);
+    expect(decodedJson.identities[1].localIdentity.pubkey.data).toMatch(/^[0-9a-f]{64}$/);
     expect(decodedJson.identities[1].localIdentity.label).toEqual("");
     expect(decodedJson.identities[1].simpleAddressIndex).toEqual(1);
     expect(decodedJson.identities[2].localIdentity).toBeTruthy();
     expect(decodedJson.identities[2].localIdentity.pubkey.algo).toEqual("ed25519");
-    expect(decodedJson.identities[2].localIdentity.pubkey.data).toMatch(/[0-9a-f]{64}/);
+    expect(decodedJson.identities[2].localIdentity.pubkey.data).toMatch(/^[0-9a-f]{64}$/);
     expect(decodedJson.identities[2].localIdentity.label).toEqual("foo");
     expect(decodedJson.identities[2].simpleAddressIndex).toEqual(2);
 

--- a/packages/iov-tendermint-rpc/src/client.spec.ts
+++ b/packages/iov-tendermint-rpc/src/client.spec.ts
@@ -181,7 +181,7 @@ describe("Client", () => {
         expect(stream).toBeTruthy();
         const subscription = stream.subscribe({
           next: event => {
-            expect(event.chainId).toMatch(/[-a-z0-9]{3,30}/);
+            expect(event.chainId).toMatch(/^[-a-z0-9]{3,30}$/);
             expect(event.height).toBeGreaterThan(0);
             expect(event.time.getTime()).toBeGreaterThan(testStart);
             expect(event.numTxs).toEqual(0);
@@ -235,7 +235,7 @@ describe("Client", () => {
         expect(stream).toBeTruthy();
         const subscription = stream.subscribe({
           next: event => {
-            expect(event.header.chainId).toMatch(/[-a-z0-9]{3,30}/);
+            expect(event.header.chainId).toMatch(/^[-a-z0-9]{3,30}$/);
             expect(event.header.height).toBeGreaterThan(0);
             expect(event.header.time.getTime()).toBeGreaterThan(testStart);
             expect(event.header.numTxs).toEqual(1);

--- a/packages/iov-tendermint-rpc/src/client.spec.ts
+++ b/packages/iov-tendermint-rpc/src/client.spec.ts
@@ -181,7 +181,7 @@ describe("Client", () => {
         expect(stream).toBeTruthy();
         const subscription = stream.subscribe({
           next: event => {
-            expect(event.chainId).toMatch(/^[-a-z0-9]{3,30}$/);
+            expect(event.chainId).toMatch(/^[-a-zA-Z0-9]{3,30}$/);
             expect(event.height).toBeGreaterThan(0);
             expect(event.time.getTime()).toBeGreaterThan(testStart);
             expect(event.numTxs).toEqual(0);
@@ -235,7 +235,7 @@ describe("Client", () => {
         expect(stream).toBeTruthy();
         const subscription = stream.subscribe({
           next: event => {
-            expect(event.header.chainId).toMatch(/^[-a-z0-9]{3,30}$/);
+            expect(event.header.chainId).toMatch(/^[-a-zA-Z0-9]{3,30}$/);
             expect(event.header.height).toBeGreaterThan(0);
             expect(event.header.time.getTime()).toBeGreaterThan(testStart);
             expect(event.header.numTxs).toEqual(1);


### PR DESCRIPTION
Because `expect("öa~").toMatch(/[a-z]+/)` passes