### PR TITLE
Fixed two minor errors in README example

### DIFF
--- a/packages/iov-core/README.md
+++ b/packages/iov-core/README.md
@@ -163,7 +163,7 @@ Now, connect to the network:
 ```ts
 import { bnsConnector, IovWriter } from '@iov/core';
 
-const writer = new IovWriter(profile, chains);
+const writer = new IovWriter(profile);
 await writer.addChain(bnsConnector('wss://bov.friendnet-fast.iov.one/'));
 
 const chainId = writer.chainIds()[0];
@@ -199,7 +199,7 @@ If you are running the testnet faucet, just ask for some free money.
 ```ts
 import { BovFaucet } from "@iov/faucets";
 
-const faucet = new BovFaucet("https://faucet.friendnet-fast.iov.one/");
+const faucet = new BovFaucet("https://faucet.friendnet-fast.iov.one/faucet");
 // You can request a given token, or omit second argument to get default
 await faucet.credit(addr, "IOV" as TokenTicker);
 ```


### PR DESCRIPTION
I verified examples worked with `npm i -g @iov/cli`. However, there were two typos.

IovWriter constructor had an unused argument (type error)
Faucet missed the trailing `/faucet` in the path, leading to 404.

Updated docs and manually verified it works.

It would be interesting mid-term to place all these samples in a script that was run by the CI now and then to make sure it works. But last I checked there was no way to include code snippets inline inside of a markdown on github....