### PR TITLE
Expose tx result

### DIFF
--- a/packages/iov-bcp-types/src/bcp.ts
+++ b/packages/iov-bcp-types/src/bcp.ts
@@ -56,6 +56,7 @@ export interface BcpTransactionResponse {
   readonly data: {
     readonly message: string;
     readonly txid: TxId; // a unique identifier (hash of the data)
+    readonly result: Uint8Array;
   };
 }
 

--- a/packages/iov-bcp-types/src/bcp.ts
+++ b/packages/iov-bcp-types/src/bcp.ts
@@ -132,8 +132,8 @@ export interface IovReader {
 export interface ConfirmedTransaction extends SignedTransaction {
   readonly height: number; // the block it was written to
   readonly txid: TxId; // a unique identifier (hash of the data)
-  // TODO: TxData (result, code, tags...)
+  // Data from executing tx (result, code, tags...)
+  readonly result: Uint8Array;
+  readonly log: string;
   // readonly tags: ReadonlyArray<Tag>;
-  // readonly result?: Uint8Array;
-  // readonly log?: string;
 }

--- a/packages/iov-bcp-types/types/bcp.d.ts
+++ b/packages/iov-bcp-types/types/bcp.d.ts
@@ -38,6 +38,7 @@ export interface BcpTransactionResponse {
     readonly data: {
         readonly message: string;
         readonly txid: TxId;
+        readonly result: Uint8Array;
     };
 }
 export interface BcpAddressQuery {

--- a/packages/iov-bcp-types/types/bcp.d.ts
+++ b/packages/iov-bcp-types/types/bcp.d.ts
@@ -69,4 +69,6 @@ export interface IovReader {
 export interface ConfirmedTransaction extends SignedTransaction {
     readonly height: number;
     readonly txid: TxId;
+    readonly result: Uint8Array;
+    readonly log: string;
 }

--- a/packages/iov-bns/src/client.spec.ts
+++ b/packages/iov-bns/src/client.spec.ts
@@ -503,7 +503,9 @@ describe("Integration tests with bov+tendermint", () => {
     // make sure we get he same tx loaded
     const loaded = search[0];
     expect(loaded.txid).toEqual(txid);
-    expect(loaded.transaction.kind).toEqual(swapOfferTx.kind);
+    // we never write the offer (with preimage) to a chain, only convert it to a SwapCounterTx
+    // which only has the hashed data, then commit it (thus the different kind is expected)
+    expect(loaded.transaction.kind).toEqual(TransactionKind.SwapCounter);
     expect((loaded.transaction as SwapOfferTx).recipient).toEqual(swapOfferTx.recipient);
     // make sure it also stored a result
     expect(loaded.result).toEqual(txResult);

--- a/packages/iov-bns/src/client.spec.ts
+++ b/packages/iov-bns/src/client.spec.ts
@@ -7,6 +7,7 @@ import {
   BcpTransactionResponse,
   Nonce,
   SendTx,
+  SwapOfferTx,
   TokenTicker,
   TransactionKind,
 } from "@iov/bcp-types";
@@ -339,7 +340,7 @@ describe("Integration tests with bov+tendermint", () => {
     client.disconnect();
   });
 
-  it("test change feeds", async () => {
+  it("can provide change feeds", async () => {
     pendingWithoutBov();
     const client = await Client.connect(tendermintUrl);
     const profile = await userProfile();
@@ -383,7 +384,7 @@ describe("Integration tests with bov+tendermint", () => {
   });
 
   // make sure we can get a reactive account balance (as well as nonce)
-  it("test watch account", async () => {
+  it("can watch accounts", async () => {
     pendingWithoutBov();
     const client = await Client.connect(tendermintUrl);
     const profile = await userProfile();
@@ -446,5 +447,66 @@ describe("Integration tests with bov+tendermint", () => {
 
     // clean up with disconnect at the end...
     client.disconnect();
+  });
+
+  it("Can start atomic swap", async () => {
+    pendingWithoutBov();
+    const client = await Client.connect(tendermintUrl);
+    const chainId = await client.chainId();
+
+    const profile = await userProfile();
+
+    const faucet = faucetId(profile);
+    const faucetAddr = keyToAddress(faucet.pubkey);
+    const rcpt = await recipient(profile, 7);
+    const rcptAddr = keyToAddress(rcpt.pubkey);
+
+    // check current nonce (should be 0, but don't fail if used by other)
+    const nonce = await getNonce(client, faucetAddr);
+
+    const preimage = Encoding.toAscii("my top secret phrase... keep it on the down low ;)");
+
+    // construct a sendtx, this is normally used in the IovWriter api
+    const swapOfferTx: SwapOfferTx = {
+      kind: TransactionKind.SwapOffer,
+      chainId,
+      signer: faucet.pubkey,
+      recipient: rcptAddr,
+      amount: [
+        {
+          whole: 123,
+          fractional: 456000,
+          tokenTicker: cash,
+        },
+      ],
+      timeout: 1000,
+      preimage,
+    };
+
+    const signed = await profile.signTransaction(0, faucet, swapOfferTx, bnsCodec, nonce);
+    const txBytes = bnsCodec.bytesToPost(signed);
+    const post = await client.postTx(txBytes);
+    // FIXME: we really should add more info here, but this is in the spec
+    expect(post.metadata.status).toBe(true);
+    const txHeight = post.metadata.height;
+    expect(txHeight).toBeTruthy();
+    expect(txHeight).toBeGreaterThan(1);
+    const txResult = post.data.result;
+    expect(txResult.length).toBe(8);
+    expect(txResult).toEqual(new Uint8Array([0, 0, 0, 0, 0, 0, 0, 1]));
+    const txid = post.data.txid;
+    expect(txid.length).toBe(20);
+
+    // now query by the txid
+    const search = await client.searchTx({ hash: txid, tags: [] });
+    expect(search.length).toEqual(1);
+    // make sure we get he same tx loaded
+    const loaded = search[0];
+    expect(loaded.txid).toEqual(txid);
+    expect(loaded.transaction.kind).toEqual(swapOfferTx.kind);
+    expect((loaded.transaction as SwapOfferTx).recipient).toEqual(swapOfferTx.recipient);
+    // make sure it also stored a result
+    expect(loaded.result).toEqual(txResult);
+    expect(loaded.height).toEqual(txHeight!);
   });
 });

--- a/packages/iov-bns/src/client.ts
+++ b/packages/iov-bns/src/client.ts
@@ -113,6 +113,7 @@ export class Client implements IovReader {
     }
 
     const message = txresp.deliverTx ? txresp.deliverTx.log : txresp.checkTx.log;
+    const result = txresp.deliverTx && txresp.deliverTx.data;
     return {
       metadata: {
         height: txresp.height,
@@ -121,6 +122,7 @@ export class Client implements IovReader {
       data: {
         txid: txresp.hash,
         message: message || "",
+        result: result || new Uint8Array([]),
       },
     };
   }

--- a/packages/iov-bns/src/client.ts
+++ b/packages/iov-bns/src/client.ts
@@ -182,9 +182,11 @@ export class Client implements IovReader {
     const query = buildTxQuery(txQuery);
     const res = await this.tmClient.txSearch({ query, per_page: perPage });
     const chainId = await this.chainId();
-    const mapper = ({ tx, hash, height }: TxResponse): ConfirmedTransaction => ({
+    const mapper = ({ tx, hash, height, txResult }: TxResponse): ConfirmedTransaction => ({
       height,
       txid: hash as TxId,
+      log: txResult.log || "",
+      result: txResult.data || new Uint8Array([]),
       ...this.codec.parseBytes(tx, chainId),
     });
     return res.txs.map(mapper);
@@ -197,9 +199,11 @@ export class Client implements IovReader {
     const txs = this.tmClient.subscribeTx(tags);
 
     // destructuring ftw (or is it too confusing?)
-    const mapper = ([{ hash, height, tx }, chainId]: [TxEvent, ChainId]): ConfirmedTransaction => ({
+    const mapper = ([{ hash, height, tx, result }, chainId]: [TxEvent, ChainId]): ConfirmedTransaction => ({
       height,
       txid: hash as TxId,
+      log: result.log || "",
+      result: result.data || new Uint8Array([]),
       ...this.codec.parseBytes(tx, chainId),
     });
     return Stream.combine(txs, streamId).map(mapper);

--- a/packages/iov-tendermint-rpc/src/requests.ts
+++ b/packages/iov-tendermint-rpc/src/requests.ts
@@ -1,3 +1,4 @@
+import { Encoding } from "@iov/encoding";
 import { Tag, TxQuery } from "@iov/tendermint-types";
 
 import { JsonRpcRequest, jsonRpcWith } from "./common";
@@ -175,6 +176,7 @@ export const buildTxQuery = (query: TxQuery): QueryString => {
     !!query.height && `tx.height=${query.height}`,
     !!query.minHeight && `tx.height>${query.minHeight}`,
     !!query.maxHeight && `tx.height<${query.maxHeight}`,
+    !!query.hash && `tx.hash='${Encoding.toHex(query.hash)}'`,
   ];
   const result: string = [...tags, ...opts.filter(x => !!x)].join(" AND ");
   return result as QueryString;

--- a/packages/iov-tendermint-rpc/src/responses.ts
+++ b/packages/iov-tendermint-rpc/src/responses.ts
@@ -127,10 +127,7 @@ export interface TxEvent {
   readonly hash: TxId;
   readonly height: number;
   readonly index: number;
-  readonly result: {
-    readonly tags: ReadonlyArray<Tag>;
-    readonly fee: any;
-  };
+  readonly result: TxData;
 }
 
 export const getTxEventHeight = (event: TxEvent): number => event.height;
@@ -149,6 +146,7 @@ export interface TxData {
   readonly log?: string;
   readonly data?: Uint8Array;
   readonly tags?: ReadonlyArray<Tag>;
+  // readonly fees?: any;
 }
 
 export interface TxProof {

--- a/packages/iov-tendermint-rpc/src/v0-20/responses.ts
+++ b/packages/iov-tendermint-rpc/src/v0-20/responses.ts
@@ -282,10 +282,7 @@ const decodeTxSearch = (data: RpcTxSearchResponse): responses.TxSearchResponse =
 
 export interface RpcTxEvent {
   readonly tx: Base64String;
-  readonly result: {
-    readonly tags: ReadonlyArray<RpcTag>;
-    readonly fee: any;
-  };
+  readonly result: RpcTxData;
   readonly height: number;
   readonly index: number;
 }
@@ -295,10 +292,7 @@ function decodeTxEvent(data: RpcTxEvent): responses.TxEvent {
   return {
     tx,
     hash: hashTx(tx),
-    result: {
-      tags: decodeTags(data.result.tags),
-      fee: data.result.fee,
-    },
+    result: decodeTxData(data.result),
     height: required(data.height),
     index: required(data.index),
   };


### PR DESCRIPTION
Resolves #348 

After executing a transaction, there is more data than just success or failure. Each transaction can return some binary result, as well as  text log message (and in some blockchains tags).

Here I ensure all this data is properly parsed by tendermint-rpc and expose it through the IovReader interface and the bns.Client implementation.

In particular, this allows `postTx` with AtomicSwap to read the `result` field in order to determine the ID of the newly created escrow holding the swap. 