### PR TITLE
[iov-lisk] Implement Lisk connector

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,11 +35,13 @@ install:
 - retry 3 yarn install
 
 before_script:
+- export TSLINT_FLAGS='-c ./tslint_ci.json'
+- export LONG_RUNNING_ENABLED=1
+
 # Make variables and function from Travis available in our script
 # See implementation https://github.com/travis-ci/travis-build/blob/4041ba116ddb3bdfd66ab8acbb7094dee28d6797/lib/travis/build/templates/header.sh
 # and http://www.garbers.co.za/2017/11/01/code-folding-and-timing-in-travis-ci/
 - export ANSI_CLEAR
-- export TSLINT_FLAGS='-c ./tslint_ci.json'
 - export -f travis_nanoseconds travis_fold travis_time_start travis_time_finish
 
 # Use Docker if available (currently Linux only)

--- a/packages/iov-core/src/index.ts
+++ b/packages/iov-core/src/index.ts
@@ -15,4 +15,4 @@ export {
 } from "@iov/keycontrol";
 export { ChainId } from "@iov/tendermint-types";
 
-export { bnsConnector, bnsFromOrToTag, IovWriter } from "./writer";
+export { bnsConnector, bnsFromOrToTag, ChainConnector, IovWriter } from "./writer";

--- a/packages/iov-core/types/index.d.ts
+++ b/packages/iov-core/types/index.d.ts
@@ -1,4 +1,4 @@
 export { Address, Nonce, SendTx, SetNameTx, TokenTicker, TransactionKind } from "@iov/bcp-types";
 export { Ed25519KeyringEntry, Ed25519SimpleAddressKeyringEntry, Keyring, KeyringEntry, KeyringEntryImplementationIdString, KeyringEntrySerializationString, UserProfile, } from "@iov/keycontrol";
 export { ChainId } from "@iov/tendermint-types";
-export { bnsConnector, bnsFromOrToTag, IovWriter } from "./writer";
+export { bnsConnector, bnsFromOrToTag, ChainConnector, IovWriter } from "./writer";

--- a/packages/iov-lisk/README.md
+++ b/packages/iov-lisk/README.md
@@ -4,11 +4,58 @@
 
 ## Getting started
 
+The primary way to use @iov/lisk is together with @iov/core. Alternatively,
+you can use @iov/lisk to create offline transactions which can be posted manually.
+
+All examples are made for use in @iov/cli and you may need to include some
+missing symbols if used in a different environment.
+
+### Using with @iov/core
+
+You can use @iov/lisk as an extension of @iov/core to interact with the
+Lisk blockchain as follows.
+
+```ts
+import { liskCodec, liskConnector, LiskKeyringEntry } from "@iov/lisk";
+
+const entry = new LiskKeyringEntry();
+const mainIdentity = await entry.createIdentity("oxygen fall sure lava energy veteran enroll frown question detail include maximum");
+
+const profile = new UserProfile();
+profile.addEntry(entry);
+
+const writer = new IovWriter(profile);
+await writer.addChain(liskConnector("https://testnet.lisk.io"));
+const chainId = writer.chainIds()[0];
+const reader = writer.reader(chainId);
+
+const mainAddress = writer.keyToAddress(chainId, mainIdentity.pubkey);
+console.log((await reader.getAccount({ address: mainAddress })).data[0].balance);
+
+const recipientAddress = Encoding.toAscii("6076671634347365051L") as Address;
+
+const sendTx: SendTx = {
+  kind: TransactionKind.Send,
+  chainId: chainId,
+  signer: mainIdentity.pubkey,
+  recipient: recipientAddress,
+  memo: "We ❤️ developers – iov.one",
+  amount: {
+    whole: 1,
+    fractional: 44550000,
+    tokenTicker: "LSK" as TokenTicker,
+  }
+};
+
+console.log("Writing to blockchain. This may take a while …");
+await writer.signAndCommit(sendTx, 0);
+console.log((await reader.getAccount({ address: recipientAddress })).data[0].balance);
+```
+
+### The manual way
+
 This is how you use `liskCodec` and `LiskKeyringEntry` to generate send transactions
 for Lisk manually, i.e. without the help of @iov/core.
-
-The following example is made for use in @iov/cli and you may need to include some
-missing symbols if used in a different environment.
 
 ```ts
 import { liskCodec, LiskKeyringEntry } from "@iov/lisk";

--- a/packages/iov-lisk/README.md
+++ b/packages/iov-lisk/README.md
@@ -27,7 +27,7 @@ const sendTx: SendTx = {
   recipient: recipientAddress,
   memo: "We ❤️ developers – iov.one",
   amount: {
-    whole: 2,
+    whole: 1,
     fractional: 44550000,
     tokenTicker: "LSK" as TokenTicker,
   }

--- a/packages/iov-lisk/README.md
+++ b/packages/iov-lisk/README.md
@@ -58,7 +58,7 @@ This is how you use `liskCodec` and `LiskKeyringEntry` to generate send transact
 for Lisk manually, i.e. without the help of @iov/core.
 
 ```ts
-import { liskCodec, LiskKeyringEntry } from "@iov/lisk";
+import { generateNonce, liskCodec, LiskKeyringEntry } from "@iov/lisk";
 
 const liskTestnet = "da3ed6a45429278bac2666961289ca17ad86595d33b31037615d4b8e8f158bba" as ChainId;
 
@@ -80,8 +80,7 @@ const sendTx: SendTx = {
   }
 };
 
-// Encode creation timestamp into nonce
-const nonce = Long.fromNumber(Math.floor(Date.now() / 1000)) as Nonce;
+const nonce = generateNonce();
 const signingJob = liskCodec.bytesToSign(sendTx, nonce);
 const signature = await entry.createTransactionSignature(mainIdentity, signingJob.bytes, signingJob.prehashType, liskTestnet);
 

--- a/packages/iov-lisk/package.json
+++ b/packages/iov-lisk/package.json
@@ -31,6 +31,7 @@
   },
   "dependencies": {
     "@iov/bcp-types": "^0.5.3",
+    "@iov/core": "^0.5.4",
     "@iov/crypto": "^0.5.3",
     "@iov/encoding": "^0.5.3",
     "@iov/keycontrol": "^0.5.4",

--- a/packages/iov-lisk/package.json
+++ b/packages/iov-lisk/package.json
@@ -36,6 +36,7 @@
     "@iov/keycontrol": "^0.5.4",
     "@types/long": "^4.0.0",
     "long": "^4.0.0",
-    "readonly-date": "^1.0.0"
+    "readonly-date": "^1.0.0",
+    "xstream": "^11.7.0"
   }
 }

--- a/packages/iov-lisk/package.json
+++ b/packages/iov-lisk/package.json
@@ -35,6 +35,7 @@
     "@iov/encoding": "^0.5.3",
     "@iov/keycontrol": "^0.5.4",
     "@types/long": "^4.0.0",
+    "axios": "^0.18.0",
     "long": "^4.0.0",
     "readonly-date": "^1.0.0",
     "xstream": "^11.7.0"

--- a/packages/iov-lisk/src/constants.ts
+++ b/packages/iov-lisk/src/constants.ts
@@ -1,0 +1,7 @@
+import { TokenTicker } from "@iov/bcp-types";
+
+export const constants = {
+  primaryTokenTicker: "LSK" as TokenTicker,
+  primaryTokenName: "Lisk",
+  primaryTokenSigFigs: 8,
+};

--- a/packages/iov-lisk/src/index.ts
+++ b/packages/iov-lisk/src/index.ts
@@ -1,2 +1,3 @@
 export { liskCodec } from "./liskcodec";
 export { LiskKeyringEntry } from "./liskkeyringentry";
+export { liskConnector } from "./liskconnector";

--- a/packages/iov-lisk/src/index.ts
+++ b/packages/iov-lisk/src/index.ts
@@ -1,4 +1,4 @@
 export { liskCodec } from "./liskcodec";
 export { LiskKeyringEntry } from "./liskkeyringentry";
 export { liskConnector } from "./liskconnector";
-export { generateNonce } from "./liskclient";
+export { generateNonce, LiskClient } from "./liskclient";

--- a/packages/iov-lisk/src/index.ts
+++ b/packages/iov-lisk/src/index.ts
@@ -1,3 +1,4 @@
 export { liskCodec } from "./liskcodec";
 export { LiskKeyringEntry } from "./liskkeyringentry";
 export { liskConnector } from "./liskconnector";
+export { generateNonce } from "./liskclient";

--- a/packages/iov-lisk/src/liskclient.spec.ts
+++ b/packages/iov-lisk/src/liskclient.spec.ts
@@ -59,7 +59,7 @@ describe("LiskClient", () => {
     expect(() => new LiskClient("http://[2001::0370:7344]/")).toThrowError(/invalid api url/i);
     expect(() => new LiskClient("http://[2001::0370:7344]:8080/")).toThrowError(/invalid api url/i);
 
-    //wrong path
+    // wrong path
     expect(() => new LiskClient("http://localhost/api")).toThrowError(/invalid api url/i);
   });
 

--- a/packages/iov-lisk/src/liskclient.spec.ts
+++ b/packages/iov-lisk/src/liskclient.spec.ts
@@ -1,3 +1,6 @@
+import { Address, BcpAccountQuery } from "@iov/bcp-types";
+import { Encoding } from "@iov/encoding";
+
 import { LiskClient } from "./liskclient";
 
 describe("LiskClient", () => {
@@ -24,5 +27,18 @@ describe("LiskClient", () => {
     const height = await client.height();
     expect(height).toBeGreaterThan(6000000);
     expect(height).toBeLessThan(8000000);
+  });
+
+  it("can get account", async () => {
+    // Generate dead target address:
+    // python3 -c 'import random; print("{}L".format(random.randint(0, 18446744073709551615)))'
+    const client = new LiskClient(base);
+    const query: BcpAccountQuery = { address: Encoding.toAscii("15683599531721344316L") as Address };
+    const account = await client.getAccount(query);
+    expect(account.data[0].address).toEqual(Encoding.toAscii("15683599531721344316L"));
+    expect(account.data[0].balance[0].tokenTicker).toEqual("LSK");
+    expect(account.data[0].balance[0].sigFigs).toEqual(8);
+    expect(account.data[0].balance[0].whole).toEqual(15);
+    expect(account.data[0].balance[0].fractional).toEqual(48687542);
   });
 });

--- a/packages/iov-lisk/src/liskclient.spec.ts
+++ b/packages/iov-lisk/src/liskclient.spec.ts
@@ -1,7 +1,12 @@
-import { Address, BcpAccountQuery } from "@iov/bcp-types";
+import Long from "long";
+
+import { Address, BcpAccountQuery, Nonce, SendTx, TokenTicker, TransactionKind } from "@iov/bcp-types";
 import { Encoding } from "@iov/encoding";
+import { ChainId } from "@iov/tendermint-types";
 
 import { LiskClient } from "./liskclient";
+import { liskCodec } from "./liskcodec";
+import { LiskKeyringEntry } from "./liskkeyringentry";
 
 describe("LiskClient", () => {
   const base = "https://testnet.lisk.io";
@@ -41,4 +46,60 @@ describe("LiskClient", () => {
     expect(account.data[0].balance[0].whole).toEqual(15);
     expect(account.data[0].balance[0].fractional).toEqual(48687542);
   });
+
+  it(
+    "can post transaction",
+    async () => {
+      const liskTestnet = "da3ed6a45429278bac2666961289ca17ad86595d33b31037615d4b8e8f158bba" as ChainId;
+
+      const entry = new LiskKeyringEntry();
+      const mainIdentity = await entry.createIdentity(
+        "oxygen fall sure lava energy veteran enroll frown question detail include maximum",
+      );
+
+      const recipientAddress = Encoding.toAscii("6076671634347365051L") as Address;
+
+      const sendTx: SendTx = {
+        kind: TransactionKind.Send,
+        chainId: liskTestnet,
+        signer: mainIdentity.pubkey,
+        recipient: recipientAddress,
+        memo: "We ❤️ developers – iov.one",
+        amount: {
+          whole: 2,
+          fractional: 44550000,
+          tokenTicker: "LSK" as TokenTicker,
+        },
+      };
+
+      // Encode creation timestamp into nonce
+      const nonce = Long.fromNumber(Math.floor(Date.now() / 1000)) as Nonce;
+      const signingJob = liskCodec.bytesToSign(sendTx, nonce);
+      const signature = await entry.createTransactionSignature(
+        mainIdentity,
+        signingJob.bytes,
+        signingJob.prehashType,
+        liskTestnet,
+      );
+
+      const signedTransaction = {
+        transaction: sendTx,
+        primarySignature: {
+          nonce: nonce,
+          publicKey: mainIdentity.pubkey,
+          signature: signature,
+        },
+        otherSignatures: [],
+      };
+      const bytesToPost = liskCodec.bytesToPost(signedTransaction);
+
+      const client = new LiskClient(base);
+      const result = await client.postTx(bytesToPost);
+      expect(result).toBeTruthy();
+      expect(result.metadata.height).toBeDefined();
+      expect(result.metadata.height).toBeGreaterThan(6000000);
+      expect(result.metadata.height).toBeLessThan(8000000);
+    },
+    40 * 1000,
+  );
 });

--- a/packages/iov-lisk/src/liskclient.spec.ts
+++ b/packages/iov-lisk/src/liskclient.spec.ts
@@ -1,10 +1,8 @@
-import Long from "long";
-
-import { Address, BcpAccountQuery, Nonce, SendTx, TokenTicker, TransactionKind } from "@iov/bcp-types";
+import { Address, BcpAccountQuery, SendTx, TokenTicker, TransactionKind } from "@iov/bcp-types";
 import { Encoding } from "@iov/encoding";
 import { ChainId } from "@iov/tendermint-types";
 
-import { LiskClient } from "./liskclient";
+import { generateNonce, LiskClient } from "./liskclient";
 import { liskCodec } from "./liskcodec";
 import { LiskKeyringEntry } from "./liskkeyringentry";
 
@@ -84,7 +82,7 @@ describe("LiskClient", () => {
       };
 
       // Encode creation timestamp into nonce
-      const nonce = Long.fromNumber(Math.floor(Date.now() / 1000)) as Nonce;
+      const nonce = generateNonce();
       const signingJob = liskCodec.bytesToSign(sendTx, nonce);
       const signature = await entry.createTransactionSignature(
         mainIdentity,

--- a/packages/iov-lisk/src/liskclient.spec.ts
+++ b/packages/iov-lisk/src/liskclient.spec.ts
@@ -1,0 +1,8 @@
+import { LiskClient } from "./liskclient";
+
+describe("LiskClient", () => {
+  it("can be constructed", () => {
+    const client = new LiskClient();
+    expect(client).toBeTruthy();
+  });
+});

--- a/packages/iov-lisk/src/liskclient.spec.ts
+++ b/packages/iov-lisk/src/liskclient.spec.ts
@@ -77,7 +77,7 @@ describe("LiskClient", () => {
         recipient: recipientAddress,
         memo: "We ❤️ developers – iov.one",
         amount: {
-          whole: 2,
+          whole: 1,
           fractional: 44550000,
           tokenTicker: "LSK" as TokenTicker,
         },

--- a/packages/iov-lisk/src/liskclient.spec.ts
+++ b/packages/iov-lisk/src/liskclient.spec.ts
@@ -6,6 +6,12 @@ import { generateNonce, LiskClient } from "./liskclient";
 import { liskCodec } from "./liskcodec";
 import { LiskKeyringEntry } from "./liskkeyringentry";
 
+function pendingWithoutLongRunning(): void {
+  if (!process.env.LONG_RUNNING_ENABLED) {
+    pending("Set LONG_RUNNING_ENABLED to enable long running tests");
+  }
+}
+
 describe("LiskClient", () => {
   const base = "https://testnet.lisk.io";
 
@@ -59,6 +65,8 @@ describe("LiskClient", () => {
   it(
     "can post transaction",
     async () => {
+      pendingWithoutLongRunning();
+
       const liskTestnet = "da3ed6a45429278bac2666961289ca17ad86595d33b31037615d4b8e8f158bba" as ChainId;
 
       const entry = new LiskKeyringEntry();

--- a/packages/iov-lisk/src/liskclient.spec.ts
+++ b/packages/iov-lisk/src/liskclient.spec.ts
@@ -20,6 +20,49 @@ describe("LiskClient", () => {
     expect(client).toBeTruthy();
   });
 
+  it("takes different kind of API URLs", () => {
+    expect(new LiskClient("http://localhost")).toBeTruthy();
+    expect(new LiskClient("http://localhost/")).toBeTruthy();
+    expect(new LiskClient("https://localhost")).toBeTruthy();
+    expect(new LiskClient("https://localhost/")).toBeTruthy();
+    expect(new LiskClient("http://localhost:456")).toBeTruthy();
+    expect(new LiskClient("http://localhost:456/")).toBeTruthy();
+    expect(new LiskClient("https://localhost:456")).toBeTruthy();
+    expect(new LiskClient("https://localhost:456/")).toBeTruthy();
+
+    expect(new LiskClient("http://my-HOST.tld")).toBeTruthy();
+    expect(new LiskClient("http://my-HOST.tld/")).toBeTruthy();
+    expect(new LiskClient("https://my-HOST.tld")).toBeTruthy();
+    expect(new LiskClient("https://my-HOST.tld/")).toBeTruthy();
+    expect(new LiskClient("http://my-HOST.tld:456")).toBeTruthy();
+    expect(new LiskClient("http://my-HOST.tld:456/")).toBeTruthy();
+    expect(new LiskClient("https://my-HOST.tld:456")).toBeTruthy();
+    expect(new LiskClient("https://my-HOST.tld:456/")).toBeTruthy();
+
+    expect(new LiskClient("http://123.123.123.123")).toBeTruthy();
+    expect(new LiskClient("http://123.123.123.123/")).toBeTruthy();
+    expect(new LiskClient("https://123.123.123.123")).toBeTruthy();
+    expect(new LiskClient("https://123.123.123.123/")).toBeTruthy();
+    expect(new LiskClient("http://123.123.123.123:456")).toBeTruthy();
+    expect(new LiskClient("http://123.123.123.123:456/")).toBeTruthy();
+    expect(new LiskClient("https://123.123.123.123:456")).toBeTruthy();
+    expect(new LiskClient("https://123.123.123.123:456/")).toBeTruthy();
+  });
+
+  it("throws for invalid API URLs", () => {
+    // wrong scheme
+    expect(() => new LiskClient("localhost")).toThrowError(/invalid api url/i);
+    expect(() => new LiskClient("ftp://localhost")).toThrowError(/invalid api url/i);
+    expect(() => new LiskClient("ws://localhost")).toThrowError(/invalid api url/i);
+
+    // unsupported hosts
+    expect(() => new LiskClient("http://[2001::0370:7344]/")).toThrowError(/invalid api url/i);
+    expect(() => new LiskClient("http://[2001::0370:7344]:8080/")).toThrowError(/invalid api url/i);
+
+    //wrong path
+    expect(() => new LiskClient("http://localhost/api")).toThrowError(/invalid api url/i);
+  });
+
   it("can disconnect", () => {
     const client = new LiskClient(base);
     expect(() => client.disconnect()).not.toThrow();

--- a/packages/iov-lisk/src/liskclient.spec.ts
+++ b/packages/iov-lisk/src/liskclient.spec.ts
@@ -18,4 +18,11 @@ describe("LiskClient", () => {
     const chainId = await client.chainId();
     expect(chainId).toEqual("da3ed6a45429278bac2666961289ca17ad86595d33b31037615d4b8e8f158bba");
   });
+
+  it("can get height", async () => {
+    const client = new LiskClient(base);
+    const height = await client.height();
+    expect(height).toBeGreaterThan(6000000);
+    expect(height).toBeLessThan(8000000);
+  });
 });

--- a/packages/iov-lisk/src/liskclient.spec.ts
+++ b/packages/iov-lisk/src/liskclient.spec.ts
@@ -47,6 +47,17 @@ describe("LiskClient", () => {
     expect(account.data[0].balance[0].fractional).toEqual(48687542);
   });
 
+  it("can get nonce", async () => {
+    const client = new LiskClient(base);
+    const query: BcpAccountQuery = { address: Encoding.toAscii("15683599531721344316L") as Address };
+    const nonce = await client.getNonce(query);
+
+    expect(nonce.data[0].address).toEqual(Encoding.toAscii("15683599531721344316L"));
+    // nonce is current timestamp +/- one second
+    expect(nonce.data[0].nonce.toNumber()).toBeGreaterThanOrEqual(Date.now() / 1000 - 1);
+    expect(nonce.data[0].nonce.toNumber()).toBeLessThanOrEqual(Date.now() / 1000 + 1);
+  });
+
   it(
     "can post transaction",
     async () => {

--- a/packages/iov-lisk/src/liskclient.spec.ts
+++ b/packages/iov-lisk/src/liskclient.spec.ts
@@ -1,13 +1,21 @@
 import { LiskClient } from "./liskclient";
 
 describe("LiskClient", () => {
+  const base = "https://testnet.lisk.io";
+
   it("can be constructed", () => {
-    const client = new LiskClient();
+    const client = new LiskClient(base);
     expect(client).toBeTruthy();
   });
 
   it("can disconnect", () => {
-    const client = new LiskClient();
+    const client = new LiskClient(base);
     expect(() => client.disconnect()).not.toThrow();
+  });
+
+  it("can get chain ID", async () => {
+    const client = new LiskClient(base);
+    const chainId = await client.chainId();
+    expect(chainId).toEqual("da3ed6a45429278bac2666961289ca17ad86595d33b31037615d4b8e8f158bba");
   });
 });

--- a/packages/iov-lisk/src/liskclient.spec.ts
+++ b/packages/iov-lisk/src/liskclient.spec.ts
@@ -5,4 +5,9 @@ describe("LiskClient", () => {
     const client = new LiskClient();
     expect(client).toBeTruthy();
   });
+
+  it("can disconnect", () => {
+    const client = new LiskClient();
+    expect(() => client.disconnect()).not.toThrow();
+  });
 });

--- a/packages/iov-lisk/src/liskclient.ts
+++ b/packages/iov-lisk/src/liskclient.ts
@@ -1,3 +1,4 @@
+import axios from "axios";
 import { Stream } from "xstream";
 
 import {
@@ -15,12 +16,21 @@ import {
 import { ChainId, PostableBytes, Tag, TxQuery } from "@iov/tendermint-types";
 
 export class LiskClient implements IovReader {
+  private readonly baseUrl: string;
+
+  constructor(baseUrl: string) {
+    this.baseUrl = baseUrl;
+  }
+
   public disconnect(): void {
     // no-op
   }
 
-  public chainId(): Promise<ChainId> {
-    throw new Error("Not implemented");
+  public async chainId(): Promise<ChainId> {
+    const url = this.baseUrl + "/api/node/constants";
+    const result = await axios.get(url);
+    const responseBody = result.data;
+    return responseBody.data.nethash;
   }
 
   public height(): Promise<number> {

--- a/packages/iov-lisk/src/liskclient.ts
+++ b/packages/iov-lisk/src/liskclient.ts
@@ -16,7 +16,7 @@ import { ChainId, PostableBytes, Tag, TxQuery } from "@iov/tendermint-types";
 
 export class LiskClient implements IovReader {
   public disconnect(): void {
-    throw new Error("Not implemented");
+    // no-op
   }
 
   public chainId(): Promise<ChainId> {

--- a/packages/iov-lisk/src/liskclient.ts
+++ b/packages/iov-lisk/src/liskclient.ts
@@ -19,6 +19,7 @@ import {
 import { Encoding } from "@iov/encoding";
 import { Algorithm, ChainId, PostableBytes, PublicKeyBytes, Tag, TxId, TxQuery } from "@iov/tendermint-types";
 
+import { constants } from "./constants";
 import { Parse } from "./parse";
 
 function isAddressQuery(query: BcpAccountQuery): query is BcpAddressQuery {
@@ -118,8 +119,8 @@ export class LiskClient implements IovReader {
         name: undefined,
         balance: [
           {
-            sigFigs: 8,
-            tokenName: undefined,
+            sigFigs: constants.primaryTokenSigFigs,
+            tokenName: constants.primaryTokenName,
             ...Parse.liskAmount(responseBody.data[0].balance),
           },
         ],

--- a/packages/iov-lisk/src/liskclient.ts
+++ b/packages/iov-lisk/src/liskclient.ts
@@ -33,8 +33,11 @@ export class LiskClient implements IovReader {
     return responseBody.data.nethash;
   }
 
-  public height(): Promise<number> {
-    throw new Error("Not implemented");
+  public async height(): Promise<number> {
+    const url = this.baseUrl + "/api/node/status";
+    const result = await axios.get(url);
+    const responseBody = result.data;
+    return responseBody.data.height;
   }
 
   public postTx(_: PostableBytes): Promise<BcpTransactionResponse> {

--- a/packages/iov-lisk/src/liskclient.ts
+++ b/packages/iov-lisk/src/liskclient.ts
@@ -1,0 +1,81 @@
+import { Stream } from "xstream";
+
+import {
+  Address,
+  BcpAccount,
+  BcpAccountQuery,
+  BcpNonce,
+  BcpQueryEnvelope,
+  BcpTicker,
+  BcpTransactionResponse,
+  ConfirmedTransaction,
+  IovReader,
+  TokenTicker,
+} from "@iov/bcp-types";
+import { ChainId, PostableBytes, Tag, TxQuery } from "@iov/tendermint-types";
+
+export class LiskClient implements IovReader {
+  public disconnect(): void {
+    throw new Error("Not implemented");
+  }
+
+  public chainId(): Promise<ChainId> {
+    throw new Error("Not implemented");
+  }
+
+  public height(): Promise<number> {
+    throw new Error("Not implemented");
+  }
+
+  public postTx(_: PostableBytes): Promise<BcpTransactionResponse> {
+    throw new Error("Not implemented");
+  }
+
+  public getTicker(_: TokenTicker): Promise<BcpQueryEnvelope<BcpTicker>> {
+    throw new Error("Not implemented");
+  }
+
+  public getAllTickers(): Promise<BcpQueryEnvelope<BcpTicker>> {
+    throw new Error("Not implemented");
+  }
+
+  public getAccount(_: BcpAccountQuery): Promise<BcpQueryEnvelope<BcpAccount>> {
+    throw new Error("Not implemented");
+  }
+
+  public getNonce(_: BcpAccountQuery): Promise<BcpQueryEnvelope<BcpNonce>> {
+    throw new Error("Not implemented");
+  }
+
+  public changeBalance(_: Address): Stream<number> {
+    throw new Error("Not implemented");
+  }
+
+  public changeNonce(_: Address): Stream<number> {
+    throw new Error("Not implemented");
+  }
+
+  public changeBlock(): Stream<number> {
+    throw new Error("Not implemented");
+  }
+
+  public watchAccount(_: BcpAccountQuery): Stream<BcpAccount | undefined> {
+    throw new Error("Not implemented");
+  }
+
+  public watchNonce(_: BcpAccountQuery): Stream<BcpNonce | undefined> {
+    throw new Error("Not implemented");
+  }
+
+  public searchTx(_: TxQuery): Promise<ReadonlyArray<ConfirmedTransaction>> {
+    throw new Error("Not implemented");
+  }
+
+  public listenTx(_: ReadonlyArray<Tag>): Stream<ConfirmedTransaction> {
+    throw new Error("Not implemented");
+  }
+
+  public liveTx(_: TxQuery): Stream<ConfirmedTransaction> {
+    throw new Error("Not implemented");
+  }
+}

--- a/packages/iov-lisk/src/liskclient.ts
+++ b/packages/iov-lisk/src/liskclient.ts
@@ -44,7 +44,7 @@ export class LiskClient implements IovReader {
       );
     }
 
-    this.baseUrl = baseUrl;
+    this.baseUrl = baseUrl.endsWith("/") ? baseUrl.slice(0, -1) : baseUrl;
   }
 
   public disconnect(): void {

--- a/packages/iov-lisk/src/liskclient.ts
+++ b/packages/iov-lisk/src/liskclient.ts
@@ -61,7 +61,7 @@ export class LiskClient implements IovReader {
 
     // Sleep some seconds to ensure transaction will be found.
     // Sleep duration determined by trial and error. 15 seconds was not enough.
-    await new Promise(resolve => setTimeout(resolve, 18 * 1000));
+    await new Promise(resolve => setTimeout(resolve, 20 * 1000));
 
     const result = await axios.get(this.baseUrl + `/api/transactions?id=${transactionId}`);
     const responseBody = result.data;

--- a/packages/iov-lisk/src/liskclient.ts
+++ b/packages/iov-lisk/src/liskclient.ts
@@ -38,6 +38,12 @@ export class LiskClient implements IovReader {
   private readonly baseUrl: string;
 
   constructor(baseUrl: string) {
+    if (!baseUrl.match(/^https?:\/\/[-\.a-zA-Z0-9]+(:[0-9]+)?\/?$/)) {
+      throw new Error(
+        "Invalid API URL. Expected a base URL like https://testnet.lisk.io or http://123.123.132.132:8000/",
+      );
+    }
+
     this.baseUrl = baseUrl;
   }
 

--- a/packages/iov-lisk/src/liskclient.ts
+++ b/packages/iov-lisk/src/liskclient.ts
@@ -1,5 +1,5 @@
 import axios from "axios";
-import Long from "long";
+import { ReadonlyDate } from "readonly-date";
 import { Stream } from "xstream";
 
 import {
@@ -23,6 +23,14 @@ import { Parse } from "./parse";
 
 function isAddressQuery(query: BcpAccountQuery): query is BcpAddressQuery {
   return (query as BcpAddressQuery).address !== undefined;
+}
+
+/**
+ * Encodes the current date and time as a nonce
+ */
+export function generateNonce(): Nonce {
+  const now = new ReadonlyDate(ReadonlyDate.now());
+  return Parse.timeToNonce(now);
 }
 
 export class LiskClient implements IovReader {
@@ -142,7 +150,7 @@ export class LiskClient implements IovReader {
           algo: Algorithm.ED25519,
           data: new Uint8Array([]) as PublicKeyBytes,
         },
-        nonce: Long.fromNumber(Math.floor(Date.now() / 1000)) as Nonce,
+        nonce: generateNonce(),
       };
 
       const out: BcpQueryEnvelope<BcpNonce> = {

--- a/packages/iov-lisk/src/liskcodec.spec.ts
+++ b/packages/iov-lisk/src/liskcodec.spec.ts
@@ -120,6 +120,9 @@ describe("liskCodec", () => {
     );
     expect(parsed.transaction.recipient).toEqual(toAscii("6076671634347365051L"));
 
+    expect(parsed.primarySignature.nonce).toEqual(Long.fromNumber(
+      73863961 + liskEpochAsUinxTimestamp,
+    ) as Nonce);
     expect(parsed.primarySignature.publicKey.algo).toEqual(Algorithm.ED25519);
     expect(parsed.primarySignature.publicKey.data).toEqual(
       fromHex("06ad4341a609af2de837e1156f81849b05bf3c280940a9f45db76d09a3a3f2fa"),

--- a/packages/iov-lisk/src/liskcodec.spec.ts
+++ b/packages/iov-lisk/src/liskcodec.spec.ts
@@ -17,8 +17,8 @@ const { fromHex, toAscii } = Encoding;
 
 // use nethash as chain ID
 const liskTestnet = "da3ed6a45429278bac2666961289ca17ad86595d33b31037615d4b8e8f158bba" as ChainId;
-const liskEpochAsUinxTimestamp = 1464109200;
-const defaultCreationTimestamp = Long.fromNumber(865708731 + liskEpochAsUinxTimestamp);
+const liskEpochAsUnixTimestamp = 1464109200;
+const defaultCreationTimestamp = Long.fromNumber(865708731 + liskEpochAsUnixTimestamp);
 
 describe("liskCodec", () => {
   it("derives addresses properly", () => {
@@ -121,7 +121,7 @@ describe("liskCodec", () => {
     expect(parsed.transaction.recipient).toEqual(toAscii("6076671634347365051L"));
 
     expect(parsed.primarySignature.nonce).toEqual(Long.fromNumber(
-      73863961 + liskEpochAsUinxTimestamp,
+      73863961 + liskEpochAsUnixTimestamp,
     ) as Nonce);
     expect(parsed.primarySignature.publicKey.algo).toEqual(Algorithm.ED25519);
     expect(parsed.primarySignature.publicKey.data).toEqual(

--- a/packages/iov-lisk/src/liskcodec.ts
+++ b/packages/iov-lisk/src/liskcodec.ts
@@ -25,7 +25,7 @@ import {
 
 import { pubkeyToAddress } from "./derivation";
 import { Parse } from "./parse";
-import { serializeTransaction, transactionId } from "./serialization";
+import { amountFromComponents, serializeTransaction, transactionId } from "./serialization";
 
 export const liskCodec: TxCodec = {
   /**
@@ -55,9 +55,9 @@ export const liskCodec: TxCodec = {
           new ReadonlyDate(timestamp * 1000),
           signed.primarySignature,
         );
-        const amount = Long.fromNumber(
-          signed.transaction.amount.whole * 100000000 + signed.transaction.amount.fractional,
-          true,
+        const amount = amountFromComponents(
+          signed.transaction.amount.whole,
+          signed.transaction.amount.fractional,
         );
 
         const postableObject = {

--- a/packages/iov-lisk/src/liskcodec.ts
+++ b/packages/iov-lisk/src/liskcodec.ts
@@ -1,4 +1,3 @@
-import Long from "long";
 import { ReadonlyDate } from "readonly-date";
 
 import {
@@ -119,7 +118,7 @@ export const liskCodec: TxCodec = {
         memo: json.asset.data,
       },
       primarySignature: {
-        nonce: new Long(0) as Nonce,
+        nonce: Parse.timeToNonce(Parse.fromLiskTimestamp(json.timestamp)),
         publicKey: {
           algo: Algorithm.ED25519,
           data: Encoding.fromHex(json.senderPublicKey) as PublicKeyBytes,

--- a/packages/iov-lisk/src/liskcodec.ts
+++ b/packages/iov-lisk/src/liskcodec.ts
@@ -95,6 +95,15 @@ export const liskCodec: TxCodec = {
   parseBytes: (bytes: PostableBytes, chainId: ChainId): SignedTransaction => {
     const json = JSON.parse(Encoding.fromUtf8(bytes));
 
+    let kind: TransactionKind;
+    switch (json.type) {
+      case 0:
+        kind = TransactionKind.Send;
+        break;
+      default:
+        throw new Error("Unsupported transaction type");
+    }
+
     return {
       transaction: {
         chainId: chainId,
@@ -104,7 +113,7 @@ export const liskCodec: TxCodec = {
           data: Encoding.fromHex(json.senderPublicKey) as PublicKeyBytes,
         },
         ttl: undefined,
-        kind: TransactionKind.Send,
+        kind: kind,
         amount: Parse.liskAmount(json.amount),
         recipient: Encoding.toAscii(json.recipientId) as Address,
         memo: json.asset.data,

--- a/packages/iov-lisk/src/liskconnector.ts
+++ b/packages/iov-lisk/src/liskconnector.ts
@@ -1,0 +1,11 @@
+import { ChainConnector } from "@iov/core";
+
+import { LiskClient } from "./liskclient";
+import { liskCodec } from "./liskcodec";
+
+export function liskConnector(url: string): ChainConnector {
+  return {
+    client: () => Promise.resolve(new LiskClient(url)),
+    codec: liskCodec,
+  };
+}

--- a/packages/iov-lisk/src/parse.spec.ts
+++ b/packages/iov-lisk/src/parse.spec.ts
@@ -40,6 +40,44 @@ describe("Parse", () => {
     expect(Parse.liskAmount("123456789")).toEqual(expected);
   });
 
+  it("parses lisk timestamp 0 as Lisk epoch", () => {
+    expect(Parse.fromLiskTimestamp(0)).toEqual(new ReadonlyDate(ReadonlyDate.UTC(2016, 4, 24, 17, 0, 0, 0)));
+  });
+
+  it("can parse positive timestamps", () => {
+    // one second
+    expect(Parse.fromLiskTimestamp(1)).toEqual(new ReadonlyDate(ReadonlyDate.UTC(2016, 4, 24, 17, 0, 1, 0)));
+    // one minute
+    expect(Parse.fromLiskTimestamp(60)).toEqual(new ReadonlyDate(ReadonlyDate.UTC(2016, 4, 24, 17, 1, 0, 0)));
+    // one hour
+    expect(Parse.fromLiskTimestamp(3600)).toEqual(
+      new ReadonlyDate(ReadonlyDate.UTC(2016, 4, 24, 18, 0, 0, 0)),
+    );
+    // one day
+    expect(Parse.fromLiskTimestamp(86400)).toEqual(
+      new ReadonlyDate(ReadonlyDate.UTC(2016, 4, 25, 17, 0, 0, 0)),
+    );
+  });
+
+  it("can parse negative timestamps", () => {
+    // one second
+    expect(Parse.fromLiskTimestamp(-1)).toEqual(
+      new ReadonlyDate(ReadonlyDate.UTC(2016, 4, 24, 16, 59, 59, 0)),
+    );
+    // one minute
+    expect(Parse.fromLiskTimestamp(-60)).toEqual(
+      new ReadonlyDate(ReadonlyDate.UTC(2016, 4, 24, 16, 59, 0, 0)),
+    );
+    // one hour
+    expect(Parse.fromLiskTimestamp(-3600)).toEqual(
+      new ReadonlyDate(ReadonlyDate.UTC(2016, 4, 24, 16, 0, 0, 0)),
+    );
+    // one day
+    expect(Parse.fromLiskTimestamp(-86400)).toEqual(
+      new ReadonlyDate(ReadonlyDate.UTC(2016, 4, 23, 17, 0, 0, 0)),
+    );
+  });
+
   it("can convert time to nonce", () => {
     // zero, positive, negative
     expect(Parse.timeToNonce(new ReadonlyDate(ReadonlyDate.UTC(1970, 0, 1, 0, 0, 0)))).toEqual(

--- a/packages/iov-lisk/src/parse.spec.ts
+++ b/packages/iov-lisk/src/parse.spec.ts
@@ -1,4 +1,7 @@
-import { TokenTicker } from "@iov/bcp-types";
+import Long from "long";
+import { ReadonlyDate } from "readonly-date";
+
+import { Nonce, TokenTicker } from "@iov/bcp-types";
 
 import { AmountFields, Parse } from "./parse";
 
@@ -35,5 +38,35 @@ describe("Parse", () => {
   it("can parse 1.23456789 LSK", () => {
     const expected: AmountFields = { whole: 1, fractional: 23456789, tokenTicker: "LSK" as TokenTicker };
     expect(Parse.liskAmount("123456789")).toEqual(expected);
+  });
+
+  it("can convert time to nonce", () => {
+    // zero, positive, negative
+    expect(Parse.timeToNonce(new ReadonlyDate(ReadonlyDate.UTC(1970, 0, 1, 0, 0, 0)))).toEqual(
+      Long.fromNumber(0) as Nonce,
+    );
+    expect(Parse.timeToNonce(new ReadonlyDate(ReadonlyDate.UTC(1999, 2, 3, 4, 5, 6)))).toEqual(
+      Long.fromNumber(920433906) as Nonce,
+    );
+    expect(Parse.timeToNonce(new ReadonlyDate(ReadonlyDate.UTC(1969, 11, 31, 23, 15, 0)))).toEqual(
+      Long.fromNumber(-45 * 60) as Nonce,
+    );
+
+    // beyond year 2038
+    expect(Parse.timeToNonce(new ReadonlyDate(ReadonlyDate.UTC(2040, 0, 1, 0, 0, 0)))).toEqual(
+      Long.fromNumber(2208988800) as Nonce,
+    );
+
+    // Out of Lisk timestamp range (2016 +/- 70 years). This is not strictly
+    // required but shows that we cover the full range and more by storing
+    // signed, long UNIX timestamps.
+    //
+    // python3 -c 'import calendar, datetime; print(calendar.timegm(datetime.datetime(1946, 4, 25, 23, 15, 14, 0).utctimetuple()))'
+    expect(Parse.timeToNonce(new ReadonlyDate(ReadonlyDate.UTC(1946, 3, 25, 23, 15, 14)))).toEqual(
+      Long.fromNumber(-747449086) as Nonce,
+    );
+    expect(Parse.timeToNonce(new ReadonlyDate(ReadonlyDate.UTC(2086, 3, 25, 23, 15, 14)))).toEqual(
+      Long.fromNumber(3670614914) as Nonce,
+    );
   });
 });

--- a/packages/iov-lisk/src/parse.spec.ts
+++ b/packages/iov-lisk/src/parse.spec.ts
@@ -1,0 +1,39 @@
+import { TokenTicker } from "@iov/bcp-types";
+
+import { AmountFields, Parse } from "./parse";
+
+describe("Parse", () => {
+  it("can parse zero amount", () => {
+    const expected: AmountFields = { whole: 0, fractional: 0, tokenTicker: "LSK" as TokenTicker };
+    expect(Parse.liskAmount("0")).toEqual(expected);
+    expect(Parse.liskAmount("00")).toEqual(expected);
+    expect(Parse.liskAmount("000000000")).toEqual(expected);
+  });
+
+  it("can parse 1 LSK", () => {
+    const expected: AmountFields = { whole: 1, fractional: 0, tokenTicker: "LSK" as TokenTicker };
+    expect(Parse.liskAmount("100000000")).toEqual(expected);
+    expect(Parse.liskAmount("00100000000")).toEqual(expected);
+    expect(Parse.liskAmount("000000000100000000")).toEqual(expected);
+  });
+
+  it("can parse 10 million LSK", () => {
+    const expected: AmountFields = { whole: 10000000, fractional: 0, tokenTicker: "LSK" as TokenTicker };
+    expect(Parse.liskAmount("1000000000000000")).toEqual(expected);
+  });
+
+  it("can parse 100 million LSK", () => {
+    const expected: AmountFields = { whole: 100000000, fractional: 0, tokenTicker: "LSK" as TokenTicker };
+    expect(Parse.liskAmount("10000000000000000")).toEqual(expected);
+  });
+
+  it("can parse 1.23 LSK", () => {
+    const expected: AmountFields = { whole: 1, fractional: 23000000, tokenTicker: "LSK" as TokenTicker };
+    expect(Parse.liskAmount("123000000")).toEqual(expected);
+  });
+
+  it("can parse 1.23456789 LSK", () => {
+    const expected: AmountFields = { whole: 1, fractional: 23456789, tokenTicker: "LSK" as TokenTicker };
+    expect(Parse.liskAmount("123456789")).toEqual(expected);
+  });
+});

--- a/packages/iov-lisk/src/parse.ts
+++ b/packages/iov-lisk/src/parse.ts
@@ -1,0 +1,20 @@
+import Long from "long";
+
+import { TokenTicker } from "@iov/bcp-types";
+
+export interface AmountFields {
+  readonly whole: number;
+  readonly fractional: number;
+  readonly tokenTicker: TokenTicker;
+}
+
+export class Parse {
+  public static liskAmount(str: string): AmountFields {
+    const amount = Long.fromString(str, true, 10);
+    return {
+      whole: amount.divide(100000000).toNumber(),
+      fractional: amount.modulo(100000000).toNumber(),
+      tokenTicker: "LSK" as TokenTicker,
+    };
+  }
+}

--- a/packages/iov-lisk/src/parse.ts
+++ b/packages/iov-lisk/src/parse.ts
@@ -3,6 +3,8 @@ import { ReadonlyDate } from "readonly-date";
 
 import { Nonce, TokenTicker } from "@iov/bcp-types";
 
+import { constants } from "./constants";
+
 export interface AmountFields {
   readonly whole: number;
   readonly fractional: number;
@@ -15,7 +17,7 @@ export class Parse {
     return {
       whole: amount.divide(100000000).toNumber(),
       fractional: amount.modulo(100000000).toNumber(),
-      tokenTicker: "LSK" as TokenTicker,
+      tokenTicker: constants.primaryTokenTicker,
     };
   }
 

--- a/packages/iov-lisk/src/parse.ts
+++ b/packages/iov-lisk/src/parse.ts
@@ -19,6 +19,20 @@ export class Parse {
     };
   }
 
+  public static fromLiskTimestamp(liskTimestamp: number): ReadonlyDate {
+    // Lisk timestamp must be in the signed int32 range (to be stored in a Postgres
+    // integer column and to be serializeable as 4 bytes) but has no further
+    // plausibility restrictions.
+    // https://github.com/LiskHQ/lisk/blob/v1.0.3/logic/transaction.js#L674
+    if (liskTimestamp < -2147483648 || liskTimestamp > 2147483647) {
+      throw new Error("Lisk timestemp not in int32 range");
+    }
+
+    const liskEpoch = Date.UTC(2016, 4, 24, 17, 0, 0, 0) / 1000;
+    const timestamp = liskEpoch + liskTimestamp;
+    return new ReadonlyDate(timestamp * 1000);
+  }
+
   /**
    * Convert a point in time to a nonce used in the Lisk codec.
    *

--- a/packages/iov-lisk/src/parse.ts
+++ b/packages/iov-lisk/src/parse.ts
@@ -1,6 +1,7 @@
 import Long from "long";
+import { ReadonlyDate } from "readonly-date";
 
-import { TokenTicker } from "@iov/bcp-types";
+import { Nonce, TokenTicker } from "@iov/bcp-types";
 
 export interface AmountFields {
   readonly whole: number;
@@ -16,5 +17,19 @@ export class Parse {
       fractional: amount.modulo(100000000).toNumber(),
       tokenTicker: "LSK" as TokenTicker,
     };
+  }
+
+  /**
+   * Convert a point in time to a nonce used in the Lisk codec.
+   *
+   * The nonce stores a UNIX timestamp as integer in seconds resolution.
+   * Since we use a Long variable, we are not affected by the year 2038 problem.
+   * The full range of possible Lisk timestamps (epoch in 2016 +/- 68 years)
+   * is covered since we allow negative nonce values.
+   *
+   * @param date the JavaScript date and time object
+   */
+  public static timeToNonce(date: ReadonlyDate): Nonce {
+    return Long.fromNumber(Math.floor(date.getTime() / 1000)) as Nonce;
   }
 }

--- a/packages/iov-lisk/src/serialization.spec.ts
+++ b/packages/iov-lisk/src/serialization.spec.ts
@@ -5,7 +5,7 @@ import { Address, Nonce, SendTx, SignedTransaction, TokenTicker, TransactionKind
 import { Encoding } from "@iov/encoding";
 import { Algorithm, ChainId, PublicKeyBytes, SignatureBytes } from "@iov/tendermint-types";
 
-import { serializeTransaction, toLiskTimestamp, transactionId } from "./serialization";
+import { amountFromComponents, serializeTransaction, toLiskTimestamp, transactionId } from "./serialization";
 
 const { fromAscii, fromHex, toAscii } = Encoding;
 
@@ -65,6 +65,30 @@ describe("toLiskTimestamp", () => {
     expect(() =>
       toLiskTimestamp(new ReadonlyDate(ReadonlyDate.UTC(2016 + 70, 4, 24, 17, 0, 0, 0))),
     ).toThrowError(/not in int32 range/i);
+  });
+});
+
+describe("amountFromComponents", () => {
+  it("works for some simple values", () => {
+    expect(amountFromComponents(0, 0)).toEqual(Long.fromNumber(0, true));
+    expect(amountFromComponents(0, 1)).toEqual(Long.fromNumber(1, true));
+    expect(amountFromComponents(0, 123)).toEqual(Long.fromNumber(123, true));
+    expect(amountFromComponents(1, 0)).toEqual(Long.fromNumber(100000000, true));
+    expect(amountFromComponents(123, 0)).toEqual(Long.fromNumber(12300000000, true));
+    expect(amountFromComponents(1, 1)).toEqual(Long.fromNumber(100000001, true));
+    expect(amountFromComponents(1, 23456789)).toEqual(Long.fromNumber(123456789, true));
+  });
+
+  it("works for 10 million lisk", () => {
+    expect(amountFromComponents(10000000, 0)).toEqual(Long.fromString("1000000000000000", true, 10));
+    // set high and low digit to trigger precision bugs in floating point operations
+    expect(amountFromComponents(10000000, 1)).toEqual(Long.fromString("1000000000000001", true, 10));
+  });
+
+  it("works for 100 million lisk", () => {
+    expect(amountFromComponents(100000000, 0)).toEqual(Long.fromString("10000000000000000", true, 10));
+    // set high and low digit to trigger precision bugs in floating point operations
+    expect(amountFromComponents(100000000, 1)).toEqual(Long.fromString("10000000000000001", true, 10));
   });
 });
 

--- a/packages/iov-lisk/src/serialization.spec.ts
+++ b/packages/iov-lisk/src/serialization.spec.ts
@@ -11,7 +11,7 @@ const { fromAscii, fromHex, toAscii } = Encoding;
 
 // use nethash as chain ID
 const liskTestnet = "da3ed6a45429278bac2666961289ca17ad86595d33b31037615d4b8e8f158bba" as ChainId;
-const liskEpochAsUinxTimestamp = 1464109200;
+const liskEpochAsUnixTimestamp = 1464109200;
 const emptyNonce = new Long(0) as Nonce;
 
 describe("toLiskTimestamp", () => {
@@ -52,7 +52,7 @@ describe("toLiskTimestamp", () => {
     // $ python3 -c 'import calendar, datetime; print(calendar.timegm(datetime.datetime(2040, 3, 21, 17, 13, 22, 0).utctimetuple()))'
     // 2215962802
     const dateIn2040 = new ReadonlyDate(ReadonlyDate.UTC(2040, 2, 21, 17, 13, 22));
-    expect(toLiskTimestamp(dateIn2040)).toEqual(2215962802 - liskEpochAsUinxTimestamp);
+    expect(toLiskTimestamp(dateIn2040)).toEqual(2215962802 - liskEpochAsUnixTimestamp);
   });
 
   it("throws for time 70 years before Lisk epoch", () => {
@@ -93,7 +93,7 @@ describe("amountFromComponents", () => {
 });
 
 describe("serializeTransaction", () => {
-  const defaultCreationDate = new ReadonlyDate((865708731 + liskEpochAsUinxTimestamp) * 1000);
+  const defaultCreationDate = new ReadonlyDate((865708731 + liskEpochAsUnixTimestamp) * 1000);
 
   it("can serialize type 0 without memo", () => {
     const pubkey = fromHex("00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff");
@@ -221,7 +221,7 @@ describe("serializeTransaction", () => {
 });
 
 describe("transactionId", () => {
-  const defaultCreationDate = new ReadonlyDate((865708731 + liskEpochAsUinxTimestamp) * 1000);
+  const defaultCreationDate = new ReadonlyDate((865708731 + liskEpochAsUnixTimestamp) * 1000);
 
   it("can calculate ID of type 0 without memo", () => {
     const pubkey = fromHex("00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff");

--- a/packages/iov-lisk/src/serialization.ts
+++ b/packages/iov-lisk/src/serialization.ts
@@ -24,6 +24,13 @@ export function toLiskTimestamp(date: ReadonlyDate): number {
   return liskTimestamp;
 }
 
+export function amountFromComponents(whole: number, fractional: number): Long {
+  return Long.fromNumber(whole)
+    .multiply(100000000)
+    .add(fractional)
+    .toUnsigned();
+}
+
 export function serializeTransaction(unsigned: UnsignedTransaction, creationTime: ReadonlyDate): Uint8Array {
   if (unsigned.fee !== undefined) {
     throw new Error("Fee must not be set. It is fixed in Lisk and not included in the signed content.");
@@ -38,7 +45,7 @@ export function serializeTransaction(unsigned: UnsignedTransaction, creationTime
         (liskTimestamp >> 16) & 0xff,
         (liskTimestamp >> 24) & 0xff,
       ]);
-      const amount = Long.fromNumber(unsigned.amount.whole * 100000000 + unsigned.amount.fractional, true);
+      const amount = amountFromComponents(unsigned.amount.whole, unsigned.amount.fractional);
       const recipientString = Encoding.fromAscii(unsigned.recipient);
       if (!recipientString.match(/^[0-9]{1,20}L$/)) {
         throw new Error("Recipient does not match expected format");

--- a/packages/iov-lisk/types/constants.d.ts
+++ b/packages/iov-lisk/types/constants.d.ts
@@ -1,0 +1,6 @@
+import { TokenTicker } from "@iov/bcp-types";
+export declare const constants: {
+    primaryTokenTicker: TokenTicker;
+    primaryTokenName: string;
+    primaryTokenSigFigs: number;
+};

--- a/packages/iov-lisk/types/index.d.ts
+++ b/packages/iov-lisk/types/index.d.ts
@@ -1,2 +1,3 @@
 export { liskCodec } from "./liskcodec";
 export { LiskKeyringEntry } from "./liskkeyringentry";
+export { liskConnector } from "./liskconnector";

--- a/packages/iov-lisk/types/index.d.ts
+++ b/packages/iov-lisk/types/index.d.ts
@@ -1,4 +1,4 @@
 export { liskCodec } from "./liskcodec";
 export { LiskKeyringEntry } from "./liskkeyringentry";
 export { liskConnector } from "./liskconnector";
-export { generateNonce } from "./liskclient";
+export { generateNonce, LiskClient } from "./liskclient";

--- a/packages/iov-lisk/types/index.d.ts
+++ b/packages/iov-lisk/types/index.d.ts
@@ -1,3 +1,4 @@
 export { liskCodec } from "./liskcodec";
 export { LiskKeyringEntry } from "./liskkeyringentry";
 export { liskConnector } from "./liskconnector";
+export { generateNonce } from "./liskclient";

--- a/packages/iov-lisk/types/liskclient.d.ts
+++ b/packages/iov-lisk/types/liskclient.d.ts
@@ -1,6 +1,7 @@
 import { Stream } from "xstream";
-import { Address, BcpAccount, BcpAccountQuery, BcpNonce, BcpQueryEnvelope, BcpTicker, BcpTransactionResponse, ConfirmedTransaction, IovReader, TokenTicker } from "@iov/bcp-types";
+import { Address, BcpAccount, BcpAccountQuery, BcpNonce, BcpQueryEnvelope, BcpTicker, BcpTransactionResponse, ConfirmedTransaction, IovReader, Nonce, TokenTicker } from "@iov/bcp-types";
 import { ChainId, PostableBytes, Tag, TxQuery } from "@iov/tendermint-types";
+export declare function generateNonce(): Nonce;
 export declare class LiskClient implements IovReader {
     private readonly baseUrl;
     constructor(baseUrl: string);

--- a/packages/iov-lisk/types/liskclient.d.ts
+++ b/packages/iov-lisk/types/liskclient.d.ts
@@ -1,0 +1,21 @@
+import { Stream } from "xstream";
+import { Address, BcpAccount, BcpAccountQuery, BcpNonce, BcpQueryEnvelope, BcpTicker, BcpTransactionResponse, ConfirmedTransaction, IovReader, TokenTicker } from "@iov/bcp-types";
+import { ChainId, PostableBytes, Tag, TxQuery } from "@iov/tendermint-types";
+export declare class LiskClient implements IovReader {
+    disconnect(): void;
+    chainId(): Promise<ChainId>;
+    height(): Promise<number>;
+    postTx(_: PostableBytes): Promise<BcpTransactionResponse>;
+    getTicker(_: TokenTicker): Promise<BcpQueryEnvelope<BcpTicker>>;
+    getAllTickers(): Promise<BcpQueryEnvelope<BcpTicker>>;
+    getAccount(_: BcpAccountQuery): Promise<BcpQueryEnvelope<BcpAccount>>;
+    getNonce(_: BcpAccountQuery): Promise<BcpQueryEnvelope<BcpNonce>>;
+    changeBalance(_: Address): Stream<number>;
+    changeNonce(_: Address): Stream<number>;
+    changeBlock(): Stream<number>;
+    watchAccount(_: BcpAccountQuery): Stream<BcpAccount | undefined>;
+    watchNonce(_: BcpAccountQuery): Stream<BcpNonce | undefined>;
+    searchTx(_: TxQuery): Promise<ReadonlyArray<ConfirmedTransaction>>;
+    listenTx(_: ReadonlyArray<Tag>): Stream<ConfirmedTransaction>;
+    liveTx(_: TxQuery): Stream<ConfirmedTransaction>;
+}

--- a/packages/iov-lisk/types/liskclient.d.ts
+++ b/packages/iov-lisk/types/liskclient.d.ts
@@ -2,6 +2,8 @@ import { Stream } from "xstream";
 import { Address, BcpAccount, BcpAccountQuery, BcpNonce, BcpQueryEnvelope, BcpTicker, BcpTransactionResponse, ConfirmedTransaction, IovReader, TokenTicker } from "@iov/bcp-types";
 import { ChainId, PostableBytes, Tag, TxQuery } from "@iov/tendermint-types";
 export declare class LiskClient implements IovReader {
+    private readonly baseUrl;
+    constructor(baseUrl: string);
     disconnect(): void;
     chainId(): Promise<ChainId>;
     height(): Promise<number>;

--- a/packages/iov-lisk/types/liskclient.d.ts
+++ b/packages/iov-lisk/types/liskclient.d.ts
@@ -10,7 +10,7 @@ export declare class LiskClient implements IovReader {
     postTx(_: PostableBytes): Promise<BcpTransactionResponse>;
     getTicker(_: TokenTicker): Promise<BcpQueryEnvelope<BcpTicker>>;
     getAllTickers(): Promise<BcpQueryEnvelope<BcpTicker>>;
-    getAccount(_: BcpAccountQuery): Promise<BcpQueryEnvelope<BcpAccount>>;
+    getAccount(query: BcpAccountQuery): Promise<BcpQueryEnvelope<BcpAccount>>;
     getNonce(_: BcpAccountQuery): Promise<BcpQueryEnvelope<BcpNonce>>;
     changeBalance(_: Address): Stream<number>;
     changeNonce(_: Address): Stream<number>;

--- a/packages/iov-lisk/types/liskclient.d.ts
+++ b/packages/iov-lisk/types/liskclient.d.ts
@@ -7,7 +7,7 @@ export declare class LiskClient implements IovReader {
     disconnect(): void;
     chainId(): Promise<ChainId>;
     height(): Promise<number>;
-    postTx(_: PostableBytes): Promise<BcpTransactionResponse>;
+    postTx(bytes: PostableBytes): Promise<BcpTransactionResponse>;
     getTicker(_: TokenTicker): Promise<BcpQueryEnvelope<BcpTicker>>;
     getAllTickers(): Promise<BcpQueryEnvelope<BcpTicker>>;
     getAccount(query: BcpAccountQuery): Promise<BcpQueryEnvelope<BcpAccount>>;

--- a/packages/iov-lisk/types/liskclient.d.ts
+++ b/packages/iov-lisk/types/liskclient.d.ts
@@ -11,7 +11,7 @@ export declare class LiskClient implements IovReader {
     getTicker(_: TokenTicker): Promise<BcpQueryEnvelope<BcpTicker>>;
     getAllTickers(): Promise<BcpQueryEnvelope<BcpTicker>>;
     getAccount(query: BcpAccountQuery): Promise<BcpQueryEnvelope<BcpAccount>>;
-    getNonce(_: BcpAccountQuery): Promise<BcpQueryEnvelope<BcpNonce>>;
+    getNonce(query: BcpAccountQuery): Promise<BcpQueryEnvelope<BcpNonce>>;
     changeBalance(_: Address): Stream<number>;
     changeNonce(_: Address): Stream<number>;
     changeBlock(): Stream<number>;

--- a/packages/iov-lisk/types/liskconnector.d.ts
+++ b/packages/iov-lisk/types/liskconnector.d.ts
@@ -1,0 +1,2 @@
+import { ChainConnector } from "@iov/core";
+export declare function liskConnector(url: string): ChainConnector;

--- a/packages/iov-lisk/types/parse.d.ts
+++ b/packages/iov-lisk/types/parse.d.ts
@@ -1,0 +1,9 @@
+import { TokenTicker } from "@iov/bcp-types";
+export interface AmountFields {
+    readonly whole: number;
+    readonly fractional: number;
+    readonly tokenTicker: TokenTicker;
+}
+export declare class Parse {
+    static liskAmount(str: string): AmountFields;
+}

--- a/packages/iov-lisk/types/parse.d.ts
+++ b/packages/iov-lisk/types/parse.d.ts
@@ -1,4 +1,5 @@
-import { TokenTicker } from "@iov/bcp-types";
+import { ReadonlyDate } from "readonly-date";
+import { Nonce, TokenTicker } from "@iov/bcp-types";
 export interface AmountFields {
     readonly whole: number;
     readonly fractional: number;
@@ -6,4 +7,5 @@ export interface AmountFields {
 }
 export declare class Parse {
     static liskAmount(str: string): AmountFields;
+    static timeToNonce(date: ReadonlyDate): Nonce;
 }

--- a/packages/iov-lisk/types/parse.d.ts
+++ b/packages/iov-lisk/types/parse.d.ts
@@ -7,5 +7,6 @@ export interface AmountFields {
 }
 export declare class Parse {
     static liskAmount(str: string): AmountFields;
+    static fromLiskTimestamp(liskTimestamp: number): ReadonlyDate;
     static timeToNonce(date: ReadonlyDate): Nonce;
 }

--- a/packages/iov-lisk/types/serialization.d.ts
+++ b/packages/iov-lisk/types/serialization.d.ts
@@ -1,5 +1,7 @@
+import Long from "long";
 import { ReadonlyDate } from "readonly-date";
 import { FullSignature, TransactionIdBytes, UnsignedTransaction } from "@iov/bcp-types";
 export declare function toLiskTimestamp(date: ReadonlyDate): number;
+export declare function amountFromComponents(whole: number, fractional: number): Long;
 export declare function serializeTransaction(unsigned: UnsignedTransaction, creationTime: ReadonlyDate): Uint8Array;
 export declare function transactionId(unsigned: UnsignedTransaction, creationTime: ReadonlyDate, primarySignature: FullSignature): TransactionIdBytes;

--- a/packages/iov-lisk/webpack.web.config.js
+++ b/packages/iov-lisk/webpack.web.config.js
@@ -1,5 +1,6 @@
 const glob = require('glob');
 const path = require('path');
+const webpack = require('webpack');
 
 const target = "web";
 const distdir = path.join(__dirname, "dist", "web");
@@ -13,5 +14,8 @@ module.exports = [
       path: distdir,
       filename: "tests.js",
     },
+    plugins: [
+      new webpack.EnvironmentPlugin(['LONG_RUNNING_ENABLED']),
+    ],
   },
 ];


### PR DESCRIPTION
This implements everything for doing stuff like

```ts
import { liskCodec, liskConnector, LiskKeyringEntry } from "@iov/lisk";

const entry = new LiskKeyringEntry();
const mainIdentity = await entry.createIdentity("oxygen fall sure lava energy veteran enroll frown question detail include maximum");

const profile = new UserProfile();
profile.addEntry(entry);

const writer = new IovWriter(profile);
await writer.addChain(liskConnector("https://testnet.lisk.io"));
const chainId = writer.chainIds()[0];
const reader = writer.reader(chainId);

const mainAddress = writer.keyToAddress(chainId, mainIdentity.pubkey);
console.log((await reader.getAccount({ address: mainAddress })).data[0].balance);

const recipientAddress = Encoding.toAscii("6076671634347365051L") as Address;

const sendTx: SendTx = {
  kind: TransactionKind.Send,
  chainId: chainId,
  signer: mainIdentity.pubkey,
  recipient: recipientAddress,
  memo: "We ❤️ developers – iov.one",
  amount: {
    whole: 1,
    fractional: 44550000,
    tokenTicker: "LSK" as TokenTicker,
  }
};

console.log("Writing to blockchain. This may take a while …");
await writer.signAndCommit(sendTx, 0);
console.log((await reader.getAccount({ address: recipientAddress })).data[0].balance);
```

Closes #292 

~Based on #356~

- [x] Extract nonce generation into function
- [x] Write transaction timestamp into nonce (in parseBytes())