### PR TITLE
Move start and stop blockchain out of .travis.yml into reusable scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,33 +46,7 @@ before_script:
 # macOS/Linux compatible temp dir deleted on reboot (https://stackoverflow.com/a/31397073)
 - |
   if which docker > /dev/null ; then
-    export TM_VERSION=0.21.0
-    export BOV_VERSION=v0.6.0
-    docker pull tendermint/tendermint:${TM_VERSION}
-    docker pull iov1/tendermint:${TM_VERSION}
-    docker pull iov1/bov:${BOV_VERSION}
-    export TENDERMINT_ENABLED=1
-    export BOV_ENABLED=1
-
-    export TM_DIR=$(mktemp -d "${TMPDIR:-/tmp}/tendermint_${TM_VERSION}.XXXXXXXXX")
-    export BOV_DIR=$(mktemp -d "${TMPDIR:-/tmp}/bov_${BOV_VERSION}.XXXXXXXXX")
-    echo "TM_DIR = $TM_DIR"
-    echo "BOV_DIR = $BOV_DIR"
-
-    ./packages/iov-tendermint-rpc/tendermint.sh > /tmp/foo.log &
-    export TM_PID=$!
-    echo "Started tendermint" $TM_PID
-    sleep 2
-
-    ./packages/iov-bns/bov_init.sh
-    ./packages/iov-bns/bov_tm.sh > /tmp/bov_tm.log &
-    export BOV_TM_PID=$!
-    ./packages/iov-bns/bov_app.sh > /tmp/bov_app.log &
-    export BOV_APP_PID=$!
-    sleep 3
-    # for debug output
-    cat /tmp/bov_tm.log
-    cat /tmp/bov_app.log
+    source ./scripts/blockchain_start.sh
   fi
 
 script:
@@ -80,19 +54,7 @@ script:
 - ./scripts/travis.sh
 
 after_script:
-- |
-  if [[ $TM_PID ]]; then
-    echo "Stopping tendermint" $TM_PID
-    kill ${TM_PID}
-  fi
-- |
-  if [[ $BOV_APP_PID ]]; then
-    echo "Stopping bov"
-    kill ${BOV_APP_PID}
-    kill ${BOV_TM_PID}
-    # for debug output
-    cat /tmp/bov_app.log
-  fi
+- source ./scripts/blockchain_start.sh
 
 # whitelist long living branches to avoid testing feature branches twice (as branch and as pull request)
 branches:

--- a/scripts/blockchain_start.sh
+++ b/scripts/blockchain_start.sh
@@ -1,0 +1,30 @@
+# blockchain_start is called in .travis.yml or also locally before running tests
+# to ensure we have all the blockchains set up for the full integration tests
+
+export TM_VERSION=0.21.0
+export BOV_VERSION=v0.6.0
+docker pull tendermint/tendermint:${TM_VERSION}
+docker pull iov1/tendermint:${TM_VERSION}
+docker pull iov1/bov:${BOV_VERSION}
+export TENDERMINT_ENABLED=1
+export BOV_ENABLED=1
+
+export TM_DIR=$(mktemp -d "${TMPDIR:-/tmp}/tendermint_${TM_VERSION}.XXXXXXXXX")
+export BOV_DIR=$(mktemp -d "${TMPDIR:-/tmp}/bov_${BOV_VERSION}.XXXXXXXXX")
+echo "TM_DIR = $TM_DIR"
+echo "BOV_DIR = $BOV_DIR"
+
+./packages/iov-tendermint-rpc/tendermint.sh > /tmp/foo.log &
+export TM_PID=$!
+echo "Started tendermint" $TM_PID
+sleep 2
+
+./packages/iov-bns/bov_init.sh
+./packages/iov-bns/bov_tm.sh > /tmp/bov_tm.log &
+export BOV_TM_PID=$!
+./packages/iov-bns/bov_app.sh > /tmp/bov_app.log &
+export BOV_APP_PID=$!
+sleep 3
+# for debug output
+cat /tmp/bov_tm.log
+cat /tmp/bov_app.log

--- a/scripts/blockchain_stop.sh
+++ b/scripts/blockchain_stop.sh
@@ -1,0 +1,17 @@
+# blockchain_stop is meant to be sourced by .travis.yml or locally after running tests
+
+if [[ $TM_PID ]]; then
+  echo "Stopping tendermint:" $TM_PID
+  kill ${TM_PID}
+  unset TM_PID
+fi
+
+if [[ $BOV_APP_PID ]]; then
+  echo "Stopping bov:" ${BOV_TM_PID} ${BOV_APP_PID}
+  kill ${BOV_APP_PID}
+  kill ${BOV_TM_PID}
+  unset BOV_APP_PID
+  unset BOV_TM_PID
+  # for debug output
+  # cat /tmp/bov_app.log
+fi


### PR DESCRIPTION
This allows for much easier setup/teardown of any tendermint/bcpd/bnsd related tests on the local system.

As I am working on query code against bcpd, this saves me a lot of trouble to verify locally it is passing without waiting for full ci run.