### PR TITLE
Compile on windows

### DIFF
--- a/.gitattibutes
+++ b/.gitattibutes
@@ -1,0 +1,1 @@
+* text=auto

--- a/.gitattibutes
+++ b/.gitattibutes
@@ -1,1 +1,0 @@
-* text=auto

--- a/README.md
+++ b/README.md
@@ -58,6 +58,27 @@ To build the documentation locally, run `yarn install && yarn build && yarn docs
 in this repository. This will generate a `./docs` directory in each package that you
 can browse locally to see API docs on the various packages.
 
+## Developing under Windows 10
+
+Most of the developers working on this project in windows are also using Windows Subsystem for Linux
+(WSL), which should have maximum compatibility, as CI is linux and osx. However, we do attempt to ensure
+that this code also compiles on the normal windows shell, if you have set up git, node, yarn etc. correctly.
+(Note this has only be verified under windows 10, no guarantees for older versions).
+
+### Line endings (CRLF vs LF)
+
+All the code in the repo should use LF not the windows-specific CRLF as a line ending.
+`tsc` is currently set up to output properly. However, you should also make sure your editor
+saves with `LF` line endings rather than `CRLF`.
+
+A bigger issue is `git` changing the endings upon commit. Here is a short workaround,
+adapted from a [stackoverflow discussion](https://stackoverflow.com/questions/2517190/how-do-i-force-git-to-use-lf-instead-of-crlf-under-windows):
+
+```
+git config --global core.autocrlf false
+git config --global core.eol lf
+```
+
 ## FAQ For Potential Issues
 
 ### Libusb fails to build, why?
@@ -72,10 +93,6 @@ the compilation issues are fixed in the `node-pre-gyp` package. This package com
 `@ledger/hw-transport-node-hid` and is not easily modifiable by our team. Once the issues are resolved,
 the hard requirement of this dependency will be removed to allow it to be synchronized with the packages
 that require it.
-
-### Windows issues
-
-
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -42,9 +42,6 @@ CI Tests:
 
 (Node 10 tested on many dev machines)
 
-**Windows note:** The development tools *definitely* work under windows in "Linux subsystem for windows"
-bash shell. They most likely work under cygwin as well. But they do rely on minor shell scripting.
-
 ## Gettting Started
 
 The best way to learn about code is to use it.
@@ -66,7 +63,7 @@ can browse locally to see API docs on the various packages.
 ### Libusb fails to build, why?
 
 If you are running on linux, you may not have the proper dependencies installed. For ubuntu, try the
-following: `sudo apt-get install libudev-dev libusb-1.0-0 libusb-1.0-0-dev`. 
+following: `sudo apt-get install libudev-dev libusb-1.0-0 libusb-1.0-0-dev`.
 These are needed to compile the usb driver.
 
 Currently, Libusb requires node-pre-gyp version `0.10.2` or lower to compile properly. If for some reason
@@ -75,6 +72,10 @@ the compilation issues are fixed in the `node-pre-gyp` package. This package com
 `@ledger/hw-transport-node-hid` and is not easily modifiable by our team. Once the issues are resolved,
 the hard requirement of this dependency will be removed to allow it to be synchronized with the packages
 that require it.
+
+### Windows issues
+
+
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "devDependencies": {
     "@types/jasmine": "^2.8.8",
     "@types/memdown": "^3.0.0",
+    "cross-env": "^5.2.0",
     "jasmine": "^3.1.0",
     "jasmine-console-reporter": "^3.0.2",
     "jasmine-core": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "lerna": "^3.0.0-rc.0",
     "memdown": "^3.0.0",
     "prettier": "^1.12.1",
+    "shx": "^0.3.2",
     "source-map-support": "^0.5.6",
     "tslint": "^5.10.0",
     "tslint-config-prettier": "^1.13.0",

--- a/packages/iov-bcp-types/package.json
+++ b/packages/iov-bcp-types/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "docs": "shx rm -rf docs && typedoc --options typedoc.js",
     "format": "prettier --write --loglevel warn \"./src/**/*.ts\"",
-    "lint": "tslint -t verbose --project . ${TSLINT_FLAGS}",
+    "lint": "cross-env-shell \"tslint -t verbose --project . ${TSLINT_FLAGS}\"",
     "lint-fix": "yarn lint --fix",
     "prebuild": "yarn format && yarn lint",
     "build": "tsc && shx rm ./types/* && shx mv build/*.d.ts ./types",

--- a/packages/iov-bcp-types/package.json
+++ b/packages/iov-bcp-types/package.json
@@ -14,12 +14,12 @@
     "access": "public"
   },
   "scripts": {
-    "docs": "rm -rf docs && typedoc --options typedoc.js",
+    "docs": "shx rm -rf docs && typedoc --options typedoc.js",
     "format": "prettier --write --loglevel warn \"./src/**/*.ts\"",
     "lint": "tslint -t verbose --project . ${TSLINT_FLAGS}",
     "lint-fix": "yarn lint --fix",
     "prebuild": "yarn format && yarn lint",
-    "build": "tsc && rm ./types/* && mv build/*.d.ts ./types",
+    "build": "tsc && shx rm ./types/* && shx mv build/*.d.ts ./types",
     "build-or-skip": "[ -n \"$SKIP_BUILD\" ] || yarn build",
     "test": "echo \"Info: no test specified\""
   },

--- a/packages/iov-bns/package.json
+++ b/packages/iov-bns/package.json
@@ -14,8 +14,8 @@
     "access": "public"
   },
   "scripts": {
-    "docs": "rm -rf docs && typedoc --options typedoc.js",
-    "lint": "tslint -t verbose --project . ${TSLINT_FLAGS}",
+    "docs": "shx rm -rf docs && typedoc --options typedoc.js",
+    "lint": "cross-env-shell \"tslint -t verbose --project . ${TSLINT_FLAGS}\"",
     "format": "prettier --write --loglevel warn \"./src/**/*.ts\"",
     "test-node": "node jasmine-testrunner.js",
     "test-edge": "yarn pack-web && karma start --single-run --browsers Edge",
@@ -24,8 +24,8 @@
     "test-safari": "yarn pack-web && karma start --single-run --browsers Safari",
     "test": "yarn build-or-skip && yarn test-node",
     "prebuild": "yarn format && yarn lint",
-    "move-types": "rm ./types/* && mv build/*.d.ts ./types && rm ./types/*.spec.d.ts",
-    "build": "rm -rf ./build && tsc && cp ./src/codecimpl.js ./src/codecimpl.d.ts ./build && yarn move-types",
+    "move-types": "shx rm ./types/* && shx mv build/*.d.ts ./types && shx rm ./types/*.spec.d.ts",
+    "build": "shx rm -rf ./build && tsc && shx cp ./src/codecimpl.js ./src/codecimpl.d.ts ./build && yarn move-types",
     "build-or-skip": "[ -n \"$SKIP_BUILD\" ] || yarn build",
     "pack-web": "yarn build-or-skip && webpack --mode development --config webpack.web.config.js",
     "find-proto": "find $GOPATH/src/github.com/confio/weave $GOPATH/src/github.com/iov-one/bcp-demo -name '*.proto' -not -path '*/vendor/*' -not -path '*/examples/*'",

--- a/packages/iov-core/package.json
+++ b/packages/iov-core/package.json
@@ -14,8 +14,8 @@
     "access": "public"
   },
   "scripts": {
-    "docs": "rm -rf docs && typedoc --options typedoc.js",
-    "lint": "tslint -t verbose --project . ${TSLINT_FLAGS}",
+    "docs": "shx rm -rf docs && typedoc --options typedoc.js",
+    "lint": "cross-env-shell \"tslint -t verbose --project . ${TSLINT_FLAGS}\"",
     "format": "prettier --write --loglevel warn \"./src/**/*.ts\"",
     "test-node": "node jasmine-testrunner.js",
     "test-edge": "yarn pack-web && karma start --single-run --browsers Edge",
@@ -24,8 +24,8 @@
     "test-safari": "yarn pack-web && karma start --single-run --browsers Safari",
     "test": "yarn build-or-skip && yarn test-node",
     "prebuild": "yarn format && yarn lint",
-    "preprocess-types": "rm -r ./types/*",
-    "postprocess-types": "rm ./types/*.spec.d.ts",
+    "preprocess-types": "shx rm -r ./types/*",
+    "postprocess-types": "shx rm ./types/*.spec.d.ts",
     "build": "yarn preprocess-types && tsc --declarationDir ./types && yarn postprocess-types",
     "build-or-skip": "[ -n \"$SKIP_BUILD\" ] || yarn build",
     "pack-web": "yarn build-or-skip && webpack --mode development --config webpack.web.config.js",

--- a/packages/iov-crypto/package.json
+++ b/packages/iov-crypto/package.json
@@ -14,8 +14,8 @@
     "access": "public"
   },
   "scripts": {
-    "docs": "rm -rf docs && typedoc --options typedoc.js",
-    "lint": "tslint -t verbose --project . ${TSLINT_FLAGS}",
+    "docs": "shx rm -rf docs && typedoc --options typedoc.js",
+    "lint": "cross-env-shell \"tslint -t verbose --project . ${TSLINT_FLAGS}\"",
     "format": "prettier --write --loglevel warn \"./src/**/*.ts\"",
     "test-node": "node jasmine-testrunner.js",
     "test-edge": "yarn pack-web && karma start --single-run --browsers Edge",
@@ -24,7 +24,7 @@
     "test-safari": "yarn pack-web && karma start --single-run --browsers Safari",
     "test": "yarn build-or-skip && yarn test-node",
     "prebuild": "yarn format && yarn lint",
-    "build": "tsc && rm ./types/* && mv build/*.d.ts ./types",
+    "build": "tsc && shx rm ./types/* && shx mv build/*.d.ts ./types",
     "build-or-skip": "[ -n \"$SKIP_BUILD\" ] || yarn build",
     "pack-web": "yarn build-or-skip && webpack --mode development --config webpack.web.config.js"
   },

--- a/packages/iov-encoding/package.json
+++ b/packages/iov-encoding/package.json
@@ -14,8 +14,8 @@
     "access": "public"
   },
   "scripts": {
-    "docs": "rm -rf docs && typedoc --options typedoc.js",
-    "lint": "tslint -t verbose --project . ${TSLINT_FLAGS}",
+    "docs": "shx rm -rf docs && typedoc --options typedoc.js",
+    "lint": "cross-env-shell \"tslint -t verbose --project . ${TSLINT_FLAGS}\"",
     "format": "prettier --write --loglevel warn \"./src/**/*.ts\"",
     "test-node": "node jasmine-testrunner.js",
     "test-edge": "yarn pack-web && karma start --single-run --browsers Edge",
@@ -24,7 +24,7 @@
     "test-safari": "yarn pack-web && karma start --single-run --browsers Safari",
     "test": "yarn build-or-skip && yarn test-node",
     "prebuild": "yarn format && yarn lint",
-    "build": "tsc && rm ./types/* && mv build/*.d.ts ./types",
+    "build": "tsc && shx rm ./types/* && shx mv build/*.d.ts ./types",
     "build-or-skip": "[ -n \"$SKIP_BUILD\" ] || yarn build",
     "pack-web": "yarn build-or-skip && webpack --mode development --config webpack.web.config.js"
   },

--- a/packages/iov-faucets/package.json
+++ b/packages/iov-faucets/package.json
@@ -14,9 +14,9 @@
     "access": "public"
   },
   "scripts": {
-    "docs": "rm -rf docs && typedoc --options typedoc.js",
+    "docs": "shx rm -rf docs && typedoc --options typedoc.js",
     "format": "prettier --write --loglevel warn \"./src/**/*.ts\"",
-    "lint": "tslint -t verbose --project . ${TSLINT_FLAGS}",
+    "lint": "cross-env-shell \"tslint -t verbose --project . ${TSLINT_FLAGS}\"",
     "prebuild": "yarn format && yarn lint",
     "build": "tsc",
     "build-or-skip": "[ -n \"$SKIP_BUILD\" ] || yarn build",

--- a/packages/iov-keycontrol/package.json
+++ b/packages/iov-keycontrol/package.json
@@ -26,7 +26,7 @@
     "test": "yarn build-or-skip && yarn test-node",
     "prebuild": "yarn format && yarn lint",
     "preprocess-types": "shx rm -r ./types/*",
-    "postprocess-types": "shx rm ./types/*.spec.d.ts ./types/**/*.spec.d.ts",
+    "postprocess-types": "shx rm ./types/*.spec.d.ts && shx rm ./types/**/*.spec.d.ts",
     "build": "yarn preprocess-types && tsc --declarationDir ./types && yarn postprocess-types",
     "build-or-skip": "[ -n \"$SKIP_BUILD\" ] || yarn build",
     "pack-web": "yarn build-or-skip && webpack --mode development --config webpack.web.config.js"

--- a/packages/iov-keycontrol/package.json
+++ b/packages/iov-keycontrol/package.json
@@ -14,9 +14,9 @@
     "access": "public"
   },
   "scripts": {
-    "docs": "rm -rf docs && typedoc --options typedoc.js",
+    "docs": "shx rm -rf docs && typedoc --options typedoc.js",
     "format": "prettier --write --loglevel warn \"./src/**/*.ts\"",
-    "lint": "tslint -t verbose --project . ${TSLINT_FLAGS}",
+    "lint": "cross-env-shell \"tslint -t verbose --project . ${TSLINT_FLAGS}\"",
     "lint-fix": "yarn lint --fix",
     "test-node": "node jasmine-testrunner.js",
     "test-edge": "yarn pack-web && karma start --single-run --browsers Edge",
@@ -25,8 +25,8 @@
     "test-safari": "yarn pack-web && karma start --single-run --browsers Safari",
     "test": "yarn build-or-skip && yarn test-node",
     "prebuild": "yarn format && yarn lint",
-    "preprocess-types": "rm -r ./types/*",
-    "postprocess-types": "rm ./types/*.spec.d.ts ./types/**/*.spec.d.ts",
+    "preprocess-types": "shx rm -r ./types/*",
+    "postprocess-types": "shx rm ./types/*.spec.d.ts ./types/**/*.spec.d.ts",
     "build": "yarn preprocess-types && tsc --declarationDir ./types && yarn postprocess-types",
     "build-or-skip": "[ -n \"$SKIP_BUILD\" ] || yarn build",
     "pack-web": "yarn build-or-skip && webpack --mode development --config webpack.web.config.js"

--- a/packages/iov-ledger-bns/package.json
+++ b/packages/iov-ledger-bns/package.json
@@ -14,13 +14,13 @@
     "access": "public"
   },
   "scripts": {
-    "docs": "rm -rf docs && typedoc --options typedoc.js",
-    "lint": "tslint -t verbose --project . ${TSLINT_FLAGS}",
+    "docs": "shx rm -rf docs && typedoc --options typedoc.js",
+    "lint": "cross-env-shell \"tslint -t verbose --project . ${TSLINT_FLAGS}\"",
     "format": "prettier --write --loglevel warn \"./src/**/*.ts\"",
     "test-node": "node jasmine-testrunner.js",
     "test": "yarn build-or-skip && yarn test-node",
     "prebuild": "yarn format && yarn lint",
-    "build": "tsc && rm ./types/* && mv build/*.d.ts ./types",
+    "build": "tsc && shx rm ./types/* && shx mv build/*.d.ts ./types",
     "build-or-skip": "[ -n \"$SKIP_BUILD\" ] || yarn build",
     "listen": "ts-node ./src/scripts/listen.ts | grep -v '^dev'",
     "checkapp": "ts-node ./src/scripts/checkapp.ts | grep -v '^dev'"

--- a/packages/iov-lisk/package.json
+++ b/packages/iov-lisk/package.json
@@ -14,12 +14,12 @@
     "access": "public"
   },
   "scripts": {
-    "docs": "rm -rf docs && typedoc --options typedoc.js",
+    "docs": "shx rm -rf docs && typedoc --options typedoc.js",
     "format": "prettier --write --loglevel warn \"./src/**/*.ts\"",
-    "lint": "tslint -t verbose --project . ${TSLINT_FLAGS}",
+    "lint": "cross-env-shell \"tslint -t verbose --project . ${TSLINT_FLAGS}\"",
     "prebuild": "yarn format && yarn lint",
-    "move-types": "rm ./types/* && mv build/*.d.ts ./types && rm ./types/*.spec.d.ts",
-    "build": "rm -rf ./build && tsc && yarn move-types",
+    "move-types": "shx rm ./types/* && shx mv build/*.d.ts ./types && shx rm ./types/*.spec.d.ts",
+    "build": "shx rm -rf ./build && tsc && yarn move-types",
     "build-or-skip": "[ -n \"$SKIP_BUILD\" ] || yarn build",
     "test-node": "node jasmine-testrunner.js",
     "test-edge": "yarn pack-web && karma start --single-run --browsers Edge",

--- a/packages/iov-stream/package.json
+++ b/packages/iov-stream/package.json
@@ -14,8 +14,8 @@
     "access": "public"
   },
   "scripts": {
-    "docs": "rm -rf docs && typedoc --options typedoc.js",
-    "lint": "tslint -t verbose --project .",
+    "docs": "shx rm -rf docs && typedoc --options typedoc.js",
+    "lint": "cross-env-shell \"tslint -t verbose --project .\"",
     "format": "prettier --write --loglevel warn \"./src/**/*.ts\"",
     "test-node": "node jasmine-testrunner.js",
     "test-edge": "yarn pack-web && karma start --single-run --browsers Edge",
@@ -24,8 +24,8 @@
     "test-safari": "yarn pack-web && karma start --single-run --browsers Safari",
     "test": "yarn build-or-skip && yarn test-node",
     "prebuild": "yarn format && yarn lint",
-    "preprocess-types": "rm -r ./types/*",
-    "postprocess-types": "rm ./types/*.spec.d.ts",
+    "preprocess-types": "shx rm -r ./types/*",
+    "postprocess-types": "shx rm ./types/*.spec.d.ts",
     "build": "yarn preprocess-types && tsc --declarationDir ./types && yarn postprocess-types",
     "build-or-skip": "[ -n \"$SKIP_BUILD\" ] || yarn build",
     "pack-web": "yarn build-or-skip && webpack --mode development --config webpack.web.config.js"

--- a/packages/iov-tendermint-rpc/package.json
+++ b/packages/iov-tendermint-rpc/package.json
@@ -14,8 +14,8 @@
     "access": "public"
   },
   "scripts": {
-    "docs": "rm -rf docs && typedoc --options typedoc.js",
-    "lint": "tslint -t verbose --project . ${TSLINT_FLAGS}",
+    "docs": "shx rm -rf docs && typedoc --options typedoc.js",
+    "lint": "cross-env-shell \"tslint -t verbose --project . ${TSLINT_FLAGS}\"",
     "format": "prettier --write --loglevel warn \"./src/**/*.ts\"",
     "test-node": "node jasmine-testrunner.js",
     "test-edge": "yarn pack-web && karma start --single-run --browsers Edge",
@@ -24,7 +24,7 @@
     "test-safari": "yarn pack-web && karma start --single-run --browsers Safari",
     "test": "yarn build-or-skip && yarn test-node",
     "prebuild": "yarn format && yarn lint",
-    "build": "rm -rf build && tsc",
+    "build": "shx rm -rf build && tsc",
     "build-or-skip": "[ -n \"$SKIP_BUILD\" ] || yarn build",
     "pack-web": "yarn build-or-skip && webpack --mode development --config webpack.web.config.js"
   },

--- a/packages/iov-tendermint-types/package.json
+++ b/packages/iov-tendermint-types/package.json
@@ -14,12 +14,12 @@
     "access": "public"
   },
   "scripts": {
-    "docs": "rm -rf docs && typedoc --options typedoc.js",
+    "docs": "shx rm -rf docs && typedoc --options typedoc.js",
     "format": "prettier --write --loglevel warn \"./src/**/*.ts\"",
-    "lint": "tslint -t verbose --project . ${TSLINT_FLAGS}",
+    "lint": "cross-env-shell \"tslint -t verbose --project . ${TSLINT_FLAGS}\"",
     "lint-fix": "yarn lint --fix",
     "prebuild": "yarn format && yarn lint",
-    "build": "tsc && rm ./types/* && mv build/*.d.ts ./types",
+    "build": "tsc && shx rm ./types/* && shx mv build/*.d.ts ./types",
     "build-or-skip": "[ -n \"$SKIP_BUILD\" ] || yarn build",
     "test": "echo \"Info: no test specified\""
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "forceConsistentCasingInFileNames": true,
     "module": "commonjs",
     "moduleResolution": "node",
+    "newLine": "LF",
     "noEmitOnError": true,
     "noFallthroughCasesInSwitch": true,
     "noImplicitReturns": true,
@@ -18,6 +19,6 @@
     "typeRoots": [
       "./node_modules/@types",
       "./custom_types"
-    ]    
+    ]
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2172,6 +2172,14 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
+cross-env@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-5.2.0.tgz#6ecd4c015d5773e614039ee529076669b9d126f2"
+  integrity sha512-jtdNFfFW1hB7sMhr/H6rW1Z45LFqyI431m3qU6bFXcQ3Eh7LtBuG3h74o7ohHZ3crrRkkqHlo4jYHFPcjroANg==
+  dependencies:
+    cross-spawn "^6.0.5"
+    is-windows "^1.0.0"
+
 cross-spawn@^5.0.1:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
@@ -2181,7 +2189,7 @@ cross-spawn@^5.0.1:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
-cross-spawn@^6.0.0:
+cross-spawn@^6.0.0, cross-spawn@^6.0.5:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
   integrity sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==
@@ -3866,7 +3874,7 @@ is-utf8@^0.2.0:
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
   integrity sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=
 
-is-windows@^1.0.2:
+is-windows@^1.0.0, is-windows@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
   integrity sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2662,6 +2662,11 @@ es6-iterator@~2.0.3:
     es5-ext "^0.10.35"
     es6-symbol "^3.1.1"
 
+es6-object-assign@^1.0.3:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/es6-object-assign/-/es6-object-assign-1.1.0.tgz#c2c3582656247c39ea107cb1e6652b6f9f24523c"
+  integrity sha1-wsNYJlYkfDnqEHyx5mUrb58kUjw=
+
 es6-promise@^4.0.3:
   version "4.2.5"
   resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.5.tgz#da6d0d5692efb461e082c14817fe2427d8f5d054"
@@ -6184,7 +6189,7 @@ shebang-regex@^1.0.0:
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
   integrity sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=
 
-shelljs@^0.8.2:
+shelljs@^0.8.1, shelljs@^0.8.2:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.2.tgz#345b7df7763f4c2340d584abb532c5f752ca9e35"
   integrity sha512-pRXeNrCA2Wd9itwhvLp5LZQvPJ0wU6bcjaTMywHHGX5XWhVN2nzSu7WV0q+oUY7mGK3mgSkDDzP3MgjqdyIgbQ==
@@ -6192,6 +6197,15 @@ shelljs@^0.8.2:
     glob "^7.0.0"
     interpret "^1.0.0"
     rechoir "^0.6.2"
+
+shx@^0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/shx/-/shx-0.3.2.tgz#40501ce14eb5e0cbcac7ddbd4b325563aad8c123"
+  integrity sha512-aS0mWtW3T2sHAenrSrip2XGv39O9dXIFUqxAEWHEOS1ePtGIBavdPJY1kE2IHl14V/4iCbUiNDPGdyYTtmhSoA==
+  dependencies:
+    es6-object-assign "^1.0.3"
+    minimist "^1.2.0"
+    shelljs "^0.8.1"
 
 signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"


### PR DESCRIPTION
Resolves #319 

Most of the scripts in package.json have errors on the normal window shell. Since this is also causing issues with my vscode integration, I finally set out to fix it. Inspired by the approach from rxjs: https://github.com/ReactiveX/rxjs/pull/1681/files I went ahead and added shx and cross-env to handle the cross-platform issues, while allowing us to retain the same functionality (mainly just prefixing the commands).

I verified on a normal windows shell that the following works:

- [x] yarn build (in root directory, using lerna)
- [x] yarn build-or-skip (doesn't like `[ -n \"$SKIP_BUILD\" ]` but always executes `yarn build`)
- [x] yarn test
- [x] yarn test-chrome
- [x] yarn test-edge

I think `find-proto` in `iov-bns` doesn't work, but this is really a preprocessor that no one except bns protobuf developers need to worry about.
