### PR TITLE
Define types, reader for atomic swap 

### DIFF
--- a/packages/iov-bcp-types/src/atomicswap.ts
+++ b/packages/iov-bcp-types/src/atomicswap.ts
@@ -50,7 +50,7 @@ export interface BcpSwapSenderQuery {
 }
 
 export interface BcpSwapIdQuery {
-  readonly id: SwapIdBytes;
+  readonly swapid: SwapIdBytes;
 }
 
 // can we implement this as well? maybe id should equal swap
@@ -59,6 +59,19 @@ export interface BcpSwapIdQuery {
 // }
 
 export type BcpSwapQuery = BcpSwapRecipientQuery | BcpSwapSenderQuery | BcpSwapIdQuery;
+
+// isQueryBySwapRecipient is a type guard to use in the swap-based queries
+export function isQueryBySwapRecipient(query: BcpSwapQuery): query is BcpSwapRecipientQuery {
+  return (query as BcpSwapRecipientQuery).recipient !== undefined;
+}
+// isQueryBySwapSender is a type guard to use in the swap-based queries
+export function isQueryBySwapSender(query: BcpSwapQuery): query is BcpSwapSenderQuery {
+  return (query as BcpSwapSenderQuery).sender !== undefined;
+}
+// isQueryBySwapId is a type guard to use in the swap-based queries
+export function isQueryBySwapId(query: BcpSwapQuery): query is BcpSwapIdQuery {
+  return (query as BcpSwapIdQuery).swapid !== undefined;
+}
 
 export interface BcpSwapEvent {
   readonly height: number;
@@ -79,4 +92,13 @@ export interface BcpAtomicSwapConnection extends BcpConnection {
   // changeSwap triggers an event when a matching swap event occurs.
   // it emits the new height as well as the swap that was modified
   readonly changeSwap: (swap: BcpSwapQuery) => Stream<BcpSwapEvent>;
+}
+
+export function isAtomicSwapConnection(conn: BcpConnection): conn is BcpAtomicSwapConnection {
+  const check = conn as BcpAtomicSwapConnection;
+  return (
+    typeof check.getSwap === "function" &&
+    typeof check.watchSwap === "function" &&
+    typeof check.changeSwap === "function"
+  );
 }

--- a/packages/iov-bcp-types/src/atomicswap.ts
+++ b/packages/iov-bcp-types/src/atomicswap.ts
@@ -1,0 +1,82 @@
+import { Stream } from "xstream";
+
+import { BcpCoin, BcpConnection, BcpQueryEnvelope } from "./bcp";
+import { Address, TransactionIdBytes } from "./signables";
+import { SwapIdBytes } from "./transactions";
+
+export enum SwapState {
+  OPEN = "open",
+  CLAIMED = "claimed",
+  EXPIRED = "expired",
+}
+
+export interface SwapData {
+  readonly id: SwapIdBytes; // this is used as an unique identitier to locate the swap
+  readonly sender: Address;
+  readonly recipient: Address;
+  readonly hashlock: Uint8Array; // this is the hash, whose preimage releases the swap
+  readonly amount: ReadonlyArray<BcpCoin>;
+  readonly timeout: number; // blockheight where the swap expires (TODO: alternatively support Date?)
+  readonly memo?: string;
+}
+
+// OpenSwap is an offer that has not yet been claimed
+export interface OpenSwap {
+  readonly kind: SwapState.OPEN;
+  readonly data: SwapData;
+}
+
+// ClosedSwap is returned once the swap has been claimed, exposing the preimage that was used to claim it
+export interface ClaimedSwap {
+  readonly kind: SwapState.CLAIMED;
+  readonly data: SwapData;
+  readonly preimage: Uint8Array;
+}
+
+// ExpiredSwap is an offer that timed out without being claimed
+export interface ExpiredSwap {
+  readonly kind: SwapState.EXPIRED;
+  readonly data: SwapData;
+}
+
+export type BcpAtomicSwap = OpenSwap | ClaimedSwap | ExpiredSwap;
+
+export interface BcpSwapRecipientQuery {
+  readonly recipient: Address;
+}
+
+export interface BcpSwapSenderQuery {
+  readonly sender: Address;
+}
+
+export interface BcpSwapIdQuery {
+  readonly id: SwapIdBytes;
+}
+
+// can we implement this as well? maybe id should equal swap
+// export interface SwapHashQuery {
+//   readonly hashlock: Uint8Array;
+// }
+
+export type BcpSwapQuery = BcpSwapRecipientQuery | BcpSwapSenderQuery | BcpSwapIdQuery;
+
+export interface BcpSwapEvent {
+  readonly height: number;
+  readonly swapid: SwapIdBytes; // the id of the swap that changed
+  readonly txid: TransactionIdBytes; // the id of the transaction that modified it
+}
+
+// BcpAtomicSwapConnection is an optional extension to the base BcpConnection
+// It allows querying and watching atomic swaps
+export interface BcpAtomicSwapConnection extends BcpConnection {
+  // getSwap returns all matching swaps in their current state
+  readonly getSwap: (swap: BcpSwapQuery) => Promise<BcpQueryEnvelope<BcpAtomicSwap>>;
+
+  // watchSwap emits currentState (getSwap) as a stream, then sends updates for any matching swap
+  // this includes an open swap beind claimed/expired as well as a new matching swap being offered
+  readonly watchSwap: (swap: BcpSwapQuery) => Stream<BcpAtomicSwap>;
+
+  // changeSwap triggers an event when a matching swap event occurs.
+  // it emits the new height as well as the swap that was modified
+  readonly changeSwap: (swap: BcpSwapQuery) => Stream<BcpSwapEvent>;
+}

--- a/packages/iov-bcp-types/src/atomicswap.ts
+++ b/packages/iov-bcp-types/src/atomicswap.ts
@@ -1,7 +1,7 @@
 import { Stream } from "xstream";
 
 import { BcpCoin, BcpConnection, BcpQueryEnvelope } from "./bcp";
-import { Address, TransactionIdBytes } from "./signables";
+import { Address } from "./signables";
 import { SwapIdBytes } from "./transactions";
 
 export enum SwapState {
@@ -73,12 +73,6 @@ export function isQueryBySwapId(query: BcpSwapQuery): query is BcpSwapIdQuery {
   return (query as BcpSwapIdQuery).swapid !== undefined;
 }
 
-export interface BcpSwapEvent {
-  readonly height: number;
-  readonly swapid: SwapIdBytes; // the id of the swap that changed
-  readonly txid: TransactionIdBytes; // the id of the transaction that modified it
-}
-
 // BcpAtomicSwapConnection is an optional extension to the base BcpConnection
 // It allows querying and watching atomic swaps
 export interface BcpAtomicSwapConnection extends BcpConnection {
@@ -88,17 +82,9 @@ export interface BcpAtomicSwapConnection extends BcpConnection {
   // watchSwap emits currentState (getSwap) as a stream, then sends updates for any matching swap
   // this includes an open swap beind claimed/expired as well as a new matching swap being offered
   readonly watchSwap: (swap: BcpSwapQuery) => Stream<BcpAtomicSwap>;
-
-  // changeSwap triggers an event when a matching swap event occurs.
-  // it emits the new height as well as the swap that was modified
-  readonly changeSwap: (swap: BcpSwapQuery) => Stream<BcpSwapEvent>;
 }
 
 export function isAtomicSwapConnection(conn: BcpConnection): conn is BcpAtomicSwapConnection {
   const check = conn as BcpAtomicSwapConnection;
-  return (
-    typeof check.getSwap === "function" &&
-    typeof check.watchSwap === "function" &&
-    typeof check.changeSwap === "function"
-  );
+  return typeof check.getSwap === "function" && typeof check.watchSwap === "function";
 }

--- a/packages/iov-bcp-types/src/atomicswap.ts
+++ b/packages/iov-bcp-types/src/atomicswap.ts
@@ -5,9 +5,9 @@ import { Address } from "./signables";
 import { SwapIdBytes } from "./transactions";
 
 export enum SwapState {
-  OPEN = "open",
-  CLAIMED = "claimed",
-  EXPIRED = "expired",
+  Open = "open",
+  Claimed = "claimed",
+  Expired = "expired",
 }
 
 export interface SwapData {
@@ -22,20 +22,20 @@ export interface SwapData {
 
 // OpenSwap is an offer that has not yet been claimed
 export interface OpenSwap {
-  readonly kind: SwapState.OPEN;
+  readonly kind: SwapState.Open;
   readonly data: SwapData;
 }
 
 // ClosedSwap is returned once the swap has been claimed, exposing the preimage that was used to claim it
 export interface ClaimedSwap {
-  readonly kind: SwapState.CLAIMED;
+  readonly kind: SwapState.Claimed;
   readonly data: SwapData;
   readonly preimage: Uint8Array;
 }
 
 // ExpiredSwap is an offer that timed out without being claimed
 export interface ExpiredSwap {
-  readonly kind: SwapState.EXPIRED;
+  readonly kind: SwapState.Expired;
   readonly data: SwapData;
 }
 

--- a/packages/iov-bcp-types/src/bcp.ts
+++ b/packages/iov-bcp-types/src/bcp.ts
@@ -17,6 +17,17 @@ export interface BcpQueryEnvelope<T> {
   readonly data: ReadonlyArray<T>;
 }
 
+// dummyEnvelope just adds some plausible metadata to make bcp happy
+export function dummyEnvelope<T>(data: ReadonlyArray<T>): BcpQueryEnvelope<T> {
+  return {
+    metadata: {
+      offset: 0,
+      limit: 100,
+    },
+    data: data,
+  };
+}
+
 export interface BcpQueryMetadata {
   readonly offset: number;
   readonly limit: number;
@@ -76,6 +87,11 @@ export interface BcpValueNameQuery {
 }
 
 export type BcpAccountQuery = BcpAddressQuery | BcpValueNameQuery;
+
+// isQueryByAddress is a type guard to use in the account-based queries
+export function isQueryByAddress(query: BcpAccountQuery): query is BcpAddressQuery {
+  return (query as BcpAddressQuery).address !== undefined;
+}
 
 // BcpConnection is a high-level interface to a blockchain node,
 // abstracted over all blockchain types and communication channel.

--- a/packages/iov-bcp-types/src/bcp.ts
+++ b/packages/iov-bcp-types/src/bcp.ts
@@ -60,6 +60,15 @@ export interface BcpTransactionResponse {
   };
 }
 
+export interface ConfirmedTransaction extends SignedTransaction {
+  readonly height: number; // the block it was written to
+  readonly txid: TxId; // a unique identifier (hash of the data)
+  // Data from executing tx (result, code, tags...)
+  readonly result: Uint8Array;
+  readonly log: string;
+  // readonly tags: ReadonlyArray<Tag>;
+}
+
 export interface BcpAddressQuery {
   readonly address: Address;
 }
@@ -70,15 +79,20 @@ export interface BcpValueNameQuery {
 
 export type BcpAccountQuery = BcpAddressQuery | BcpValueNameQuery;
 
-// IovReader is a high-level interface to a blockchain node,
+// BcpConnection is a high-level interface to a blockchain node,
 // abstracted over all blockchain types and communication channel.
 // A direct connection or a proxy server should implement this.
 // The implementation takes care to convert our internal types into
 // the proper format for the blockchain.
 //
-// The IovReader will most likely contain some private state to maintain
-// the connection, subscription, and such.
-export interface IovReader {
+// BcpConnection is the minimal interface needed to be supported by any blockchain
+// that is compatible with the bcp spec and iov-core library. This supports
+// getting account balances, sending tokens, and observing the blockchain state.
+//
+// There are other optional interfaces that extend this functionality with
+// features like atomic swap, NFTs, etc which may be implemented by any connector
+// to enable enhanced features in the clients
+export interface BcpConnection {
   readonly disconnect: () => void;
 
   // // headers returns all headers in that range.
@@ -120,20 +134,9 @@ export interface IovReader {
 
   // searchTx searches for all tx that match these tags and subscribes to new ones
   readonly searchTx: (query: TxQuery) => Promise<ReadonlyArray<ConfirmedTransaction>>;
-
   // listenTx subscribes to all newly added transactions with these tags
   readonly listenTx: (tags: ReadonlyArray<Tag>) => Stream<ConfirmedTransaction>;
-
   // liveTx returns a stream for all historical transactions that match
   // the query, along with all new transactions arriving from listenTx
   readonly liveTx: (txQuery: TxQuery) => Stream<ConfirmedTransaction>;
-}
-
-export interface ConfirmedTransaction extends SignedTransaction {
-  readonly height: number; // the block it was written to
-  readonly txid: TxId; // a unique identifier (hash of the data)
-  // Data from executing tx (result, code, tags...)
-  readonly result: Uint8Array;
-  readonly log: string;
-  // readonly tags: ReadonlyArray<Tag>;
 }

--- a/packages/iov-bcp-types/src/bcp.ts
+++ b/packages/iov-bcp-types/src/bcp.ts
@@ -88,8 +88,8 @@ export interface BcpValueNameQuery {
 
 export type BcpAccountQuery = BcpAddressQuery | BcpValueNameQuery;
 
-// isQueryByAddress is a type guard to use in the account-based queries
-export function isQueryByAddress(query: BcpAccountQuery): query is BcpAddressQuery {
+// a type checker to use in the account-based queries
+export function isAddressQuery(query: BcpAccountQuery): query is BcpAddressQuery {
   return (query as BcpAddressQuery).address !== undefined;
 }
 

--- a/packages/iov-bcp-types/src/bcp.ts
+++ b/packages/iov-bcp-types/src/bcp.ts
@@ -127,6 +127,10 @@ export interface BcpConnection {
   readonly chainId: () => Promise<ChainId>;
   readonly height: () => Promise<number>;
 
+  // these emits the new blockHeight on every block,
+  // so you can trigger a custom response
+  readonly changeBlock: () => Stream<number>;
+
   // submitTx submits a signed tx as is notified on every state change
   readonly postTx: (tx: PostableBytes) => Promise<BcpTransactionResponse>;
 
@@ -135,12 +139,6 @@ export interface BcpConnection {
   readonly getAllTickers: () => Promise<BcpQueryEnvelope<BcpTicker>>;
   readonly getAccount: (account: BcpAccountQuery) => Promise<BcpQueryEnvelope<BcpAccount>>;
   readonly getNonce: (account: BcpAccountQuery) => Promise<BcpQueryEnvelope<BcpNonce>>;
-
-  // these return a blockheight for any change, so you can trigger
-  // a custom response (changeBlock emits on every block)
-  readonly changeBalance: (addr: Address) => Stream<number>;
-  readonly changeNonce: (addr: Address) => Stream<number>;
-  readonly changeBlock: () => Stream<number>;
 
   // these query the currenct value and update a new value every time it changes
   readonly watchAccount: (account: BcpAccountQuery) => Stream<BcpAccount | undefined>;

--- a/packages/iov-bcp-types/src/bcp.ts
+++ b/packages/iov-bcp-types/src/bcp.ts
@@ -12,7 +12,7 @@ https://app.swaggerhub.com/apis/IOV.one/BOV/0.0.4#/basic/getAccounts
 Only a subset currently implemented.
 */
 
-export interface BcpQueryEnvelope<T extends BcpData> {
+export interface BcpQueryEnvelope<T> {
   readonly metadata: BcpQueryMetadata;
   readonly data: ReadonlyArray<T>;
 }
@@ -21,8 +21,6 @@ export interface BcpQueryMetadata {
   readonly offset: number;
   readonly limit: number;
 }
-
-export type BcpData = BcpAccount | BcpNonce | BcpTicker;
 
 export interface BcpAccount {
   readonly address: Address;

--- a/packages/iov-bcp-types/src/index.ts
+++ b/packages/iov-bcp-types/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./atomicswap";
 export * from "./bcp";
 export * from "./signables";
 export * from "./transactions";

--- a/packages/iov-bcp-types/types/atomicswap.d.ts
+++ b/packages/iov-bcp-types/types/atomicswap.d.ts
@@ -3,9 +3,9 @@ import { BcpCoin, BcpConnection, BcpQueryEnvelope } from "./bcp";
 import { Address } from "./signables";
 import { SwapIdBytes } from "./transactions";
 export declare enum SwapState {
-    OPEN = "open",
-    CLAIMED = "claimed",
-    EXPIRED = "expired"
+    Open = "open",
+    Claimed = "claimed",
+    Expired = "expired"
 }
 export interface SwapData {
     readonly id: SwapIdBytes;
@@ -17,16 +17,16 @@ export interface SwapData {
     readonly memo?: string;
 }
 export interface OpenSwap {
-    readonly kind: SwapState.OPEN;
+    readonly kind: SwapState.Open;
     readonly data: SwapData;
 }
 export interface ClaimedSwap {
-    readonly kind: SwapState.CLAIMED;
+    readonly kind: SwapState.Claimed;
     readonly data: SwapData;
     readonly preimage: Uint8Array;
 }
 export interface ExpiredSwap {
-    readonly kind: SwapState.EXPIRED;
+    readonly kind: SwapState.Expired;
     readonly data: SwapData;
 }
 export declare type BcpAtomicSwap = OpenSwap | ClaimedSwap | ExpiredSwap;

--- a/packages/iov-bcp-types/types/atomicswap.d.ts
+++ b/packages/iov-bcp-types/types/atomicswap.d.ts
@@ -1,6 +1,6 @@
 import { Stream } from "xstream";
 import { BcpCoin, BcpConnection, BcpQueryEnvelope } from "./bcp";
-import { Address, TransactionIdBytes } from "./signables";
+import { Address } from "./signables";
 import { SwapIdBytes } from "./transactions";
 export declare enum SwapState {
     OPEN = "open",
@@ -43,14 +43,8 @@ export declare type BcpSwapQuery = BcpSwapRecipientQuery | BcpSwapSenderQuery | 
 export declare function isQueryBySwapRecipient(query: BcpSwapQuery): query is BcpSwapRecipientQuery;
 export declare function isQueryBySwapSender(query: BcpSwapQuery): query is BcpSwapSenderQuery;
 export declare function isQueryBySwapId(query: BcpSwapQuery): query is BcpSwapIdQuery;
-export interface BcpSwapEvent {
-    readonly height: number;
-    readonly swapid: SwapIdBytes;
-    readonly txid: TransactionIdBytes;
-}
 export interface BcpAtomicSwapConnection extends BcpConnection {
     readonly getSwap: (swap: BcpSwapQuery) => Promise<BcpQueryEnvelope<BcpAtomicSwap>>;
     readonly watchSwap: (swap: BcpSwapQuery) => Stream<BcpAtomicSwap>;
-    readonly changeSwap: (swap: BcpSwapQuery) => Stream<BcpSwapEvent>;
 }
 export declare function isAtomicSwapConnection(conn: BcpConnection): conn is BcpAtomicSwapConnection;

--- a/packages/iov-bcp-types/types/atomicswap.d.ts
+++ b/packages/iov-bcp-types/types/atomicswap.d.ts
@@ -37,9 +37,12 @@ export interface BcpSwapSenderQuery {
     readonly sender: Address;
 }
 export interface BcpSwapIdQuery {
-    readonly id: SwapIdBytes;
+    readonly swapid: SwapIdBytes;
 }
 export declare type BcpSwapQuery = BcpSwapRecipientQuery | BcpSwapSenderQuery | BcpSwapIdQuery;
+export declare function isQueryBySwapRecipient(query: BcpSwapQuery): query is BcpSwapRecipientQuery;
+export declare function isQueryBySwapSender(query: BcpSwapQuery): query is BcpSwapSenderQuery;
+export declare function isQueryBySwapId(query: BcpSwapQuery): query is BcpSwapIdQuery;
 export interface BcpSwapEvent {
     readonly height: number;
     readonly swapid: SwapIdBytes;
@@ -50,3 +53,4 @@ export interface BcpAtomicSwapConnection extends BcpConnection {
     readonly watchSwap: (swap: BcpSwapQuery) => Stream<BcpAtomicSwap>;
     readonly changeSwap: (swap: BcpSwapQuery) => Stream<BcpSwapEvent>;
 }
+export declare function isAtomicSwapConnection(conn: BcpConnection): conn is BcpAtomicSwapConnection;

--- a/packages/iov-bcp-types/types/atomicswap.d.ts
+++ b/packages/iov-bcp-types/types/atomicswap.d.ts
@@ -1,0 +1,52 @@
+import { Stream } from "xstream";
+import { BcpCoin, BcpConnection, BcpQueryEnvelope } from "./bcp";
+import { Address, TransactionIdBytes } from "./signables";
+import { SwapIdBytes } from "./transactions";
+export declare enum SwapState {
+    OPEN = "open",
+    CLAIMED = "claimed",
+    EXPIRED = "expired"
+}
+export interface SwapData {
+    readonly id: SwapIdBytes;
+    readonly sender: Address;
+    readonly recipient: Address;
+    readonly hashlock: Uint8Array;
+    readonly amount: ReadonlyArray<BcpCoin>;
+    readonly timeout: number;
+    readonly memo?: string;
+}
+export interface OpenSwap {
+    readonly kind: SwapState.OPEN;
+    readonly data: SwapData;
+}
+export interface ClaimedSwap {
+    readonly kind: SwapState.CLAIMED;
+    readonly data: SwapData;
+    readonly preimage: Uint8Array;
+}
+export interface ExpiredSwap {
+    readonly kind: SwapState.EXPIRED;
+    readonly data: SwapData;
+}
+export declare type BcpAtomicSwap = OpenSwap | ClaimedSwap | ExpiredSwap;
+export interface BcpSwapRecipientQuery {
+    readonly recipient: Address;
+}
+export interface BcpSwapSenderQuery {
+    readonly sender: Address;
+}
+export interface BcpSwapIdQuery {
+    readonly id: SwapIdBytes;
+}
+export declare type BcpSwapQuery = BcpSwapRecipientQuery | BcpSwapSenderQuery | BcpSwapIdQuery;
+export interface BcpSwapEvent {
+    readonly height: number;
+    readonly swapid: SwapIdBytes;
+    readonly txid: TransactionIdBytes;
+}
+export interface BcpAtomicSwapConnection extends BcpConnection {
+    readonly getSwap: (swap: BcpSwapQuery) => Promise<BcpQueryEnvelope<BcpAtomicSwap>>;
+    readonly watchSwap: (swap: BcpSwapQuery) => Stream<BcpAtomicSwap>;
+    readonly changeSwap: (swap: BcpSwapQuery) => Stream<BcpSwapEvent>;
+}

--- a/packages/iov-bcp-types/types/bcp.d.ts
+++ b/packages/iov-bcp-types/types/bcp.d.ts
@@ -59,14 +59,12 @@ export interface BcpConnection {
     readonly disconnect: () => void;
     readonly chainId: () => Promise<ChainId>;
     readonly height: () => Promise<number>;
+    readonly changeBlock: () => Stream<number>;
     readonly postTx: (tx: PostableBytes) => Promise<BcpTransactionResponse>;
     readonly getTicker: (ticker: TokenTicker) => Promise<BcpQueryEnvelope<BcpTicker>>;
     readonly getAllTickers: () => Promise<BcpQueryEnvelope<BcpTicker>>;
     readonly getAccount: (account: BcpAccountQuery) => Promise<BcpQueryEnvelope<BcpAccount>>;
     readonly getNonce: (account: BcpAccountQuery) => Promise<BcpQueryEnvelope<BcpNonce>>;
-    readonly changeBalance: (addr: Address) => Stream<number>;
-    readonly changeNonce: (addr: Address) => Stream<number>;
-    readonly changeBlock: () => Stream<number>;
     readonly watchAccount: (account: BcpAccountQuery) => Stream<BcpAccount | undefined>;
     readonly watchNonce: (account: BcpAccountQuery) => Stream<BcpNonce | undefined>;
     readonly searchTx: (query: TxQuery) => Promise<ReadonlyArray<ConfirmedTransaction>>;

--- a/packages/iov-bcp-types/types/bcp.d.ts
+++ b/packages/iov-bcp-types/types/bcp.d.ts
@@ -2,7 +2,7 @@ import { Stream } from "xstream";
 import { ChainId, PostableBytes, PublicKeyBundle, Tag, TxId, TxQuery } from "@iov/tendermint-types";
 import { Address, SignedTransaction } from "./signables";
 import { Nonce, TokenTicker } from "./transactions";
-export interface BcpQueryEnvelope<T extends BcpData> {
+export interface BcpQueryEnvelope<T> {
     readonly metadata: BcpQueryMetadata;
     readonly data: ReadonlyArray<T>;
 }
@@ -10,7 +10,6 @@ export interface BcpQueryMetadata {
     readonly offset: number;
     readonly limit: number;
 }
-export declare type BcpData = BcpAccount | BcpNonce | BcpTicker;
 export interface BcpAccount {
     readonly address: Address;
     readonly name?: string;

--- a/packages/iov-bcp-types/types/bcp.d.ts
+++ b/packages/iov-bcp-types/types/bcp.d.ts
@@ -41,6 +41,12 @@ export interface BcpTransactionResponse {
         readonly result: Uint8Array;
     };
 }
+export interface ConfirmedTransaction extends SignedTransaction {
+    readonly height: number;
+    readonly txid: TxId;
+    readonly result: Uint8Array;
+    readonly log: string;
+}
 export interface BcpAddressQuery {
     readonly address: Address;
 }
@@ -48,7 +54,7 @@ export interface BcpValueNameQuery {
     readonly name: string;
 }
 export declare type BcpAccountQuery = BcpAddressQuery | BcpValueNameQuery;
-export interface IovReader {
+export interface BcpConnection {
     readonly disconnect: () => void;
     readonly chainId: () => Promise<ChainId>;
     readonly height: () => Promise<number>;
@@ -65,10 +71,4 @@ export interface IovReader {
     readonly searchTx: (query: TxQuery) => Promise<ReadonlyArray<ConfirmedTransaction>>;
     readonly listenTx: (tags: ReadonlyArray<Tag>) => Stream<ConfirmedTransaction>;
     readonly liveTx: (txQuery: TxQuery) => Stream<ConfirmedTransaction>;
-}
-export interface ConfirmedTransaction extends SignedTransaction {
-    readonly height: number;
-    readonly txid: TxId;
-    readonly result: Uint8Array;
-    readonly log: string;
 }

--- a/packages/iov-bcp-types/types/bcp.d.ts
+++ b/packages/iov-bcp-types/types/bcp.d.ts
@@ -54,7 +54,7 @@ export interface BcpValueNameQuery {
     readonly name: string;
 }
 export declare type BcpAccountQuery = BcpAddressQuery | BcpValueNameQuery;
-export declare function isQueryByAddress(query: BcpAccountQuery): query is BcpAddressQuery;
+export declare function isAddressQuery(query: BcpAccountQuery): query is BcpAddressQuery;
 export interface BcpConnection {
     readonly disconnect: () => void;
     readonly chainId: () => Promise<ChainId>;

--- a/packages/iov-bcp-types/types/bcp.d.ts
+++ b/packages/iov-bcp-types/types/bcp.d.ts
@@ -6,6 +6,7 @@ export interface BcpQueryEnvelope<T> {
     readonly metadata: BcpQueryMetadata;
     readonly data: ReadonlyArray<T>;
 }
+export declare function dummyEnvelope<T>(data: ReadonlyArray<T>): BcpQueryEnvelope<T>;
 export interface BcpQueryMetadata {
     readonly offset: number;
     readonly limit: number;
@@ -53,6 +54,7 @@ export interface BcpValueNameQuery {
     readonly name: string;
 }
 export declare type BcpAccountQuery = BcpAddressQuery | BcpValueNameQuery;
+export declare function isQueryByAddress(query: BcpAccountQuery): query is BcpAddressQuery;
 export interface BcpConnection {
     readonly disconnect: () => void;
     readonly chainId: () => Promise<ChainId>;

--- a/packages/iov-bcp-types/types/index.d.ts
+++ b/packages/iov-bcp-types/types/index.d.ts
@@ -1,3 +1,4 @@
+export * from "./atomicswap";
 export * from "./bcp";
 export * from "./signables";
 export * from "./transactions";

--- a/packages/iov-bns/src/client.ts
+++ b/packages/iov-bns/src/client.ts
@@ -4,14 +4,13 @@ import {
   Address,
   BcpAccount,
   BcpAccountQuery,
-  BcpAddressQuery,
   BcpConnection,
-  BcpData,
   BcpNonce,
   BcpQueryEnvelope,
   BcpTicker,
   BcpTransactionResponse,
   ConfirmedTransaction,
+  dummyEnvelope,
   TokenTicker,
   TxReadCodec,
 } from "@iov/bcp-types";
@@ -318,17 +317,6 @@ function parseMap<T extends {}>(decoder: Decoder<T>, sliceKey: number): (res: Re
     return Object.assign({}, val, { _id: res.key.slice(sliceKey) });
   };
   return mapper;
-}
-
-// dummyEnvelope just adds some plausible metadata to make bcp happy
-function dummyEnvelope<T extends BcpData>(data: ReadonlyArray<T>): BcpQueryEnvelope<T> {
-  return {
-    metadata: {
-      offset: 0,
-      limit: 100,
-    },
-    data: data,
-  };
 }
 
 /* maybe a bit abstract, but maybe we can reuse... */

--- a/packages/iov-bns/src/client.ts
+++ b/packages/iov-bns/src/client.ts
@@ -5,13 +5,13 @@ import {
   BcpAccount,
   BcpAccountQuery,
   BcpAddressQuery,
+  BcpConnection,
   BcpData,
   BcpNonce,
   BcpQueryEnvelope,
   BcpTicker,
   BcpTransactionResponse,
   ConfirmedTransaction,
-  IovReader,
   TokenTicker,
   TxReadCodec,
 } from "@iov/bcp-types";
@@ -55,7 +55,7 @@ function onChange<T>(): (val: T) => boolean {
 // Client talks directly to the BNS blockchain and exposes the
 // same interface we have with the BCP protocol.
 // We can embed in iov-core process or use this in a BCP-relay
-export class Client implements IovReader {
+export class Client implements BcpConnection {
   public static fromOrToTag(addr: Address): Tag {
     const id = Uint8Array.from([...Encoding.toAscii("wllt:"), ...addr]);
     const key = Encoding.toHex(id).toUpperCase();

--- a/packages/iov-bns/src/client.ts
+++ b/packages/iov-bns/src/client.ts
@@ -11,6 +11,7 @@ import {
   BcpTransactionResponse,
   ConfirmedTransaction,
   dummyEnvelope,
+  isAddressQuery,
   TokenTicker,
   TxReadCodec,
 } from "@iov/bcp-types";
@@ -32,11 +33,6 @@ import { bnsCodec } from "./bnscodec";
 import * as codecImpl from "./codecimpl";
 import { InitData, Normalize } from "./normalize";
 import { Decoder, Keyed, Result } from "./types";
-
-// a type checker to use in the account-based queries
-function isAddressQuery(query: BcpAccountQuery): query is BcpAddressQuery {
-  return (query as BcpAddressQuery).address !== undefined;
-}
 
 // onChange returns a filter than only passes when the
 // value is different than the last one

--- a/packages/iov-bns/types/client.d.ts
+++ b/packages/iov-bns/types/client.d.ts
@@ -1,10 +1,10 @@
 import { Stream } from "xstream";
-import { Address, BcpAccount, BcpAccountQuery, BcpNonce, BcpQueryEnvelope, BcpTicker, BcpTransactionResponse, ConfirmedTransaction, IovReader, TokenTicker, TxReadCodec } from "@iov/bcp-types";
+import { Address, BcpAccount, BcpAccountQuery, BcpConnection, BcpNonce, BcpQueryEnvelope, BcpTicker, BcpTransactionResponse, ConfirmedTransaction, TokenTicker, TxReadCodec } from "@iov/bcp-types";
 import { Client as TendermintClient, StatusResponse } from "@iov/tendermint-rpc";
 import { ChainId, PostableBytes, Tag, TxQuery } from "@iov/tendermint-types";
 import { InitData } from "./normalize";
 import { Result } from "./types";
-export declare class Client implements IovReader {
+export declare class Client implements BcpConnection {
     static fromOrToTag(addr: Address): Tag;
     static nonceTag(addr: Address): Tag;
     static connect(url: string): Promise<Client>;

--- a/packages/iov-core/src/writer.ts
+++ b/packages/iov-core/src/writer.ts
@@ -2,8 +2,8 @@ import Long from "long";
 
 import {
   Address,
+  BcpConnection,
   BcpTransactionResponse,
-  IovReader,
   Nonce,
   TxCodec,
   UnsignedTransaction,
@@ -33,7 +33,7 @@ export class IovWriter {
     return Array.from(this.knownChains).map(([x, _]: [string, ChainConnection]) => x as ChainId);
   }
 
-  public reader(chainId: ChainId): IovReader {
+  public reader(chainId: ChainId): BcpConnection {
     return this.getChain(chainId).client;
   }
 
@@ -95,13 +95,13 @@ export class IovWriter {
 }
 
 export interface ChainConnector {
-  readonly client: () => Promise<IovReader>;
+  readonly client: () => Promise<BcpConnection>;
   readonly codec: TxCodec;
 }
 
 export interface ChainConnection {
   readonly chainId: ChainId;
-  readonly client: IovReader;
+  readonly client: BcpConnection;
   readonly codec: TxCodec;
 }
 

--- a/packages/iov-core/types/writer.d.ts
+++ b/packages/iov-core/types/writer.d.ts
@@ -1,4 +1,4 @@
-import { Address, BcpTransactionResponse, IovReader, Nonce, TxCodec, UnsignedTransaction } from "@iov/bcp-types";
+import { Address, BcpConnection, BcpTransactionResponse, Nonce, TxCodec, UnsignedTransaction } from "@iov/bcp-types";
 import { Client as BnsClient } from "@iov/bns";
 import { KeyringEntryId, UserProfile } from "@iov/keycontrol";
 import { ChainId, PublicKeyBundle } from "@iov/tendermint-types";
@@ -7,7 +7,7 @@ export declare class IovWriter {
     private readonly knownChains;
     constructor(profile: UserProfile);
     chainIds(): ReadonlyArray<ChainId>;
-    reader(chainId: ChainId): IovReader;
+    reader(chainId: ChainId): BcpConnection;
     addChain(connector: ChainConnector): Promise<void>;
     keyToAddress(chainId: ChainId, key: PublicKeyBundle): Address;
     getNonce(chainId: ChainId, addr: Address): Promise<Nonce>;
@@ -15,12 +15,12 @@ export declare class IovWriter {
     private getChain;
 }
 export interface ChainConnector {
-    readonly client: () => Promise<IovReader>;
+    readonly client: () => Promise<BcpConnection>;
     readonly codec: TxCodec;
 }
 export interface ChainConnection {
     readonly chainId: ChainId;
-    readonly client: IovReader;
+    readonly client: BcpConnection;
     readonly codec: TxCodec;
 }
 export declare const bnsFromOrToTag: typeof BnsClient.fromOrToTag;

--- a/packages/iov-lisk/src/liskclient.ts
+++ b/packages/iov-lisk/src/liskclient.ts
@@ -7,12 +7,12 @@ import {
   BcpAccount,
   BcpAccountQuery,
   BcpAddressQuery,
+  BcpConnection,
   BcpNonce,
   BcpQueryEnvelope,
   BcpTicker,
   BcpTransactionResponse,
   ConfirmedTransaction,
-  IovReader,
   Nonce,
   TokenTicker,
 } from "@iov/bcp-types";
@@ -34,7 +34,7 @@ export function generateNonce(): Nonce {
   return Parse.timeToNonce(now);
 }
 
-export class LiskClient implements IovReader {
+export class LiskClient implements BcpConnection {
   private readonly baseUrl: string;
 
   constructor(baseUrl: string) {

--- a/packages/iov-lisk/types/liskclient.d.ts
+++ b/packages/iov-lisk/types/liskclient.d.ts
@@ -1,8 +1,8 @@
 import { Stream } from "xstream";
-import { Address, BcpAccount, BcpAccountQuery, BcpNonce, BcpQueryEnvelope, BcpTicker, BcpTransactionResponse, ConfirmedTransaction, IovReader, Nonce, TokenTicker } from "@iov/bcp-types";
+import { Address, BcpAccount, BcpAccountQuery, BcpConnection, BcpNonce, BcpQueryEnvelope, BcpTicker, BcpTransactionResponse, ConfirmedTransaction, Nonce, TokenTicker } from "@iov/bcp-types";
 import { ChainId, PostableBytes, Tag, TxQuery } from "@iov/tendermint-types";
 export declare function generateNonce(): Nonce;
-export declare class LiskClient implements IovReader {
+export declare class LiskClient implements BcpConnection {
     private readonly baseUrl;
     constructor(baseUrl: string);
     disconnect(): void;


### PR DESCRIPTION
This defines the interfaces for #347 
Also addresses the naming issue for IovReader from #291 

Builds on top of #359 which should be merged first

I changed `IovReader` interface to `BcpConnection` and added a new `BcpAtomicSwapConnection` which extends the basic connection with information on atomic swap for those chains that support it.

I defined the types for atomic swap in [@iov/bcp-types](https://github.com/iov-one/iov-core/blob/separate-reader-types/packages/iov-bcp-types/src/atomicswap.ts)

I pulled some common functionality related to bcp into the bcp-types packages (as it is now ts and not just .d.ts), such as dummyEnvelope and the type guards for queries.

If the interfaces are clean, the next step for #347 is to actually implement the logic in @iov/bns.