### PR TITLE
Search pagination

### DIFF
--- a/packages/iov-bns/src/client.ts
+++ b/packages/iov-bns/src/client.ts
@@ -179,9 +179,9 @@ export class Client implements IovReader {
   }
 
   public async searchTx(txQuery: TxQuery): Promise<ReadonlyArray<ConfirmedTransaction>> {
-    const perPage = 100; // how many tx to return in search page, default 30
-    const query = buildTxQuery(txQuery);
-    const res = await this.tmClient.txSearch({ query, per_page: perPage });
+    // this will paginate over all transactions, even if multiple pages.
+    // FIXME: consider making a streaming interface here, but that will break clients
+    const res = await this.tmClient.txSearchAll({ query: buildTxQuery(txQuery) });
     const chainId = await this.chainId();
     const mapper = ({ tx, hash, height, txResult }: TxResponse): ConfirmedTransaction => ({
       height,

--- a/packages/iov-tendermint-rpc/src/client.spec.ts
+++ b/packages/iov-tendermint-rpc/src/client.spec.ts
@@ -146,6 +146,48 @@ function kvTestSuite(rpcFactory: () => RpcClient): void {
     expect(block.block.txs.length).toEqual(1);
     expect(block.block.txs[0]).toEqual(tx);
   });
+
+  it("Can paginate over all txs", async () => {
+    pendingWithoutTendermint();
+    const client = new Client(rpcFactory(), v0_20);
+
+    const find = randomId();
+    const query = buildTxQuery({ tags: [{ key: "app.key", value: find }] });
+
+    const sendTx = async () => {
+      const me = randomId();
+      const tx = buildKvTx(find, me);
+
+      const txRes = await client.broadcastTxCommit({ tx });
+      expect(responses.txCommitSuccess(txRes)).toBeTruthy();
+      expect(txRes.height).toBeTruthy();
+      expect(txRes.hash.length).not.toEqual(0);
+    };
+
+    // send 3 txs
+    await sendTx();
+    await sendTx();
+    await sendTx();
+
+    // expect one page of results
+    const s1 = await client.txSearch({ query, page: 1, per_page: 2 });
+    expect(s1.totalCount).toEqual(3);
+    expect(s1.txs.length).toEqual(2);
+
+    // second page
+    const s2 = await client.txSearch({ query, page: 2, per_page: 2 });
+    expect(s2.totalCount).toEqual(3);
+    expect(s2.txs.length).toEqual(1);
+
+    // and all together now
+    const sall = await client.txSearchAll({ query, per_page: 2 });
+    expect(sall.totalCount).toEqual(3);
+    expect(sall.txs.length).toEqual(3);
+    // make sure there are in order from lowest to highest height
+    const [tx1, tx2, tx3] = sall.txs;
+    expect(tx2.height).toEqual(tx1.height + 1);
+    expect(tx3.height).toEqual(tx2.height + 1);
+  });
 }
 
 describe("Client", () => {

--- a/packages/iov-tendermint-rpc/src/client.spec.ts
+++ b/packages/iov-tendermint-rpc/src/client.spec.ts
@@ -132,6 +132,14 @@ function kvTestSuite(rpcFactory: () => RpcClient): void {
     // except without the proof
     expect(s.txs[0]).toEqual({ ...r, proof: undefined });
 
+    // ensure txSearchAll works as well
+    const sall = await client.txSearchAll({ query });
+    // should find the tx
+    expect(sall.totalCount).toEqual(1);
+    // should return same info as querying directly,
+    // except without the proof
+    expect(sall.txs[0]).toEqual({ ...r, proof: undefined });
+
     // and let's query the block itself to see this transaction
     const block = await client.block(height);
     expect(block.blockMeta.header.numTxs).toEqual(1);


### PR DESCRIPTION
Resolves #329 

- Adds tendermint-rpc method `txSearchAll` to iterate over all pages
- Use txSearchAll in bns client, so we get all tx regardless of size

Note: I would like to move to a Stream interface, as it can be slow to buffer them all if there are 100's of tx, but this breaks many apis, so let's consider this later when doing other breaking api changes