### PR TITLE
Don't use SignableBytes as output type of prehash()

### DIFF
--- a/packages/iov-keycontrol/src/prehashing.ts
+++ b/packages/iov-keycontrol/src/prehashing.ts
@@ -1,14 +1,14 @@
 import { PrehashType, SignableBytes } from "@iov/bcp-types";
 import { Sha256, Sha512 } from "@iov/crypto";
 
-export function prehash(bytes: SignableBytes, type: PrehashType): SignableBytes {
+export function prehash(bytes: SignableBytes, type: PrehashType): Uint8Array {
   switch (type) {
     case PrehashType.None:
-      return new Uint8Array([...bytes]) as SignableBytes;
+      return new Uint8Array([...bytes]);
     case PrehashType.Sha256:
-      return new Sha256(bytes).digest() as SignableBytes;
+      return new Sha256(bytes).digest();
     case PrehashType.Sha512:
-      return new Sha512(bytes).digest() as SignableBytes;
+      return new Sha512(bytes).digest();
     default:
       throw new Error("Unknown prehash type");
   }

--- a/packages/iov-keycontrol/types/prehashing.d.ts
+++ b/packages/iov-keycontrol/types/prehashing.d.ts
@@ -1,2 +1,2 @@
 import { PrehashType, SignableBytes } from "@iov/bcp-types";
-export declare function prehash(bytes: SignableBytes, type: PrehashType): SignableBytes;
+export declare function prehash(bytes: SignableBytes, type: PrehashType): Uint8Array;


### PR DESCRIPTION
this is confusing since SignableBytes should either be prehashed or plain