### PR TITLE
Convert some comments to TSDoc format

### DIFF
--- a/packages/iov-bns/types/client.d.ts
+++ b/packages/iov-bns/types/client.d.ts
@@ -4,6 +4,12 @@ import { Client as TendermintClient, StatusResponse } from "@iov/tendermint-rpc"
 import { ChainId, PostableBytes, Tag, TxQuery } from "@iov/tendermint-types";
 import { InitData } from "./normalize";
 import { Result } from "./types";
+/**
+ * Talks directly to the BNS blockchain and exposes the
+ * same interface we have with the BCP protocol.
+ *
+ * We can embed in iov-core process or use this in a BCP-relay
+ */
 export declare class Client implements BcpAtomicSwapConnection {
     static connect(url: string): Promise<Client>;
     protected static initialize(tmClient: TendermintClient): Promise<InitData>;
@@ -12,6 +18,11 @@ export declare class Client implements BcpAtomicSwapConnection {
     protected readonly initData: InitData;
     constructor(tmClient: TendermintClient, codec: TxReadCodec, initData: InitData);
     disconnect(): void;
+    /**
+     * The chain ID this connection is connected to
+     *
+     * We store this info from the initialization, no need to query every time
+     */
     chainId(): ChainId;
     height(): Promise<number>;
     status(): Promise<StatusResponse>;
@@ -20,17 +31,54 @@ export declare class Client implements BcpAtomicSwapConnection {
     getAllTickers(): Promise<BcpQueryEnvelope<BcpTicker>>;
     getAccount(account: BcpAccountQuery): Promise<BcpQueryEnvelope<BcpAccount>>;
     getNonce(account: BcpAccountQuery): Promise<BcpQueryEnvelope<BcpNonce>>;
+    /**
+     * All matching swaps that are open (from app state)
+     */
     getSwapFromState(query: BcpSwapQuery): Promise<BcpQueryEnvelope<BcpAtomicSwap>>;
+    /**
+     * All matching swaps that are open (in app state)
+     *
+     * To get claimed and returned, we need to look at the transactions.... TODO
+     */
     getSwap(query: BcpSwapQuery): Promise<BcpQueryEnvelope<BcpAtomicSwap>>;
+    /**
+     * Emits currentState (getSwap) as a stream, then sends updates for any matching swap
+     *
+     * This includes an open swap beind claimed/expired as well as a new matching swap being offered
+     */
     watchSwap(query: BcpSwapQuery): Stream<BcpAtomicSwap>;
     searchTx(txQuery: TxQuery): Promise<ReadonlyArray<ConfirmedTransaction>>;
+    /**
+     * A stream of all transactions that match the tags from the present moment on
+     */
     listenTx(tags: ReadonlyArray<Tag>): Stream<ConfirmedTransaction>;
+    /**
+     * Does a search and then subscribes to all future changes.
+     *
+     * It returns a stream starting the array of all existing transactions
+     * and then continuing with live feeds
+     */
     liveTx(txQuery: TxQuery): Stream<ConfirmedTransaction>;
     changeBlock(): Stream<number>;
+    /**
+     * Emits the blockheight for every block where a tx matching these tags is emitted
+     */
     changeTx(tags: ReadonlyArray<Tag>): Stream<number>;
+    /**
+     * A helper that triggers if the balance ever changes
+     */
     changeBalance(addr: Address): Stream<number>;
+    /**
+     * A helper that triggers if the nonce every changes
+     */
     changeNonce(addr: Address): Stream<number>;
+    /**
+     * Gets current balance and emits an update every time it changes
+     */
     watchAccount(account: BcpAccountQuery): Stream<BcpAccount | undefined>;
+    /**
+     * Gets current nonce and emits an update every time it changes
+     */
     watchNonce(account: BcpAccountQuery): Stream<BcpNonce | undefined>;
     protected query(path: string, data: Uint8Array): Promise<QueryResponse>;
 }


### PR DESCRIPTION
This is mostly to show the idea:

- [tsdocs](https://github.com/Microsoft/tsdoc) are preserved in declaration files
- tsdocs [are preserved in our documentation](https://iov-one.github.io/iov-core-docs/latest/iov-crypto/enums/slip10curve.html)
- IDEs use that to show function/class descriptions at the caller side

<img width="618" alt="oneliner" src="https://user-images.githubusercontent.com/2603011/46524388-f9642f00-c888-11e8-9eca-5b25884ac5e9.png">

Additionally, I am removing the duplicate class/function name from the comment to

1. make comments shorter
2. avoid mismatch between comment and descrition after simple renamings