### PR TITLE
Add and enforce optional expectedChainId in ChainConnector

### DIFF
--- a/packages/iov-bcp-types/src/bcp.ts
+++ b/packages/iov-bcp-types/src/bcp.ts
@@ -166,4 +166,5 @@ export interface BcpConnection {
 export interface ChainConnector {
   readonly client: () => Promise<BcpConnection>;
   readonly codec: TxCodec;
+  readonly expectedChainId?: ChainId;
 }

--- a/packages/iov-bcp-types/types/bcp.d.ts
+++ b/packages/iov-bcp-types/types/bcp.d.ts
@@ -85,4 +85,5 @@ export interface BcpConnection {
 export interface ChainConnector {
     readonly client: () => Promise<BcpConnection>;
     readonly codec: TxCodec;
+    readonly expectedChainId?: ChainId;
 }

--- a/packages/iov-bns/src/bnsconnector.ts
+++ b/packages/iov-bns/src/bnsconnector.ts
@@ -1,4 +1,5 @@
 import { ChainConnector } from "@iov/bcp-types";
+import { ChainId } from "@iov/tendermint-types";
 
 import { bnsCodec } from "./bnscodec";
 import { BnsConnection } from "./bnsconnection";
@@ -6,9 +7,10 @@ import { BnsConnection } from "./bnsconnection";
 /**
  * A helper to connect to a bns-based chain at a given url
  */
-export function bnsConnector(url: string): ChainConnector {
+export function bnsConnector(url: string, expectedChainId?: ChainId): ChainConnector {
   return {
     client: () => BnsConnection.establish(url),
     codec: bnsCodec,
+    expectedChainId,
   };
 }

--- a/packages/iov-bns/types/bnsconnector.d.ts
+++ b/packages/iov-bns/types/bnsconnector.d.ts
@@ -1,5 +1,6 @@
 import { ChainConnector } from "@iov/bcp-types";
+import { ChainId } from "@iov/tendermint-types";
 /**
  * A helper to connect to a bns-based chain at a given url
  */
-export declare function bnsConnector(url: string): ChainConnector;
+export declare function bnsConnector(url: string, expectedChainId?: ChainId): ChainConnector;

--- a/packages/iov-core/src/multichainsigner.spec.ts
+++ b/packages/iov-core/src/multichainsigner.spec.ts
@@ -135,12 +135,12 @@ describe("MultiChainSigner", () => {
   });
 
   // transforms promise so resolved->rejected and rejected->resolved
-  const expectRejected = (prom: Promise<any>): Promise<boolean> =>
+  const expectRejected = (prom: Promise<any>): Promise<any> =>
     prom.then(
       () => {
         throw new Error("expected rejection");
       },
-      () => true,
+      (err: any) => err,
     );
 
   it("optionally enforces chainId", async () => {

--- a/packages/iov-core/src/multichainsigner.ts
+++ b/packages/iov-core/src/multichainsigner.ts
@@ -63,6 +63,9 @@ export class MultiChainSigner {
   public async addChain(connector: ChainConnector): Promise<{ readonly connection: BcpConnection }> {
     const chain = await connectChain(connector);
     const chainId = chain.connection.chainId();
+    if (connector.expectedChainId && connector.expectedChainId !== chainId) {
+      throw new Error(`Connected to chain id ${chainId} but expected ${connector.expectedChainId}`);
+    }
     if (this.knownChains.has(chainId)) {
       throw new Error(`Chain ${chainId} is already registered`);
     }


### PR DESCRIPTION
If we know the chainId ahead of time, we can pass it to `addChain` for extra security