### PR TITLE
Update createIdentity interface

### DIFF
--- a/packages/iov-keycontrol/src/keyring-entries/ed25519.ts
+++ b/packages/iov-keycontrol/src/keyring-entries/ed25519.ts
@@ -120,10 +120,11 @@ export class Ed25519KeyringEntry implements KeyringEntry {
     this.labelProducer.update(label);
   }
 
-  public async createIdentity(keypair?: Ed25519Keypair): Promise<LocalIdentity> {
-    if (!keypair) {
+  public async createIdentity(options: unknown): Promise<LocalIdentity> {
+    if (!(options instanceof Ed25519Keypair)) {
       throw new Error("Ed25519.createIdentity requires a keypair argument");
     }
+    const keypair = options;
 
     const newIdentity = this.buildLocalIdentity(keypair.pubkey as PublicKeyBytes, undefined);
 

--- a/packages/iov-keycontrol/src/keyring-entries/ed25519hdwallet.ts
+++ b/packages/iov-keycontrol/src/keyring-entries/ed25519hdwallet.ts
@@ -1,6 +1,6 @@
-import { Slip10Curve, Slip10RawIndex } from "@iov/crypto";
+import { Slip10Curve } from "@iov/crypto";
 
-import { KeyringEntryImplementationIdString, LocalIdentity } from "../keyring";
+import { KeyringEntryImplementationIdString } from "../keyring";
 import { Slip10Wallet } from "./slip10wallet";
 
 export class Ed25519HdWallet extends Slip10Wallet {
@@ -17,13 +17,6 @@ export class Ed25519HdWallet extends Slip10Wallet {
   }
 
   public readonly implementationId = "ed25519-hd" as KeyringEntryImplementationIdString;
-
-  public async createIdentity(path?: ReadonlyArray<Slip10RawIndex>): Promise<LocalIdentity> {
-    if (path === undefined) {
-      throw new Error("Ed25519HdWallet.createIdentity requires a `path` argument");
-    }
-    return super.createIdentityWithPath(path);
-  }
 
   public clone(): Ed25519HdWallet {
     return new Ed25519HdWallet(this.serialize());

--- a/packages/iov-keycontrol/src/keyring-entries/ed25519hdwallet.ts
+++ b/packages/iov-keycontrol/src/keyring-entries/ed25519hdwallet.ts
@@ -18,7 +18,7 @@ export class Ed25519HdWallet extends Slip10Wallet {
 
   public readonly implementationId = "ed25519-hd" as KeyringEntryImplementationIdString;
 
-  public createIdentity(path?: ReadonlyArray<Slip10RawIndex>): Promise<LocalIdentity> {
+  public async createIdentity(path?: ReadonlyArray<Slip10RawIndex>): Promise<LocalIdentity> {
     if (path === undefined) {
       throw new Error("Ed25519HdWallet.createIdentity requires a `path` argument");
     }

--- a/packages/iov-keycontrol/src/keyring-entries/secp256k1hdwallet.ts
+++ b/packages/iov-keycontrol/src/keyring-entries/secp256k1hdwallet.ts
@@ -1,6 +1,6 @@
-import { Slip10Curve, Slip10RawIndex } from "@iov/crypto";
+import { Slip10Curve } from "@iov/crypto";
 
-import { KeyringEntryImplementationIdString, LocalIdentity } from "../keyring";
+import { KeyringEntryImplementationIdString } from "../keyring";
 import { Slip10Wallet } from "./slip10wallet";
 
 export class Secp256k1HdWallet extends Slip10Wallet {
@@ -21,13 +21,6 @@ export class Secp256k1HdWallet extends Slip10Wallet {
   }
 
   public readonly implementationId = "secp256k1-hd" as KeyringEntryImplementationIdString;
-
-  public async createIdentity(path?: ReadonlyArray<Slip10RawIndex>): Promise<LocalIdentity> {
-    if (path === undefined) {
-      throw new Error("Secp256k1HdWallet.createIdentity requires a `path` argument");
-    }
-    return super.createIdentityWithPath(path);
-  }
 
   public clone(): Secp256k1HdWallet {
     return new Secp256k1HdWallet(this.serialize());

--- a/packages/iov-keycontrol/src/keyring-entries/secp256k1hdwallet.ts
+++ b/packages/iov-keycontrol/src/keyring-entries/secp256k1hdwallet.ts
@@ -22,7 +22,7 @@ export class Secp256k1HdWallet extends Slip10Wallet {
 
   public readonly implementationId = "secp256k1-hd" as KeyringEntryImplementationIdString;
 
-  public createIdentity(path?: ReadonlyArray<Slip10RawIndex>): Promise<LocalIdentity> {
+  public async createIdentity(path?: ReadonlyArray<Slip10RawIndex>): Promise<LocalIdentity> {
     if (path === undefined) {
       throw new Error("Secp256k1HdWallet.createIdentity requires a `path` argument");
     }

--- a/packages/iov-keycontrol/src/keyring-entries/slip10wallet.spec.ts
+++ b/packages/iov-keycontrol/src/keyring-entries/slip10wallet.spec.ts
@@ -73,9 +73,9 @@ describe("Slip10Wallet", () => {
     ];
 
     for (const entry of emptyEntries) {
-      const newIdentity1 = await entry.createIdentityWithPath([Slip10RawIndex.hardened(0)]);
-      const newIdentity2 = await entry.createIdentityWithPath([Slip10RawIndex.hardened(1)]);
-      const newIdentity3 = await entry.createIdentityWithPath([Slip10RawIndex.hardened(1), Slip10RawIndex.hardened(0)]);
+      const newIdentity1 = await entry.createIdentity([Slip10RawIndex.hardened(0)]);
+      const newIdentity2 = await entry.createIdentity([Slip10RawIndex.hardened(1)]);
+      const newIdentity3 = await entry.createIdentity([Slip10RawIndex.hardened(1), Slip10RawIndex.hardened(0)]);
 
       // all pubkeys must be different
       const pubkeySet = new Set([newIdentity1, newIdentity2, newIdentity3].map(i => Encoding.toHex(i.pubkey.data)));
@@ -111,9 +111,9 @@ describe("Slip10Wallet", () => {
     ];
 
     for (const wallet of emptyWallets) {
-      await wallet.createIdentityWithPath(defaultPath);
+      await wallet.createIdentity(defaultPath);
       await wallet
-        .createIdentityWithPath(defaultPath)
+        .createIdentity(defaultPath)
         .then(() => fail("must not resolve"))
         .catch(error => expect(error).toMatch(/ID collision/i));
     }
@@ -128,9 +128,9 @@ describe("Slip10Wallet", () => {
     ];
 
     for (const entry of emptyEntries) {
-      const newIdentity1 = await entry.createIdentityWithPath([Slip10RawIndex.hardened(0)]);
-      const newIdentity2 = await entry.createIdentityWithPath([Slip10RawIndex.hardened(1)]);
-      const newIdentity3 = await entry.createIdentityWithPath([Slip10RawIndex.hardened(1), Slip10RawIndex.hardened(0)]);
+      const newIdentity1 = await entry.createIdentity([Slip10RawIndex.hardened(0)]);
+      const newIdentity2 = await entry.createIdentity([Slip10RawIndex.hardened(1)]);
+      const newIdentity3 = await entry.createIdentity([Slip10RawIndex.hardened(1), Slip10RawIndex.hardened(0)]);
 
       // all pubkeys must be different
       const pubkeySet = new Set([newIdentity1, newIdentity2, newIdentity3].map(i => Encoding.toHex(i.pubkey.data)));
@@ -157,15 +157,15 @@ describe("Slip10Wallet", () => {
     const entry = Slip10Wallet.fromMnemonicWithCurve(Slip10Curve.Secp256k1, "mushroom faint dumb venture million true skull grab pitch mesh share tortoise");
 
     // m/44'/0'/7'/1/0
-    const address0 = await entry.createIdentityWithPath([Slip10RawIndex.hardened(44), Slip10RawIndex.hardened(0), Slip10RawIndex.hardened(7), Slip10RawIndex.normal(1), Slip10RawIndex.normal(0)]);
+    const address0 = await entry.createIdentity([Slip10RawIndex.hardened(44), Slip10RawIndex.hardened(0), Slip10RawIndex.hardened(7), Slip10RawIndex.normal(1), Slip10RawIndex.normal(0)]);
     expect(address0.pubkey.data).toEqual(fromHex("0388557bc34cf8229fc40cffe464344e946bf5c46257e820ea1632f3acbeaa723b"));
 
     // m/44'/0'/7'/1/1
-    const address1 = await entry.createIdentityWithPath([Slip10RawIndex.hardened(44), Slip10RawIndex.hardened(0), Slip10RawIndex.hardened(7), Slip10RawIndex.normal(1), Slip10RawIndex.normal(1)]);
+    const address1 = await entry.createIdentity([Slip10RawIndex.hardened(44), Slip10RawIndex.hardened(0), Slip10RawIndex.hardened(7), Slip10RawIndex.normal(1), Slip10RawIndex.normal(1)]);
     expect(address1.pubkey.data).toEqual(fromHex("03cf16066cbcb077cac488ad03995db1a6ad97c3f1088b59a9d5ae4ca449d7e4ad"));
 
     // m/44'/0'/7'/1/2
-    const address2 = await entry.createIdentityWithPath([Slip10RawIndex.hardened(44), Slip10RawIndex.hardened(0), Slip10RawIndex.hardened(7), Slip10RawIndex.normal(1), Slip10RawIndex.normal(2)]);
+    const address2 = await entry.createIdentity([Slip10RawIndex.hardened(44), Slip10RawIndex.hardened(0), Slip10RawIndex.hardened(7), Slip10RawIndex.normal(1), Slip10RawIndex.normal(2)]);
     expect(address2.pubkey.data).toEqual(fromHex("02f4a71480c4f6928ad10002ab17815ea4db2a56e545e5ef74d71d7b490171db93"));
   });
 
@@ -179,21 +179,21 @@ describe("Slip10Wallet", () => {
     const entry = Slip10Wallet.fromMnemonicWithCurve(Slip10Curve.Ed25519, "illness spike retreat truth genius clock brain pass fit cave bargain toe");
 
     // m/44'/148'/0'
-    const address0 = await entry.createIdentityWithPath([Slip10RawIndex.hardened(44), Slip10RawIndex.hardened(148), Slip10RawIndex.hardened(0)]);
+    const address0 = await entry.createIdentity([Slip10RawIndex.hardened(44), Slip10RawIndex.hardened(148), Slip10RawIndex.hardened(0)]);
     expect(address0.pubkey.data).toEqual(fromHex("e3726830a0b60cb5f52c844cffcd4eed65eba5c155e89b26411562724e71e544"));
 
     // m/44'/148'/1'
-    const address1 = await entry.createIdentityWithPath([Slip10RawIndex.hardened(44), Slip10RawIndex.hardened(148), Slip10RawIndex.hardened(1)]);
+    const address1 = await entry.createIdentity([Slip10RawIndex.hardened(44), Slip10RawIndex.hardened(148), Slip10RawIndex.hardened(1)]);
     expect(address1.pubkey.data).toEqual(fromHex("416edcd6746d5293579a7039ac67bcf1a8698efecf81183bbb0ac877da86ada3"));
 
     // m/44'/148'/2'
-    const address2 = await entry.createIdentityWithPath([Slip10RawIndex.hardened(44), Slip10RawIndex.hardened(148), Slip10RawIndex.hardened(2)]);
+    const address2 = await entry.createIdentity([Slip10RawIndex.hardened(44), Slip10RawIndex.hardened(148), Slip10RawIndex.hardened(2)]);
     expect(address2.pubkey.data).toEqual(fromHex("31d7c4074e8e8c07025e6f33a07e93ea45b9d83e96179f6b1f23465e96d8dd89"));
   });
 
   it("can set, change and unset an identity label", async () => {
     const entry = new Slip10Wallet(emptyEntry);
-    const newIdentity = await entry.createIdentityWithPath([Slip10RawIndex.hardened(0)]);
+    const newIdentity = await entry.createIdentity([Slip10RawIndex.hardened(0)]);
     const originalId = newIdentity.id;
     expect(entry.getIdentities()[0].label).toBeUndefined();
 
@@ -211,7 +211,7 @@ describe("Slip10Wallet", () => {
 
   it("can sign", async () => {
     const entry = new Slip10Wallet(emptyEntry);
-    const newIdentity = await entry.createIdentityWithPath([Slip10RawIndex.hardened(0)]);
+    const newIdentity = await entry.createIdentity([Slip10RawIndex.hardened(0)]);
 
     expect(entry.canSign.value).toEqual(true);
 
@@ -224,7 +224,7 @@ describe("Slip10Wallet", () => {
 
   it("can sign with different prehash types", async () => {
     const entry = new Slip10Wallet(emptyEntry);
-    const mainIdentity = await entry.createIdentityWithPath([Slip10RawIndex.hardened(0)]);
+    const mainIdentity = await entry.createIdentity([Slip10RawIndex.hardened(0)]);
 
     const transactionBytes = new Uint8Array([0x11, 0x22, 0x33]) as SignableBytes;
     const chainId = "some-chain" as ChainId;
@@ -243,7 +243,7 @@ describe("Slip10Wallet", () => {
 
   it("produces correct data for prehash signatures", async () => {
     const entry = new Slip10Wallet(emptyEntry);
-    const mainIdentity = await entry.createIdentityWithPath([Slip10RawIndex.hardened(0)]);
+    const mainIdentity = await entry.createIdentity([Slip10RawIndex.hardened(0)]);
     const chainId = "some-chain" as ChainId;
 
     const bytes = new Uint8Array([0x11, 0x22, 0x33]) as SignableBytes;
@@ -262,9 +262,9 @@ describe("Slip10Wallet", () => {
     entry.setLabel("entry with 3 identities");
     const originalId = entry.id;
     expect(originalId).toBeTruthy();
-    const identity1 = await entry.createIdentityWithPath([Slip10RawIndex.hardened(0)]);
-    const identity2 = await entry.createIdentityWithPath([Slip10RawIndex.hardened(1)]);
-    const identity3 = await entry.createIdentityWithPath([Slip10RawIndex.hardened(2), Slip10RawIndex.hardened(0)]);
+    const identity1 = await entry.createIdentity([Slip10RawIndex.hardened(0)]);
+    const identity2 = await entry.createIdentity([Slip10RawIndex.hardened(1)]);
+    const identity3 = await entry.createIdentity([Slip10RawIndex.hardened(2), Slip10RawIndex.hardened(0)]);
     entry.setIdentityLabel(identity1, undefined);
     entry.setIdentityLabel(identity2, "");
     entry.setIdentityLabel(identity3, "foo");
@@ -395,9 +395,9 @@ describe("Slip10Wallet", () => {
 
   it("can serialize and restore a full keyring entry", async () => {
     const original = new Slip10Wallet(emptyEntry);
-    const identity1 = await original.createIdentityWithPath([Slip10RawIndex.hardened(0)]);
-    const identity2 = await original.createIdentityWithPath([Slip10RawIndex.hardened(1)]);
-    const identity3 = await original.createIdentityWithPath([Slip10RawIndex.hardened(2)]);
+    const identity1 = await original.createIdentity([Slip10RawIndex.hardened(0)]);
+    const identity2 = await original.createIdentity([Slip10RawIndex.hardened(1)]);
+    const identity3 = await original.createIdentity([Slip10RawIndex.hardened(2)]);
     original.setIdentityLabel(identity1, undefined);
     original.setIdentityLabel(identity2, "");
     original.setIdentityLabel(identity3, "foo");

--- a/packages/iov-keycontrol/src/keyring-entries/slip10wallet.ts
+++ b/packages/iov-keycontrol/src/keyring-entries/slip10wallet.ts
@@ -53,6 +53,13 @@ interface Slip10WalletConstructor {
   new (data: KeyringEntrySerializationString): Slip10Wallet;
 }
 
+function isPath(value: unknown): value is ReadonlyArray<Slip10RawIndex> {
+  if (!Array.isArray(value)) {
+    return false;
+  }
+  return value.every(item => item instanceof Slip10RawIndex);
+}
+
 export class Slip10Wallet implements KeyringEntry {
   public static fromEntropyWithCurve(
     curve: Slip10Curve,
@@ -169,11 +176,12 @@ export class Slip10Wallet implements KeyringEntry {
     this.labelProducer.update(label);
   }
 
-  public async createIdentity(_?: any): Promise<LocalIdentity> {
-    throw new Error("Slip10Wallet.createIdentity must not be called directly. Use derived type.");
-  }
+  public async createIdentity(options: unknown): Promise<LocalIdentity> {
+    if (!isPath(options)) {
+      throw new Error("Did not get the correct argument type. Expected array of Slip10RawIndex");
+    }
+    const path = options;
 
-  public async createIdentityWithPath(path: ReadonlyArray<Slip10RawIndex>): Promise<LocalIdentity> {
     const seed = await Bip39.mnemonicToSeed(this.secret);
     const derivationResult = Slip10.derivePath(this.curve, seed, path);
 

--- a/packages/iov-keycontrol/src/keyring.ts
+++ b/packages/iov-keycontrol/src/keyring.ts
@@ -1,6 +1,7 @@
 import { As } from "type-tagger";
 
 import { PrehashType, SignableBytes } from "@iov/bcp-types";
+import { Slip10RawIndex } from "@iov/crypto";
 import { ValueAndUpdates } from "@iov/stream";
 import { ChainId, PublicKeyBundle, SignatureBytes } from "@iov/tendermint-types";
 
@@ -150,7 +151,9 @@ export interface KeyringEntry {
   readonly setLabel: (label: string | undefined) => void;
 
   // createIdentity will create one new identity
-  readonly createIdentity: (options?: any) => Promise<LocalIdentity>;
+  readonly createIdentity: (
+    options: Ed25519KeyringEntry | ReadonlyArray<Slip10RawIndex> | number,
+  ) => Promise<LocalIdentity>;
 
   // Sets a local label associated with the public identity to be displayed in the UI.
   // To clear a label, set it to undefined

--- a/packages/iov-keycontrol/src/userprofile.ts
+++ b/packages/iov-keycontrol/src/userprofile.ts
@@ -7,6 +7,7 @@ import {
   Argon2id,
   Argon2idOptions,
   Random,
+  Slip10RawIndex,
   Xchacha20poly1305Ietf,
   Xchacha20poly1305IetfCiphertext,
   Xchacha20poly1305IetfKey,
@@ -24,6 +25,7 @@ import {
   LocalIdentity,
   PublicIdentity,
 } from "./keyring";
+import { Ed25519KeyringEntry } from "./keyring-entries";
 import { DatabaseUtils } from "./utils";
 
 const { toAscii, fromBase64, toBase64, fromUtf8, toUtf8, toRfc3339, fromRfc3339 } = Encoding;
@@ -175,7 +177,10 @@ export class UserProfile {
   }
 
   // creates an identitiy in the n-th keyring entry of the primary keyring
-  public async createIdentity(id: KeyringEntryId, options?: any): Promise<LocalIdentity> {
+  public async createIdentity(
+    id: KeyringEntryId,
+    options: Ed25519KeyringEntry | ReadonlyArray<Slip10RawIndex> | number,
+  ): Promise<LocalIdentity> {
     const entry = this.entryInPrimaryKeyring(id);
     return entry.createIdentity(options);
   }

--- a/packages/iov-keycontrol/types/keyring-entries/ed25519.d.ts
+++ b/packages/iov-keycontrol/types/keyring-entries/ed25519.d.ts
@@ -1,5 +1,4 @@
 import { PrehashType, SignableBytes } from "@iov/bcp-types";
-import { Ed25519Keypair } from "@iov/crypto";
 import { ValueAndUpdates } from "@iov/stream";
 import { ChainId, SignatureBytes } from "@iov/tendermint-types";
 import { KeyringEntry, KeyringEntryId, KeyringEntryImplementationIdString, KeyringEntrySerializationString, LocalIdentity, PublicIdentity } from "../keyring";
@@ -17,7 +16,7 @@ export declare class Ed25519KeyringEntry implements KeyringEntry {
     private readonly labelProducer;
     constructor(data?: KeyringEntrySerializationString);
     setLabel(label: string | undefined): void;
-    createIdentity(keypair?: Ed25519Keypair): Promise<LocalIdentity>;
+    createIdentity(options: unknown): Promise<LocalIdentity>;
     setIdentityLabel(identity: PublicIdentity, label: string | undefined): void;
     getIdentities(): ReadonlyArray<LocalIdentity>;
     createTransactionSignature(identity: PublicIdentity, transactionBytes: SignableBytes, prehashType: PrehashType, _: ChainId): Promise<SignatureBytes>;

--- a/packages/iov-keycontrol/types/keyring-entries/ed25519hdwallet.d.ts
+++ b/packages/iov-keycontrol/types/keyring-entries/ed25519hdwallet.d.ts
@@ -1,10 +1,8 @@
-import { Slip10RawIndex } from "@iov/crypto";
-import { KeyringEntryImplementationIdString, LocalIdentity } from "../keyring";
+import { KeyringEntryImplementationIdString } from "../keyring";
 import { Slip10Wallet } from "./slip10wallet";
 export declare class Ed25519HdWallet extends Slip10Wallet {
     static fromEntropy(bip39Entropy: Uint8Array): Ed25519HdWallet;
     static fromMnemonic(mnemonicString: string): Ed25519HdWallet;
     readonly implementationId: KeyringEntryImplementationIdString;
-    createIdentity(path?: ReadonlyArray<Slip10RawIndex>): Promise<LocalIdentity>;
     clone(): Ed25519HdWallet;
 }

--- a/packages/iov-keycontrol/types/keyring-entries/secp256k1hdwallet.d.ts
+++ b/packages/iov-keycontrol/types/keyring-entries/secp256k1hdwallet.d.ts
@@ -1,10 +1,8 @@
-import { Slip10RawIndex } from "@iov/crypto";
-import { KeyringEntryImplementationIdString, LocalIdentity } from "../keyring";
+import { KeyringEntryImplementationIdString } from "../keyring";
 import { Slip10Wallet } from "./slip10wallet";
 export declare class Secp256k1HdWallet extends Slip10Wallet {
     static fromEntropy(bip39Entropy: Uint8Array): Secp256k1HdWallet;
     static fromMnemonic(mnemonicString: string): Secp256k1HdWallet;
     readonly implementationId: KeyringEntryImplementationIdString;
-    createIdentity(path?: ReadonlyArray<Slip10RawIndex>): Promise<LocalIdentity>;
     clone(): Secp256k1HdWallet;
 }

--- a/packages/iov-keycontrol/types/keyring-entries/slip10wallet.d.ts
+++ b/packages/iov-keycontrol/types/keyring-entries/slip10wallet.d.ts
@@ -1,5 +1,5 @@
 import { PrehashType, SignableBytes } from "@iov/bcp-types";
-import { Slip10Curve, Slip10RawIndex } from "@iov/crypto";
+import { Slip10Curve } from "@iov/crypto";
 import { ValueAndUpdates } from "@iov/stream";
 import { ChainId, SignatureBytes } from "@iov/tendermint-types";
 import { KeyringEntry, KeyringEntryId, KeyringEntryImplementationIdString, KeyringEntrySerializationString, LocalIdentity, PublicIdentity } from "../keyring";
@@ -25,8 +25,7 @@ export declare class Slip10Wallet implements KeyringEntry {
     private readonly labelProducer;
     constructor(data: KeyringEntrySerializationString);
     setLabel(label: string | undefined): void;
-    createIdentity(_?: any): Promise<LocalIdentity>;
-    createIdentityWithPath(path: ReadonlyArray<Slip10RawIndex>): Promise<LocalIdentity>;
+    createIdentity(options: unknown): Promise<LocalIdentity>;
     setIdentityLabel(identity: PublicIdentity, label: string | undefined): void;
     getIdentities(): ReadonlyArray<LocalIdentity>;
     createTransactionSignature(identity: PublicIdentity, transactionBytes: SignableBytes, prehashType: PrehashType, _: ChainId): Promise<SignatureBytes>;

--- a/packages/iov-keycontrol/types/keyring.d.ts
+++ b/packages/iov-keycontrol/types/keyring.d.ts
@@ -1,7 +1,9 @@
 import { As } from "type-tagger";
 import { PrehashType, SignableBytes } from "@iov/bcp-types";
+import { Slip10RawIndex } from "@iov/crypto";
 import { ValueAndUpdates } from "@iov/stream";
 import { ChainId, PublicKeyBundle, SignatureBytes } from "@iov/tendermint-types";
+import { Ed25519KeyringEntry } from "./keyring-entries";
 export declare type KeyringEntrySerializationString = string & As<"keyring-entry-serialization">;
 export declare type KeyringSerializationString = string & As<"keyring-serialization">;
 export declare type KeyringEntryImplementationIdString = string & As<"keyring-entry-implementation-id">;
@@ -39,7 +41,7 @@ export interface KeyringEntry {
     readonly label: ValueAndUpdates<string | undefined>;
     readonly id: KeyringEntryId;
     readonly setLabel: (label: string | undefined) => void;
-    readonly createIdentity: (options?: any) => Promise<LocalIdentity>;
+    readonly createIdentity: (options: Ed25519KeyringEntry | ReadonlyArray<Slip10RawIndex> | number) => Promise<LocalIdentity>;
     readonly setIdentityLabel: (identity: PublicIdentity, label: string | undefined) => void;
     readonly getIdentities: () => ReadonlyArray<LocalIdentity>;
     readonly canSign: ValueAndUpdates<boolean>;

--- a/packages/iov-keycontrol/types/userprofile.d.ts
+++ b/packages/iov-keycontrol/types/userprofile.d.ts
@@ -2,8 +2,10 @@ import { AbstractLevelDOWN } from "abstract-leveldown";
 import { LevelUp } from "levelup";
 import { ReadonlyDate } from "readonly-date";
 import { Nonce, SignedTransaction, TxCodec, UnsignedTransaction } from "@iov/bcp-types";
+import { Slip10RawIndex } from "@iov/crypto";
 import { ValueAndUpdates } from "@iov/stream";
 import { Keyring, KeyringEntry, KeyringEntryId, LocalIdentity, PublicIdentity } from "./keyring";
+import { Ed25519KeyringEntry } from "./keyring-entries";
 export interface UserProfileOptions {
     readonly createdAt: ReadonlyDate;
     readonly keyring: Keyring;
@@ -36,7 +38,7 @@ export declare class UserProfile {
     lock(): void;
     addEntry(entry: KeyringEntry): void;
     setEntryLabel(id: KeyringEntryId, label: string | undefined): void;
-    createIdentity(id: KeyringEntryId, options?: any): Promise<LocalIdentity>;
+    createIdentity(id: KeyringEntryId, options: Ed25519KeyringEntry | ReadonlyArray<Slip10RawIndex> | number): Promise<LocalIdentity>;
     setIdentityLabel(id: KeyringEntryId, identity: PublicIdentity, label: string | undefined): void;
     getIdentities(id: KeyringEntryId): ReadonlyArray<LocalIdentity>;
     signTransaction(id: KeyringEntryId, identity: PublicIdentity, transaction: UnsignedTransaction, codec: TxCodec, nonce: Nonce): Promise<SignedTransaction>;

--- a/packages/iov-ledger-bns/src/ledgersimpleaddresskeyringentry.ts
+++ b/packages/iov-ledger-bns/src/ledgersimpleaddresskeyringentry.ts
@@ -142,7 +142,12 @@ export class LedgerSimpleAddressKeyringEntry implements KeyringEntry {
     this.labelProducer.update(label);
   }
 
-  public async createIdentity(index: number): Promise<LocalIdentity> {
+  public async createIdentity(options: unknown): Promise<LocalIdentity> {
+    if (typeof options !== "number") {
+      throw new Error("Expected numeric argument");
+    }
+    const index = options;
+
     if (!this.deviceTracker.running) {
       throw new Error("Device tracking off. Did you call startDeviceTracking()?");
     }

--- a/packages/iov-ledger-bns/types/ledgersimpleaddresskeyringentry.d.ts
+++ b/packages/iov-ledger-bns/types/ledgersimpleaddresskeyringentry.d.ts
@@ -37,7 +37,7 @@ export declare class LedgerSimpleAddressKeyringEntry implements KeyringEntry {
      */
     stopDeviceTracking(): void;
     setLabel(label: string | undefined): void;
-    createIdentity(index: number): Promise<LocalIdentity>;
+    createIdentity(options: unknown): Promise<LocalIdentity>;
     setIdentityLabel(identity: PublicIdentity, label: string | undefined): void;
     getIdentities(): ReadonlyArray<LocalIdentity>;
     createTransactionSignature(identity: PublicIdentity, transactionBytes: SignableBytes, prehashType: PrehashType, _: ChainId): Promise<SignatureBytes>;


### PR DESCRIPTION
Closes #302 

* The `options` argument is non-optional everywhere now
* `KeyringEntry` implementations use type`unknown` to avoid requiring the knowledge of every possible type
* `UserProfile` and `KeyringEntry` use the stricter type `Ed25519KeyringEntry | ReadonlyArray<Slip10RawIndex> | number` to support developers at the cost of having a centralized and exhaustive list of possible types