### PR TITLE
Update ledger path

### DIFF
--- a/packages/iov-ledger-bns/src/app.ts
+++ b/packages/iov-ledger-bns/src/app.ts
@@ -12,7 +12,7 @@ const cmdAppVersion = 0xca;
 
 export function getPublicKeyWithIndex(transport: TransportNodeHid, i: number): Promise<Uint8Array> {
   const pathComponent = Slip10RawIndex.hardened(i);
-  const chunk = buildPathPrefix([pathComponent]);
+  const chunk = buildPrefixedPath([pathComponent]);
   return sendChunks(transport, appCode, cmdPubkeyWithPath, chunk);
 }
 
@@ -22,17 +22,17 @@ export function signTransactionWithIndex(
   i: number,
 ): Promise<Uint8Array> {
   const pathComponent = Slip10RawIndex.hardened(i);
-  const data = new Uint8Array([...buildPathPrefix([pathComponent]), ...transaction]);
+  const data = new Uint8Array([...buildPrefixedPath([pathComponent]), ...transaction]);
   return sendChunks(transport, appCode, cmdSignWithPath, data);
 }
 
 // construct a binary length-prefixed path to send to the ledger
-function buildPathPrefix(path: ReadonlyArray<Slip10RawIndex>): Uint8Array {
+function buildPrefixedPath(path: ReadonlyArray<Slip10RawIndex>): Uint8Array {
   // I'm sure there is a better way to do this, but...
   let res = new Uint8Array([path.length]);
   // note: as an example how to combine Uint8Arrays, look at appendSignBytes in iov-bns/src/util.ts
-  for (const step of path.map(slip => slip.toBytesBigEndian())) {
-    res = Uint8Array.from([...res, ...step]);
+  for (const componentBytes of path.map(component => component.toBytesBigEndian())) {
+    res = Uint8Array.from([...res, ...componentBytes]);
   }
   return res;
 }

--- a/packages/iov-ledger-bns/src/app.ts
+++ b/packages/iov-ledger-bns/src/app.ts
@@ -12,7 +12,10 @@ const cmdAppVersion = 0xca;
 
 export function getPublicKeyWithIndex(transport: TransportNodeHid, i: number): Promise<Uint8Array> {
   const pathComponent = Slip10RawIndex.hardened(i).asNumber();
-  return sendChunks(transport, appCode, cmdPubkeyWithPath, encodeUint32(pathComponent));
+  // note: as an example how to combine Uint8Arrays, look at appendSignBytes in iov-bns/src/util.ts
+  // this hard-codes to one segment
+  const chunk = Uint8Array.from([1, ...encodeUint32(pathComponent)]);
+  return sendChunks(transport, appCode, cmdPubkeyWithPath, chunk);
 }
 
 export function signTransactionWithIndex(
@@ -21,7 +24,8 @@ export function signTransactionWithIndex(
   i: number,
 ): Promise<Uint8Array> {
   const pathComponent = Slip10RawIndex.hardened(i).asNumber();
-  const data = new Uint8Array([...encodeUint32(pathComponent), ...transaction]);
+  // this hard-codes to one segment
+  const data = new Uint8Array([1, ...encodeUint32(pathComponent), ...transaction]);
   return sendChunks(transport, appCode, cmdSignWithPath, data);
 }
 


### PR DESCRIPTION
Replaces #438

The first commit is a super-minimal change that should work. Please try that against the ledger. It just prepends the byte '0x1' before the 4 byte path component. If this doesn't work, I understood the protocol wrong (it is 1 byte length prefix, not 2, right?)

The second commit is a refactor to abstract this to encode arbitrary paths, even if we only use one segment now, it makes it easy to expand later.

@rudi-cilibrasi i haven't run this against the newly compiled ledger app to test yet, please validate or wait some time for me to get set up.