### PR TITLE
Sort search_tx by height to ensure consistent order

### DIFF
--- a/packages/iov-bns/src/bnsconnection.ts
+++ b/packages/iov-bns/src/bnsconnection.ts
@@ -306,9 +306,7 @@ export class BnsConnection implements BcpAtomicSwapConnection {
       ...this.codec.parseBytes(tx, chainId),
     });
     // make sure we sort by height, as tendermint may be sorting by string value of the height
-    return res.txs
-      .map(mapper)
-      .sort((a: ConfirmedTransaction, b: ConfirmedTransaction) => a.height - b.height);
+    return res.txs.map(mapper);
   }
 
   /**

--- a/packages/iov-bns/src/bnsconnection.ts
+++ b/packages/iov-bns/src/bnsconnection.ts
@@ -305,7 +305,6 @@ export class BnsConnection implements BcpAtomicSwapConnection {
       result: txResult.data || new Uint8Array([]),
       ...this.codec.parseBytes(tx, chainId),
     });
-    // make sure we sort by height, as tendermint may be sorting by string value of the height
     return res.txs.map(mapper);
   }
 

--- a/packages/iov-tendermint-rpc/src/client.ts
+++ b/packages/iov-tendermint-rpc/src/client.ts
@@ -134,6 +134,7 @@ export class Client {
     const resp = await this.doCall(query, this.p.encodeTxSearch, this.r.decodeTxSearch);
     return {
       ...resp,
+      // make sure we sort by height, as tendermint may be sorting by string value of the height
       txs: [...resp.txs].sort((a, b) => a.height - b.height),
     };
   }
@@ -155,6 +156,8 @@ export class Client {
         done = true;
       }
     }
+    // make sure we sort by height, as tendermint may be sorting by string value of the height
+    // and the earlier items may be in a higher page than the later items
     txs.sort((a, b) => a.height - b.height);
 
     return {


### PR DESCRIPTION
Closes #500 

It seems like tendermint sorts height by strings sometimes....
Do a numeric sort client-side to ensure consistent, expected ordering of transactions for search_tx