### PR TITLE
Add support for tendermint 0.25

### DIFF
--- a/packages/iov-tendermint-rpc/src/0-25/requests.ts
+++ b/packages/iov-tendermint-rpc/src/0-25/requests.ts
@@ -1,0 +1,129 @@
+import { Encoding } from "@iov/encoding";
+
+import { JsonRpcRequest, jsonRpcWith } from "../common";
+import { Base64, Base64String, encodeInteger, HexString, may, notEmpty } from "../encodings";
+import * as requests from "../requests";
+
+/***** queries *****/
+
+export class Params extends requests.DefaultParams {
+  public static encodeAbciQuery(req: requests.AbciQueryRequest): JsonRpcRequest {
+    return jsonRpcWith(req.method, encodeAbciQueryParams(req.params));
+  }
+
+  public static encodeBlock(req: requests.BlockRequest): JsonRpcRequest {
+    return jsonRpcWith(req.method, encodeHeightParam(req.params));
+  }
+
+  public static encodeBlockchain(req: requests.BlockchainRequest): JsonRpcRequest {
+    return jsonRpcWith(req.method, encodeBlockchainRequestParams(req.params));
+  }
+
+  public static encodeBlockResults(req: requests.BlockResultsRequest): JsonRpcRequest {
+    return jsonRpcWith(req.method, encodeHeightParam(req.params));
+  }
+
+  public static encodeBroadcastTx(req: requests.BroadcastTxRequest): JsonRpcRequest {
+    return jsonRpcWith(req.method, encodeBroadcastTxParams(req.params));
+  }
+
+  public static encodeCommit(req: requests.CommitRequest): JsonRpcRequest {
+    return jsonRpcWith(req.method, encodeHeightParam(req.params));
+  }
+
+  public static encodeSubscribe(req: requests.SubscribeRequest): JsonRpcRequest {
+    const allTags: ReadonlyArray<requests.QueryTag> = [
+      { key: "tm.event", value: req.query.type },
+      ...(req.query.tags ? req.query.tags : []),
+    ];
+
+    const queryString = requests.buildTagsQuery(allTags);
+    return jsonRpcWith("subscribe", { query: queryString });
+  }
+
+  public static encodeTx(req: requests.TxRequest): JsonRpcRequest {
+    return jsonRpcWith(req.method, encodeTxParams(req.params));
+  }
+
+  // TODO: encode params for query string???
+  public static encodeTxSearch(req: requests.TxSearchRequest): JsonRpcRequest {
+    return jsonRpcWith(req.method, encodeTxSearchParams(req.params));
+  }
+
+  public static encodeValidators(req: requests.ValidatorsRequest): JsonRpcRequest {
+    return jsonRpcWith(req.method, encodeHeightParam(req.params));
+  }
+}
+
+interface HeightParam {
+  readonly height?: number;
+}
+interface RpcHeightParam {
+  readonly height?: string;
+}
+function encodeHeightParam(param: HeightParam): RpcHeightParam {
+  return {
+    height: may(encodeInteger, param.height)
+  };
+}
+
+interface RpcBlockchainRequestParams {
+  readonly minHeight?: string;
+  readonly maxHeight?: string;
+}
+function encodeBlockchainRequestParams(param: requests.BlockchainRequestParams): RpcBlockchainRequestParams {
+  return {
+    minHeight: may(encodeInteger, param.minHeight),
+    maxHeight: may(encodeInteger, param.maxHeight),
+  };
+}
+
+interface RpcAbciQueryParams {
+  readonly path: string;
+  readonly data: HexString;
+  readonly height?: string;
+  readonly trusted?: boolean;
+}
+function encodeAbciQueryParams(params: requests.AbciQueryParams): RpcAbciQueryParams {
+  return {
+    path: notEmpty(params.path),
+    data: Encoding.toHex(params.data) as HexString,
+    height: may(encodeInteger, params.height),
+    trusted: params.trusted,
+  };
+}
+
+interface RpcBroadcastTxParams {
+  readonly tx: Base64String;
+}
+function encodeBroadcastTxParams(params: requests.BroadcastTxParams): RpcBroadcastTxParams {
+  return {
+    tx: Base64.encode(notEmpty(params.tx)),
+  };
+}
+
+interface RpcTxParams {
+  readonly hash: Base64String;
+  readonly prove?: boolean;
+}
+function encodeTxParams(params: requests.TxParams): RpcTxParams {
+  return {
+    hash: Base64.encode(notEmpty(params.hash)),
+    prove: params.prove,
+  };
+}
+
+interface RpcTxSearchParams {
+  readonly query: requests.QueryString;
+  readonly prove?: boolean;
+  readonly page?: string;
+  readonly per_page?: string;
+}
+function encodeTxSearchParams(params: requests.TxSearchParams): RpcTxSearchParams {
+  return {
+    query: params.query,
+    prove: params.prove,
+    page: may(encodeInteger, params.page),
+    per_page: may(encodeInteger, params.per_page),
+  };
+}

--- a/packages/iov-tendermint-rpc/src/encodings.ts
+++ b/packages/iov-tendermint-rpc/src/encodings.ts
@@ -48,6 +48,10 @@ export function parseInteger(str: IntegerString): number {
   return Int53.fromString(str).toNumber();
 }
 
+export function encodeInteger(num: number): IntegerString {
+  return new Int53(num).toString();
+}
+
 export class Base64 {
   public static encode(data: Uint8Array): Base64String {
     return Encoding.toBase64(data) as Base64String;

--- a/packages/iov-tendermint-rpc/src/requests.ts
+++ b/packages/iov-tendermint-rpc/src/requests.ts
@@ -73,11 +73,12 @@ export interface BlockRequest {
 
 export interface BlockchainRequest {
   readonly method: Method.BLOCKCHAIN;
-  readonly params: {
-    readonly minHeight?: number;
-    readonly maxHeight?: number;
-  };
+  readonly params: BlockchainRequestParams;
 }
+export interface BlockchainRequestParams {
+  readonly minHeight?: number;
+  readonly maxHeight?: number;
+};
 
 export interface BlockResultsRequest {
   readonly method: Method.BLOCK_RESULTS;


### PR DESCRIPTION
Closes #295 

- [x] Update request formatting (integers as strings)
- [ ] Update response formatting (quite a bit)
- [ ] Test compatibility with basic tendermint rpc kvstore
- [ ] Test compatibility in bns