### PR TITLE
Update lisk branch from 1.2.0 to v1.2.0

### DIFF
--- a/scripts/lisk/start.sh
+++ b/scripts/lisk/start.sh
@@ -10,7 +10,7 @@ TMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/lisk_start.XXXXXXXXX")
 (
   cd "$TMP_DIR"
   echo "Navigated to temp directory $(pwd)"
-  git clone --depth 1 --branch 1.2.0 https://github.com/LiskHQ/lisk.git
+  git clone --depth 1 --branch v1.2.0 https://github.com/LiskHQ/lisk.git
 
   (
     cd "lisk/docker"


### PR DESCRIPTION
This broke in TravisCI:

```
Navigated to temp directory /tmp/lisk_start.F3nBF0xu2
Cloning into 'lisk'...
warning: Could not find remote branch 1.2.0 to clone.
fatal: Remote branch 1.2.0 not found in upstream origin
The command "./scripts/travis.sh" exited with 1.
```

Seems they renamed the branch to `v1.2.0`