### PR TITLE
Implement block info as return type of postTx

### DIFF
--- a/packages/iov-bcp-types/package.json
+++ b/packages/iov-bcp-types/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@iov/base-types": "^0.9.0",
     "@iov/encoding": "^0.9.0",
+    "@iov/stream": "^0.9.0",
     "type-tagger": "^1.0.0",
     "xstream": "^11.7.0"
   }

--- a/packages/iov-bcp-types/src/bcp.ts
+++ b/packages/iov-bcp-types/src/bcp.ts
@@ -76,6 +76,8 @@ export interface BcpTransactionResponse {
 export interface ConfirmedTransaction<T extends UnsignedTransaction = UnsignedTransaction>
   extends SignedTransaction<T> {
   readonly height: number; // the block it was written to
+  /** number of blocks on top of the transaction's block */
+  readonly confirmations: number;
   readonly txid: TxId; // a unique identifier (hash of the data)
   /** Data from executing tx (result, code, tags...) */
   readonly result?: Uint8Array;

--- a/packages/iov-bcp-types/src/bcp.ts
+++ b/packages/iov-bcp-types/src/bcp.ts
@@ -76,7 +76,7 @@ export interface BcpTransactionResponse {
 export interface ConfirmedTransaction<T extends UnsignedTransaction = UnsignedTransaction>
   extends SignedTransaction<T> {
   readonly height: number; // the block it was written to
-  /** number of blocks on top of the transaction's block */
+  /** depth of the transaction's block, starting at 1 as soon as transaction is in a block */
   readonly confirmations: number;
   readonly txid: TxId; // a unique identifier (hash of the data)
   /** Data from executing tx (result, code, tags...) */

--- a/packages/iov-bcp-types/src/bcp.ts
+++ b/packages/iov-bcp-types/src/bcp.ts
@@ -77,9 +77,9 @@ export interface ConfirmedTransaction<T extends UnsignedTransaction = UnsignedTr
   extends SignedTransaction<T> {
   readonly height: number; // the block it was written to
   readonly txid: TxId; // a unique identifier (hash of the data)
-  // Data from executing tx (result, code, tags...)
-  readonly result: Uint8Array;
-  readonly log: string;
+  /** Data from executing tx (result, code, tags...) */
+  readonly result?: Uint8Array;
+  readonly log?: string;
   // readonly tags: ReadonlyArray<Tag>;
 }
 

--- a/packages/iov-bcp-types/src/bcp.ts
+++ b/packages/iov-bcp-types/src/bcp.ts
@@ -1,6 +1,7 @@
 import { Stream } from "xstream";
 
 import { ChainId, PostableBytes, PublicKeyBundle, TxId } from "@iov/base-types";
+import { ValueAndUpdates } from "@iov/stream";
 
 import { Address, SignedTransaction, TxCodec } from "./signables";
 import { Nonce, TokenTicker, UnsignedTransaction } from "./transactions";
@@ -62,10 +63,31 @@ export interface BcpTicker {
   readonly tokenName: string;
 }
 
+export enum BcpTransactionState {
+  /** accepted by a blockchain node and in mempool */
+  Pending,
+  /** successfully written in a block, but cannot yet guarantee it won't be reverted */
+  InBlock,
+}
+
+/** Information attached to a signature about its state in a block */
+export type BcpBlockInfo =
+  | { readonly state: BcpTransactionState.Pending }
+  | {
+      readonly state: BcpTransactionState.InBlock;
+      /** block height, if the transaction is included in a block */
+      readonly height: number;
+      /** depth of the transaction's block, starting at 1 as soon as transaction is in a block */
+      readonly confirmations: number;
+    };
+
 export interface BcpTransactionResponse {
+  /** @deprecated use blockInfo instead */
   readonly metadata: {
     readonly height?: number;
   };
+  /** TODO: Make non-optional as soon as implemented everywhere */
+  readonly blockInfo?: ValueAndUpdates<BcpBlockInfo>;
   readonly data: {
     readonly message: string;
     readonly txid: TxId; // a unique identifier (hash of the data)

--- a/packages/iov-bcp-types/src/bcp.ts
+++ b/packages/iov-bcp-types/src/bcp.ts
@@ -86,8 +86,8 @@ export interface BcpTransactionResponse {
   readonly metadata: {
     readonly height?: number;
   };
-  /** TODO: Make non-optional as soon as implemented everywhere */
-  readonly blockInfo?: ValueAndUpdates<BcpBlockInfo>;
+  /** Information abot the block the transaction is in */
+  readonly blockInfo: ValueAndUpdates<BcpBlockInfo>;
   readonly data: {
     readonly message: string;
     readonly txid: TxId; // a unique identifier (hash of the data)

--- a/packages/iov-bcp-types/types/bcp.d.ts
+++ b/packages/iov-bcp-types/types/bcp.d.ts
@@ -1,5 +1,6 @@
 import { Stream } from "xstream";
 import { ChainId, PostableBytes, PublicKeyBundle, TxId } from "@iov/base-types";
+import { ValueAndUpdates } from "@iov/stream";
 import { Address, SignedTransaction, TxCodec } from "./signables";
 import { Nonce, TokenTicker, UnsignedTransaction } from "./transactions";
 export interface BcpQueryEnvelope<T> {
@@ -37,10 +38,29 @@ export interface BcpTicker {
      */
     readonly tokenName: string;
 }
+export declare enum BcpTransactionState {
+    /** accepted by a blockchain node and in mempool */
+    Pending = 0,
+    /** successfully written in a block, but cannot yet guarantee it won't be reverted */
+    InBlock = 1
+}
+/** Information attached to a signature about its state in a block */
+export declare type BcpBlockInfo = {
+    readonly state: BcpTransactionState.Pending;
+} | {
+    readonly state: BcpTransactionState.InBlock;
+    /** block height, if the transaction is included in a block */
+    readonly height: number;
+    /** depth of the transaction's block, starting at 1 as soon as transaction is in a block */
+    readonly confirmations: number;
+};
 export interface BcpTransactionResponse {
+    /** @deprecated use blockInfo instead */
     readonly metadata: {
         readonly height?: number;
     };
+    /** TODO: Make non-optional as soon as implemented everywhere */
+    readonly blockInfo?: ValueAndUpdates<BcpBlockInfo>;
     readonly data: {
         readonly message: string;
         readonly txid: TxId;

--- a/packages/iov-bcp-types/types/bcp.d.ts
+++ b/packages/iov-bcp-types/types/bcp.d.ts
@@ -59,8 +59,8 @@ export interface BcpTransactionResponse {
     readonly metadata: {
         readonly height?: number;
     };
-    /** TODO: Make non-optional as soon as implemented everywhere */
-    readonly blockInfo?: ValueAndUpdates<BcpBlockInfo>;
+    /** Information abot the block the transaction is in */
+    readonly blockInfo: ValueAndUpdates<BcpBlockInfo>;
     readonly data: {
         readonly message: string;
         readonly txid: TxId;

--- a/packages/iov-bcp-types/types/bcp.d.ts
+++ b/packages/iov-bcp-types/types/bcp.d.ts
@@ -49,6 +49,8 @@ export interface BcpTransactionResponse {
 }
 export interface ConfirmedTransaction<T extends UnsignedTransaction = UnsignedTransaction> extends SignedTransaction<T> {
     readonly height: number;
+    /** number of blocks on top of the transaction's block */
+    readonly confirmations: number;
     readonly txid: TxId;
     /** Data from executing tx (result, code, tags...) */
     readonly result?: Uint8Array;

--- a/packages/iov-bcp-types/types/bcp.d.ts
+++ b/packages/iov-bcp-types/types/bcp.d.ts
@@ -49,7 +49,7 @@ export interface BcpTransactionResponse {
 }
 export interface ConfirmedTransaction<T extends UnsignedTransaction = UnsignedTransaction> extends SignedTransaction<T> {
     readonly height: number;
-    /** number of blocks on top of the transaction's block */
+    /** depth of the transaction's block, starting at 1 as soon as transaction is in a block */
     readonly confirmations: number;
     readonly txid: TxId;
     /** Data from executing tx (result, code, tags...) */

--- a/packages/iov-bcp-types/types/bcp.d.ts
+++ b/packages/iov-bcp-types/types/bcp.d.ts
@@ -50,8 +50,9 @@ export interface BcpTransactionResponse {
 export interface ConfirmedTransaction<T extends UnsignedTransaction = UnsignedTransaction> extends SignedTransaction<T> {
     readonly height: number;
     readonly txid: TxId;
-    readonly result: Uint8Array;
-    readonly log: string;
+    /** Data from executing tx (result, code, tags...) */
+    readonly result?: Uint8Array;
+    readonly log?: string;
 }
 export interface BcpQueryTag {
     readonly key: string;

--- a/packages/iov-bns/package.json
+++ b/packages/iov-bns/package.json
@@ -43,6 +43,7 @@
     "@iov/tendermint-rpc": "^0.9.1",
     "@types/long": "^4.0.0",
     "@types/node": "^10.3.2",
+    "fast-deep-equal": "^2.0.1",
     "long": "^4.0.0",
     "protobufjs": "^6.8.6",
     "type-tagger": "^1.0.0",

--- a/packages/iov-bns/src/bnsconnection.spec.ts
+++ b/packages/iov-bns/src/bnsconnection.spec.ts
@@ -327,70 +327,73 @@ describe("BnsConnection", () => {
       connection.disconnect();
     });
 
-    it("can post transaction and watch confirmations", async done => {
+    it("can post transaction and watch confirmations", done => {
       pendingWithoutBnsd();
-      const connection = await BnsConnection.establish(bnsdTendermintUrl);
-      const chainId = await connection.chainId();
 
-      const { profile, mainWalletId, faucet } = await userProfileWithFaucet();
-      const faucetAddr = keyToAddress(faucet.pubkey);
-      const rcpt = await profile.createIdentity(mainWalletId, HdPaths.simpleAddress(2));
-      const rcptAddr = keyToAddress(rcpt.pubkey);
+      (async () => {
+        const connection = await BnsConnection.establish(bnsdTendermintUrl);
+        const chainId = await connection.chainId();
 
-      // construct a sendtx, this is normally used in the MultiChainSigner api
-      const sendTx: SendTx = {
-        kind: TransactionKind.Send,
-        chainId,
-        signer: faucet.pubkey,
-        recipient: rcptAddr,
-        memo: "My first payment",
-        amount: {
-          whole: 500,
-          fractional: 75000,
-          tokenTicker: cash,
-        },
-      };
-      const nonce = await getNonce(connection, faucetAddr);
-      const signed = await profile.signTransaction(mainWalletId, faucet, sendTx, bnsCodec, nonce);
-      const txBytes = bnsCodec.bytesToPost(signed);
-      const heightBeforeTransaction = await connection.height();
-      const result = await connection.postTx(txBytes);
-      expect(result.blockInfo!.value).toEqual({
-        state: BcpTransactionState.InBlock,
-        height: heightBeforeTransaction + 1,
-        confirmations: 1,
-      });
+        const { profile, mainWalletId, faucet } = await userProfileWithFaucet();
+        const faucetAddr = keyToAddress(faucet.pubkey);
+        const rcpt = await profile.createIdentity(mainWalletId, HdPaths.simpleAddress(2));
+        const rcptAddr = keyToAddress(rcpt.pubkey);
 
-      const events = new Array<BcpBlockInfo>();
-      const subscription = result.blockInfo!.updates.subscribe({
-        next: info => {
-          events.push(info);
+        // construct a sendtx, this is normally used in the MultiChainSigner api
+        const sendTx: SendTx = {
+          kind: TransactionKind.Send,
+          chainId,
+          signer: faucet.pubkey,
+          recipient: rcptAddr,
+          memo: "My first payment",
+          amount: {
+            whole: 500,
+            fractional: 75000,
+            tokenTicker: cash,
+          },
+        };
+        const nonce = await getNonce(connection, faucetAddr);
+        const signed = await profile.signTransaction(mainWalletId, faucet, sendTx, bnsCodec, nonce);
+        const txBytes = bnsCodec.bytesToPost(signed);
+        const heightBeforeTransaction = await connection.height();
+        const result = await connection.postTx(txBytes);
+        expect(result.blockInfo!.value).toEqual({
+          state: BcpTransactionState.InBlock,
+          height: heightBeforeTransaction + 1,
+          confirmations: 1,
+        });
 
-          if (events.length === 3) {
-            expect(events[0]).toEqual({
-              state: BcpTransactionState.InBlock,
-              height: heightBeforeTransaction + 1,
-              confirmations: 1,
-            });
-            expect(events[1]).toEqual({
-              state: BcpTransactionState.InBlock,
-              height: heightBeforeTransaction + 1,
-              confirmations: 2,
-            });
-            expect(events[2]).toEqual({
-              state: BcpTransactionState.InBlock,
-              height: heightBeforeTransaction + 1,
-              confirmations: 3,
-            });
+        const events = new Array<BcpBlockInfo>();
+        const subscription = result.blockInfo!.updates.subscribe({
+          next: info => {
+            events.push(info);
 
-            subscription.unsubscribe();
-            connection.disconnect();
-            done();
-          }
-        },
-        complete: fail,
-        error: fail,
-      });
+            if (events.length === 3) {
+              expect(events[0]).toEqual({
+                state: BcpTransactionState.InBlock,
+                height: heightBeforeTransaction + 1,
+                confirmations: 1,
+              });
+              expect(events[1]).toEqual({
+                state: BcpTransactionState.InBlock,
+                height: heightBeforeTransaction + 1,
+                confirmations: 2,
+              });
+              expect(events[2]).toEqual({
+                state: BcpTransactionState.InBlock,
+                height: heightBeforeTransaction + 1,
+                confirmations: 3,
+              });
+
+              subscription.unsubscribe();
+              connection.disconnect();
+              done();
+            }
+          },
+          complete: fail,
+          error: fail,
+        });
+      })().catch(fail);
     });
 
     it("can register a blockchain", async () => {

--- a/packages/iov-bns/src/bnsconnection.spec.ts
+++ b/packages/iov-bns/src/bnsconnection.spec.ts
@@ -357,14 +357,14 @@ describe("BnsConnection", () => {
         const txBytes = bnsCodec.bytesToPost(signed);
         const heightBeforeTransaction = await connection.height();
         const result = await connection.postTx(txBytes);
-        expect(result.blockInfo!.value).toEqual({
+        expect(result.blockInfo.value).toEqual({
           state: BcpTransactionState.InBlock,
           height: heightBeforeTransaction + 1,
           confirmations: 1,
         });
 
         const events = new Array<BcpBlockInfo>();
-        const subscription = result.blockInfo!.updates.subscribe({
+        const subscription = result.blockInfo.updates.subscribe({
           next: info => {
             events.push(info);
 

--- a/packages/iov-bns/src/bnsconnection.ts
+++ b/packages/iov-bns/src/bnsconnection.ts
@@ -321,7 +321,7 @@ export class BnsConnection implements BcpAtomicSwapConnection {
     const currentHeight = await this.height();
     const mapper = ({ tx, hash, height, txResult }: TxResponse): ConfirmedTransaction => ({
       height: height,
-      confirmations: currentHeight - height,
+      confirmations: currentHeight - height + 1,
       txid: hash as TxId,
       log: txResult.log,
       result: txResult.data,
@@ -340,7 +340,7 @@ export class BnsConnection implements BcpAtomicSwapConnection {
     // destructuring ftw (or is it too confusing?)
     const mapper = ({ hash, height, tx, result }: TxEvent): ConfirmedTransaction => ({
       height: height,
-      confirmations: 0, // assuming block height is current height when listening to events
+      confirmations: 1, // assuming block height is current height when listening to events
       txid: hash as TxId,
       log: result.log,
       result: result.data,

--- a/packages/iov-bns/src/bnsconnection.ts
+++ b/packages/iov-bns/src/bnsconnection.ts
@@ -318,8 +318,10 @@ export class BnsConnection implements BcpAtomicSwapConnection {
     // FIXME: consider making a streaming interface here, but that will break clients
     const res = await this.tmClient.txSearchAll({ query: buildTxQuery(txQuery) });
     const chainId = await this.chainId();
+    const currentHeight = await this.height();
     const mapper = ({ tx, hash, height, txResult }: TxResponse): ConfirmedTransaction => ({
-      height,
+      height: height,
+      confirmations: currentHeight - height,
       txid: hash as TxId,
       log: txResult.log,
       result: txResult.data,
@@ -337,7 +339,8 @@ export class BnsConnection implements BcpAtomicSwapConnection {
 
     // destructuring ftw (or is it too confusing?)
     const mapper = ({ hash, height, tx, result }: TxEvent): ConfirmedTransaction => ({
-      height,
+      height: height,
+      confirmations: 0, // assuming block height is current height when listening to events
       txid: hash as TxId,
       log: result.log,
       result: result.data,

--- a/packages/iov-bns/src/bnsconnection.ts
+++ b/packages/iov-bns/src/bnsconnection.ts
@@ -321,8 +321,8 @@ export class BnsConnection implements BcpAtomicSwapConnection {
     const mapper = ({ tx, hash, height, txResult }: TxResponse): ConfirmedTransaction => ({
       height,
       txid: hash as TxId,
-      log: txResult.log || "",
-      result: txResult.data || new Uint8Array([]),
+      log: txResult.log,
+      result: txResult.data,
       ...this.codec.parseBytes(tx, chainId),
     });
     return res.txs.map(mapper);
@@ -339,8 +339,8 @@ export class BnsConnection implements BcpAtomicSwapConnection {
     const mapper = ({ hash, height, tx, result }: TxEvent): ConfirmedTransaction => ({
       height,
       txid: hash as TxId,
-      log: result.log || "",
-      result: result.data || new Uint8Array([]),
+      log: result.log,
+      result: result.data,
       ...this.codec.parseBytes(tx, chainId),
     });
     return txs.map(mapper);

--- a/packages/iov-lisk/package.json
+++ b/packages/iov-lisk/package.json
@@ -36,8 +36,10 @@
     "@iov/dpos": "^0.9.1",
     "@iov/encoding": "^0.9.0",
     "@iov/keycontrol": "^0.9.1",
+    "@iov/stream": "^0.9.1",
     "@types/long": "^4.0.0",
     "axios": "^0.18.0",
+    "fast-deep-equal": "^2.0.1",
     "long": "^4.0.0",
     "readonly-date": "^1.0.0",
     "xstream": "^11.7.0"

--- a/packages/iov-lisk/src/liskconnection.spec.ts
+++ b/packages/iov-lisk/src/liskconnection.spec.ts
@@ -1,6 +1,7 @@
 import { Algorithm, ChainId, PublicKeyBundle, PublicKeyBytes, SignatureBytes, TxId } from "@iov/base-types";
 import {
   Address,
+  Amount,
   BcpAccountQuery,
   BcpBlockInfo,
   BcpTransactionState,
@@ -31,6 +32,15 @@ describe("LiskConnection", () => {
   // a local devnet
   const devnetBase = "http://localhost:4000";
   const devnetChainId = "198f2b61a8eb95fbeed58b8216780b68f697f26b849acf00c8c93bb9b24f783d" as ChainId;
+  const devnetDefaultRecipient = "16313739661670634666L" as Address;
+  const devnetDefaultKeypair = Derivation.passphraseToKeypair(
+    "wagon stock borrow episode laundry kitten salute link globe zero feed marble",
+  );
+  const devnetDefaultAmount: Amount = {
+    whole: 1,
+    fractional: 44550000,
+    tokenTicker: "LSK" as TokenTicker,
+  };
 
   it("can be constructed", () => {
     const connection = new LiskConnection(dummynetBase, dummynetChainId);
@@ -184,25 +194,15 @@ describe("LiskConnection", () => {
     pendingWithoutLiskDevnet();
 
     const wallet = new Ed25519Wallet();
-    const mainIdentity = await wallet.createIdentity(
-      await Derivation.passphraseToKeypair(
-        "wagon stock borrow episode laundry kitten salute link globe zero feed marble",
-      ),
-    );
-
-    const recipientAddress = "16313739661670634666L" as Address;
+    const mainIdentity = await wallet.createIdentity(await devnetDefaultKeypair);
 
     const sendTx: SendTx = {
       kind: TransactionKind.Send,
       chainId: devnetChainId,
       signer: mainIdentity.pubkey,
-      recipient: recipientAddress,
-      memo: "We ❤️ developers – iov.one",
-      amount: {
-        whole: 1,
-        fractional: 44550000,
-        tokenTicker: "LSK" as TokenTicker,
-      },
+      recipient: devnetDefaultRecipient,
+      memo: `We ❤️ developers – iov.one ${Math.random()}`,
+      amount: devnetDefaultAmount,
     };
 
     // Encode creation timestamp into nonce
@@ -235,25 +235,15 @@ describe("LiskConnection", () => {
     pendingWithoutLiskDevnet();
 
     const wallet = new Ed25519Wallet();
-    const mainIdentity = await wallet.createIdentity(
-      await Derivation.passphraseToKeypair(
-        "wagon stock borrow episode laundry kitten salute link globe zero feed marble",
-      ),
-    );
-
-    const recipientAddress = "16313739661670634666L" as Address;
+    const mainIdentity = await wallet.createIdentity(await devnetDefaultKeypair);
 
     const sendTx: SendTx = {
       kind: TransactionKind.Send,
       chainId: devnetChainId,
       signer: mainIdentity.pubkey,
-      recipient: recipientAddress,
-      memo: "We ❤️ developers – iov.one",
-      amount: {
-        whole: 1,
-        fractional: 44550000,
-        tokenTicker: "LSK" as TokenTicker,
-      },
+      recipient: devnetDefaultRecipient,
+      memo: `We ❤️ developers – iov.one ${Math.random()}`,
+      amount: devnetDefaultAmount,
     };
 
     // Encode creation timestamp into nonce
@@ -288,17 +278,12 @@ describe("LiskConnection", () => {
       next: info => {
         events.push(info);
 
-        if (events.length === 3) {
+        if (events.length === 2) {
           expect(events[0]).toEqual({ state: BcpTransactionState.Pending });
           expect(events[1]).toEqual({
             state: BcpTransactionState.InBlock,
             height: heightBeforeTransaction + 1,
             confirmations: 1,
-          });
-          expect(events[2]).toEqual({
-            state: BcpTransactionState.InBlock,
-            height: heightBeforeTransaction + 1,
-            confirmations: 2,
           });
           subscription.unsubscribe();
           done();
@@ -313,25 +298,15 @@ describe("LiskConnection", () => {
     pendingWithoutLiskDevnet();
 
     const wallet = new Ed25519Wallet();
-    const mainIdentity = await wallet.createIdentity(
-      await Derivation.passphraseToKeypair(
-        "wagon stock borrow episode laundry kitten salute link globe zero feed marble",
-      ),
-    );
-
-    const recipientAddress = "16313739661670634666L" as Address;
+    const mainIdentity = await wallet.createIdentity(await devnetDefaultKeypair);
 
     const sendTx: SendTx = {
       kind: TransactionKind.Send,
       chainId: devnetChainId,
       signer: mainIdentity.pubkey,
-      recipient: recipientAddress,
+      recipient: devnetDefaultRecipient,
       memo: `We ❤️ developers – iov.one ${Math.random()}`,
-      amount: {
-        whole: 1,
-        fractional: 44550000,
-        tokenTicker: "LSK" as TokenTicker,
-      },
+      amount: devnetDefaultAmount,
     };
 
     // Encode creation timestamp into nonce
@@ -373,25 +348,15 @@ describe("LiskConnection", () => {
     pendingWithoutLiskDevnet();
 
     const wallet = new Ed25519Wallet();
-    const mainIdentity = await wallet.createIdentity(
-      await Derivation.passphraseToKeypair(
-        "wagon stock borrow episode laundry kitten salute link globe zero feed marble",
-      ),
-    );
-
-    const recipientAddress = "16313739661670634666L" as Address;
+    const mainIdentity = await wallet.createIdentity(await devnetDefaultKeypair);
 
     const sendTx: SendTx = {
       kind: TransactionKind.Send,
       chainId: devnetChainId,
       signer: mainIdentity.pubkey,
-      recipient: recipientAddress,
+      recipient: devnetDefaultRecipient,
       memo: "We ❤️ developers – iov.one",
-      amount: {
-        whole: 1,
-        fractional: 44550000,
-        tokenTicker: "LSK" as TokenTicker,
-      },
+      amount: devnetDefaultAmount,
     };
 
     // Encode creation timestamp into nonce

--- a/packages/iov-lisk/src/liskconnection.spec.ts
+++ b/packages/iov-lisk/src/liskconnection.spec.ts
@@ -273,10 +273,10 @@ describe("LiskConnection", () => {
         const heightBeforeTransaction = await connection.height();
         const result = await connection.postTx(bytesToPost);
         expect(result).toBeTruthy();
-        expect(result.blockInfo!.value.state).toEqual(BcpTransactionState.Pending);
+        expect(result.blockInfo.value.state).toEqual(BcpTransactionState.Pending);
 
         const events = new Array<BcpBlockInfo>();
-        const subscription = result.blockInfo!.updates.subscribe({
+        const subscription = result.blockInfo.updates.subscribe({
           next: info => {
             events.push(info);
 
@@ -336,11 +336,11 @@ describe("LiskConnection", () => {
       const connection = await LiskConnection.establish(devnetBase);
       const heightBeforeTransaction = await connection.height();
       const result = await connection.postTx(bytesToPost);
-      await result.blockInfo!.waitFor(
+      await result.blockInfo.waitFor(
         info => info.state === BcpTransactionState.InBlock && info.confirmations === 4,
       );
 
-      expect(result.blockInfo!.value).toEqual({
+      expect(result.blockInfo.value).toEqual({
         state: BcpTransactionState.InBlock,
         height: heightBeforeTransaction + 1,
         confirmations: 4,

--- a/packages/iov-lisk/src/liskconnection.spec.ts
+++ b/packages/iov-lisk/src/liskconnection.spec.ts
@@ -190,235 +190,237 @@ describe("LiskConnection", () => {
     expect(nonce.data[0].nonce.toNumber()).toBeLessThanOrEqual(Date.now() / 1000 + 1);
   });
 
-  it("can post transaction", async () => {
-    pendingWithoutLiskDevnet();
+  describe("postTx", () => {
+    it("can post transaction", async () => {
+      pendingWithoutLiskDevnet();
 
-    const wallet = new Ed25519Wallet();
-    const mainIdentity = await wallet.createIdentity(await devnetDefaultKeypair);
+      const wallet = new Ed25519Wallet();
+      const mainIdentity = await wallet.createIdentity(await devnetDefaultKeypair);
 
-    const sendTx: SendTx = {
-      kind: TransactionKind.Send,
-      chainId: devnetChainId,
-      signer: mainIdentity.pubkey,
-      recipient: devnetDefaultRecipient,
-      memo: `We ❤️ developers – iov.one ${Math.random()}`,
-      amount: devnetDefaultAmount,
-    };
+      const sendTx: SendTx = {
+        kind: TransactionKind.Send,
+        chainId: devnetChainId,
+        signer: mainIdentity.pubkey,
+        recipient: devnetDefaultRecipient,
+        memo: `We ❤️ developers – iov.one ${Math.random()}`,
+        amount: devnetDefaultAmount,
+      };
 
-    // Encode creation timestamp into nonce
-    const nonce = generateNonce();
-    const signingJob = liskCodec.bytesToSign(sendTx, nonce);
-    const signature = await wallet.createTransactionSignature(
-      mainIdentity,
-      signingJob.bytes,
-      signingJob.prehashType,
-      devnetChainId,
-    );
+      // Encode creation timestamp into nonce
+      const nonce = generateNonce();
+      const signingJob = liskCodec.bytesToSign(sendTx, nonce);
+      const signature = await wallet.createTransactionSignature(
+        mainIdentity,
+        signingJob.bytes,
+        signingJob.prehashType,
+        devnetChainId,
+      );
 
-    const signedTransaction: SignedTransaction = {
-      transaction: sendTx,
-      primarySignature: {
-        nonce: nonce,
-        pubkey: mainIdentity.pubkey,
-        signature: signature,
-      },
-      otherSignatures: [],
-    };
-    const bytesToPost = liskCodec.bytesToPost(signedTransaction);
+      const signedTransaction: SignedTransaction = {
+        transaction: sendTx,
+        primarySignature: {
+          nonce: nonce,
+          pubkey: mainIdentity.pubkey,
+          signature: signature,
+        },
+        otherSignatures: [],
+      };
+      const bytesToPost = liskCodec.bytesToPost(signedTransaction);
 
-    const connection = await LiskConnection.establish(devnetBase);
-    const result = await connection.postTx(bytesToPost);
-    expect(result).toBeTruthy();
-  });
-
-  it("can post transaction and watch confirmations", async done => {
-    pendingWithoutLiskDevnet();
-
-    const wallet = new Ed25519Wallet();
-    const mainIdentity = await wallet.createIdentity(await devnetDefaultKeypair);
-
-    const sendTx: SendTx = {
-      kind: TransactionKind.Send,
-      chainId: devnetChainId,
-      signer: mainIdentity.pubkey,
-      recipient: devnetDefaultRecipient,
-      memo: `We ❤️ developers – iov.one ${Math.random()}`,
-      amount: devnetDefaultAmount,
-    };
-
-    // Encode creation timestamp into nonce
-    const nonce = generateNonce();
-    const signingJob = liskCodec.bytesToSign(sendTx, nonce);
-    const signature = await wallet.createTransactionSignature(
-      mainIdentity,
-      signingJob.bytes,
-      signingJob.prehashType,
-      devnetChainId,
-    );
-
-    const signedTransaction: SignedTransaction = {
-      transaction: sendTx,
-      primarySignature: {
-        nonce: nonce,
-        pubkey: mainIdentity.pubkey,
-        signature: signature,
-      },
-      otherSignatures: [],
-    };
-    const bytesToPost = liskCodec.bytesToPost(signedTransaction);
-
-    const connection = await LiskConnection.establish(devnetBase);
-    const heightBeforeTransaction = await connection.height();
-    const result = await connection.postTx(bytesToPost);
-    expect(result).toBeTruthy();
-    expect(result.blockInfo!.value.state).toEqual(BcpTransactionState.Pending);
-
-    const events = new Array<BcpBlockInfo>();
-    const subscription = result.blockInfo!.updates.subscribe({
-      next: info => {
-        events.push(info);
-
-        if (events.length === 2) {
-          expect(events[0]).toEqual({ state: BcpTransactionState.Pending });
-          expect(events[1]).toEqual({
-            state: BcpTransactionState.InBlock,
-            height: heightBeforeTransaction + 1,
-            confirmations: 1,
-          });
-          subscription.unsubscribe();
-          done();
-        }
-      },
-      complete: fail,
-      error: fail,
+      const connection = await LiskConnection.establish(devnetBase);
+      const result = await connection.postTx(bytesToPost);
+      expect(result).toBeTruthy();
     });
-  }, 30000);
 
-  xit("can post transaction and wait for 4 confirmations", async () => {
-    pendingWithoutLiskDevnet();
+    it("can post transaction and watch confirmations", async done => {
+      pendingWithoutLiskDevnet();
 
-    const wallet = new Ed25519Wallet();
-    const mainIdentity = await wallet.createIdentity(await devnetDefaultKeypair);
+      const wallet = new Ed25519Wallet();
+      const mainIdentity = await wallet.createIdentity(await devnetDefaultKeypair);
 
-    const sendTx: SendTx = {
-      kind: TransactionKind.Send,
-      chainId: devnetChainId,
-      signer: mainIdentity.pubkey,
-      recipient: devnetDefaultRecipient,
-      memo: `We ❤️ developers – iov.one ${Math.random()}`,
-      amount: devnetDefaultAmount,
-    };
+      const sendTx: SendTx = {
+        kind: TransactionKind.Send,
+        chainId: devnetChainId,
+        signer: mainIdentity.pubkey,
+        recipient: devnetDefaultRecipient,
+        memo: `We ❤️ developers – iov.one ${Math.random()}`,
+        amount: devnetDefaultAmount,
+      };
 
-    // Encode creation timestamp into nonce
-    const nonce = generateNonce();
-    const signingJob = liskCodec.bytesToSign(sendTx, nonce);
-    const signature = await wallet.createTransactionSignature(
-      mainIdentity,
-      signingJob.bytes,
-      signingJob.prehashType,
-      devnetChainId,
-    );
+      // Encode creation timestamp into nonce
+      const nonce = generateNonce();
+      const signingJob = liskCodec.bytesToSign(sendTx, nonce);
+      const signature = await wallet.createTransactionSignature(
+        mainIdentity,
+        signingJob.bytes,
+        signingJob.prehashType,
+        devnetChainId,
+      );
 
-    const signedTransaction: SignedTransaction = {
-      transaction: sendTx,
-      primarySignature: {
-        nonce: nonce,
-        pubkey: mainIdentity.pubkey,
-        signature: signature,
-      },
-      otherSignatures: [],
-    };
-    const bytesToPost = liskCodec.bytesToPost(signedTransaction);
+      const signedTransaction: SignedTransaction = {
+        transaction: sendTx,
+        primarySignature: {
+          nonce: nonce,
+          pubkey: mainIdentity.pubkey,
+          signature: signature,
+        },
+        otherSignatures: [],
+      };
+      const bytesToPost = liskCodec.bytesToPost(signedTransaction);
 
-    const connection = await LiskConnection.establish(devnetBase);
-    const heightBeforeTransaction = await connection.height();
-    const result = await connection.postTx(bytesToPost);
-    await result.blockInfo!.waitFor(
-      info => info.state === BcpTransactionState.InBlock && info.confirmations === 4,
-    );
+      const connection = await LiskConnection.establish(devnetBase);
+      const heightBeforeTransaction = await connection.height();
+      const result = await connection.postTx(bytesToPost);
+      expect(result).toBeTruthy();
+      expect(result.blockInfo!.value.state).toEqual(BcpTransactionState.Pending);
 
-    expect(result.blockInfo!.value).toEqual({
-      state: BcpTransactionState.InBlock,
-      height: heightBeforeTransaction + 1,
-      confirmations: 4,
+      const events = new Array<BcpBlockInfo>();
+      const subscription = result.blockInfo!.updates.subscribe({
+        next: info => {
+          events.push(info);
+
+          if (events.length === 2) {
+            expect(events[0]).toEqual({ state: BcpTransactionState.Pending });
+            expect(events[1]).toEqual({
+              state: BcpTransactionState.InBlock,
+              height: heightBeforeTransaction + 1,
+              confirmations: 1,
+            });
+            subscription.unsubscribe();
+            done();
+          }
+        },
+        complete: fail,
+        error: fail,
+      });
+    }, 30000);
+
+    xit("can post transaction and wait for 4 confirmations", async () => {
+      pendingWithoutLiskDevnet();
+
+      const wallet = new Ed25519Wallet();
+      const mainIdentity = await wallet.createIdentity(await devnetDefaultKeypair);
+
+      const sendTx: SendTx = {
+        kind: TransactionKind.Send,
+        chainId: devnetChainId,
+        signer: mainIdentity.pubkey,
+        recipient: devnetDefaultRecipient,
+        memo: `We ❤️ developers – iov.one ${Math.random()}`,
+        amount: devnetDefaultAmount,
+      };
+
+      // Encode creation timestamp into nonce
+      const nonce = generateNonce();
+      const signingJob = liskCodec.bytesToSign(sendTx, nonce);
+      const signature = await wallet.createTransactionSignature(
+        mainIdentity,
+        signingJob.bytes,
+        signingJob.prehashType,
+        devnetChainId,
+      );
+
+      const signedTransaction: SignedTransaction = {
+        transaction: sendTx,
+        primarySignature: {
+          nonce: nonce,
+          pubkey: mainIdentity.pubkey,
+          signature: signature,
+        },
+        otherSignatures: [],
+      };
+      const bytesToPost = liskCodec.bytesToPost(signedTransaction);
+
+      const connection = await LiskConnection.establish(devnetBase);
+      const heightBeforeTransaction = await connection.height();
+      const result = await connection.postTx(bytesToPost);
+      await result.blockInfo!.waitFor(
+        info => info.state === BcpTransactionState.InBlock && info.confirmations === 4,
+      );
+
+      expect(result.blockInfo!.value).toEqual({
+        state: BcpTransactionState.InBlock,
+        height: heightBeforeTransaction + 1,
+        confirmations: 4,
+      });
+    }, 60000);
+
+    it("throws for invalid transaction", async () => {
+      pendingWithoutLiskDevnet();
+
+      const wallet = new Ed25519Wallet();
+      const mainIdentity = await wallet.createIdentity(await devnetDefaultKeypair);
+
+      const sendTx: SendTx = {
+        kind: TransactionKind.Send,
+        chainId: devnetChainId,
+        signer: mainIdentity.pubkey,
+        recipient: devnetDefaultRecipient,
+        memo: "We ❤️ developers – iov.one",
+        amount: devnetDefaultAmount,
+      };
+
+      // Encode creation timestamp into nonce
+      const nonce = generateNonce();
+      const signingJob = liskCodec.bytesToSign(sendTx, nonce);
+      const signature = await wallet.createTransactionSignature(
+        mainIdentity,
+        signingJob.bytes,
+        signingJob.prehashType,
+        devnetChainId,
+      );
+
+      // tslint:disable-next-line:no-bitwise
+      const corruptedSignature = signature.map((x, i) => (i === 0 ? x ^ 0x01 : x)) as SignatureBytes;
+
+      const signedTransaction: SignedTransaction = {
+        transaction: sendTx,
+        primarySignature: {
+          nonce: nonce,
+          pubkey: mainIdentity.pubkey,
+          signature: corruptedSignature,
+        },
+        otherSignatures: [],
+      };
+      const bytesToPost = liskCodec.bytesToPost(signedTransaction);
+
+      const connection = await LiskConnection.establish(devnetBase);
+      await connection
+        .postTx(bytesToPost)
+        .then(() => fail("must not resolve"))
+        .catch(error => expect(error).toMatch(/failed with status code 409/i));
     });
-  }, 60000);
 
-  it("throws for invalid transaction", async () => {
-    pendingWithoutLiskDevnet();
+    it("can search transaction", async () => {
+      pendingWithoutLiskDevnet();
+      const connection = await LiskConnection.establish(devnetBase);
 
-    const wallet = new Ed25519Wallet();
-    const mainIdentity = await wallet.createIdentity(await devnetDefaultKeypair);
-
-    const sendTx: SendTx = {
-      kind: TransactionKind.Send,
-      chainId: devnetChainId,
-      signer: mainIdentity.pubkey,
-      recipient: devnetDefaultRecipient,
-      memo: "We ❤️ developers – iov.one",
-      amount: devnetDefaultAmount,
-    };
-
-    // Encode creation timestamp into nonce
-    const nonce = generateNonce();
-    const signingJob = liskCodec.bytesToSign(sendTx, nonce);
-    const signature = await wallet.createTransactionSignature(
-      mainIdentity,
-      signingJob.bytes,
-      signingJob.prehashType,
-      devnetChainId,
-    );
-
-    // tslint:disable-next-line:no-bitwise
-    const corruptedSignature = signature.map((x, i) => (i === 0 ? x ^ 0x01 : x)) as SignatureBytes;
-
-    const signedTransaction: SignedTransaction = {
-      transaction: sendTx,
-      primarySignature: {
-        nonce: nonce,
-        pubkey: mainIdentity.pubkey,
-        signature: corruptedSignature,
-      },
-      otherSignatures: [],
-    };
-    const bytesToPost = liskCodec.bytesToPost(signedTransaction);
-
-    const connection = await LiskConnection.establish(devnetBase);
-    await connection
-      .postTx(bytesToPost)
-      .then(() => fail("must not resolve"))
-      .catch(error => expect(error).toMatch(/failed with status code 409/i));
-  });
-
-  it("can search transaction", async () => {
-    pendingWithoutLiskDevnet();
-    const connection = await LiskConnection.establish(devnetBase);
-
-    // by non-existing ID
-    {
-      const searchId = "98568736528934587";
-      const results = await connection.searchTx({ hash: toAscii(searchId) as TxId, tags: [] });
-      expect(results.length).toEqual(0);
-    }
-
-    // by existing ID (from lisk/init.sh)
-    {
-      const searchId = "12493173350733478622";
-      const results = await connection.searchTx({ hash: toAscii(searchId) as TxId, tags: [] });
-      expect(results.length).toEqual(1);
-      const result = results[0];
-      expect(result.height).toBeGreaterThanOrEqual(2);
-      expect(result.height).toBeLessThan(100);
-      expect(result.txid).toEqual(toAscii(searchId));
-      const transaction = result.transaction;
-      if (transaction.kind !== TransactionKind.Send) {
-        throw new Error("Unexpected transaction type");
+      // by non-existing ID
+      {
+        const searchId = "98568736528934587";
+        const results = await connection.searchTx({ hash: toAscii(searchId) as TxId, tags: [] });
+        expect(results.length).toEqual(0);
       }
-      expect(transaction.recipient).toEqual("1349293588603668134L");
-      expect(transaction.amount.whole).toEqual(100);
-      expect(transaction.amount.fractional).toEqual(44556677);
-    }
 
-    connection.disconnect();
+      // by existing ID (from lisk/init.sh)
+      {
+        const searchId = "12493173350733478622";
+        const results = await connection.searchTx({ hash: toAscii(searchId) as TxId, tags: [] });
+        expect(results.length).toEqual(1);
+        const result = results[0];
+        expect(result.height).toBeGreaterThanOrEqual(2);
+        expect(result.height).toBeLessThan(100);
+        expect(result.txid).toEqual(toAscii(searchId));
+        const transaction = result.transaction;
+        if (transaction.kind !== TransactionKind.Send) {
+          throw new Error("Unexpected transaction type");
+        }
+        expect(transaction.recipient).toEqual("1349293588603668134L");
+        expect(transaction.amount.whole).toEqual(100);
+        expect(transaction.amount.fractional).toEqual(44556677);
+      }
+
+      connection.disconnect();
+    });
   });
 });

--- a/packages/iov-lisk/src/liskconnection.ts
+++ b/packages/iov-lisk/src/liskconnection.ts
@@ -228,7 +228,6 @@ export class LiskConnection implements BcpConnection {
           ...transaction,
           height: height.toNumber(),
           txid: query.hash,
-          result: new Uint8Array([]),
           log: `Found transaction with ${confirmations} confirmations`,
         },
       ];

--- a/packages/iov-lisk/src/liskconnection.ts
+++ b/packages/iov-lisk/src/liskconnection.ts
@@ -33,6 +33,9 @@ import { liskCodec } from "./liskcodec";
 
 const { fromAscii, toAscii, toUtf8 } = Encoding;
 
+// poll every 3 seconds (block time 10s)
+const transactionStatePollInterval = 3_000;
+
 /**
  * Encodes the current date and time as a nonce
  */
@@ -129,7 +132,7 @@ export class LiskConnection implements BcpConnection {
                 lastEventSent = event;
               }
             }
-          }, 3000);
+          }, transactionStatePollInterval);
         },
         onStop: () => clearInterval(blockInfoInterval),
       },

--- a/packages/iov-lisk/src/liskconnection.ts
+++ b/packages/iov-lisk/src/liskconnection.ts
@@ -227,8 +227,8 @@ export class LiskConnection implements BcpConnection {
         {
           ...transaction,
           height: height.toNumber(),
+          confirmations: confirmations.toNumber(),
           txid: query.hash,
-          log: `Found transaction with ${confirmations} confirmations`,
         },
       ];
     } else {

--- a/packages/iov-lisk/types/liskconnection.d.ts
+++ b/packages/iov-lisk/types/liskconnection.d.ts
@@ -21,7 +21,7 @@ export declare class LiskConnection implements BcpConnection {
     changeBlock(): Stream<number>;
     watchAccount(_: BcpAccountQuery): Stream<BcpAccount | undefined>;
     watchNonce(_: BcpAccountQuery): Stream<BcpNonce | undefined>;
-    searchTx(_: BcpTxQuery): Promise<ReadonlyArray<ConfirmedTransaction>>;
+    searchTx(query: BcpTxQuery): Promise<ReadonlyArray<ConfirmedTransaction>>;
     listenTx(_: ReadonlyArray<BcpQueryTag>): Stream<ConfirmedTransaction>;
     liveTx(_: BcpTxQuery): Stream<ConfirmedTransaction>;
 }

--- a/packages/iov-rise/package.json
+++ b/packages/iov-rise/package.json
@@ -36,8 +36,10 @@
     "@iov/dpos": "^0.9.1",
     "@iov/encoding": "^0.9.0",
     "@iov/keycontrol": "^0.9.1",
+    "@iov/stream": "^0.9.1",
     "@types/long": "^4.0.0",
     "axios": "^0.18.0",
+    "fast-deep-equal": "^2.0.1",
     "long": "^4.0.0",
     "readonly-date": "^1.0.0",
     "xstream": "^11.7.0"

--- a/packages/iov-rise/src/riseconnection.spec.ts
+++ b/packages/iov-rise/src/riseconnection.spec.ts
@@ -19,6 +19,10 @@ const riseTestnet = "e90d39ac200c495b97deb6d9700745177c7fc4aa80a404108ec820cbece
 
 describe("RiseConnection", () => {
   const base = "https://twallet.rise.vision";
+  const defaultKeypair = Derivation.passphraseToKeypair(
+    "squeeze frog deposit chase sudden clutch fortune spring tone have snow column",
+  );
+  const defaultRecipientAddress = "10145108642177909005R" as Address;
   const defaultSendAmount = {
     whole: 0,
     fractional: 14550000,
@@ -167,19 +171,13 @@ describe("RiseConnection", () => {
 
   it("can post transaction", async () => {
     const wallet = new Ed25519Wallet();
-    const mainIdentity = await wallet.createIdentity(
-      await Derivation.passphraseToKeypair(
-        "squeeze frog deposit chase sudden clutch fortune spring tone have snow column",
-      ),
-    );
-
-    const recipientAddress = "10145108642177909005R" as Address;
+    const mainIdentity = await wallet.createIdentity(await defaultKeypair);
 
     const sendTx: SendTx = {
       kind: TransactionKind.Send,
       chainId: riseTestnet,
       signer: mainIdentity.pubkey,
-      recipient: recipientAddress,
+      recipient: defaultRecipientAddress,
       amount: defaultSendAmount,
     };
 
@@ -211,19 +209,13 @@ describe("RiseConnection", () => {
 
   it("throws for transaction with corrupted signature", async () => {
     const wallet = new Ed25519Wallet();
-    const mainIdentity = await wallet.createIdentity(
-      await Derivation.passphraseToKeypair(
-        "squeeze frog deposit chase sudden clutch fortune spring tone have snow column",
-      ),
-    );
-
-    const recipientAddress = "10145108642177909005R" as Address;
+    const mainIdentity = await wallet.createIdentity(await defaultKeypair);
 
     const sendTx: SendTx = {
       kind: TransactionKind.Send,
       chainId: riseTestnet,
       signer: mainIdentity.pubkey,
-      recipient: recipientAddress,
+      recipient: defaultRecipientAddress,
       amount: defaultSendAmount,
     };
 

--- a/packages/iov-rise/src/riseconnection.spec.ts
+++ b/packages/iov-rise/src/riseconnection.spec.ts
@@ -248,10 +248,10 @@ describe("RiseConnection", () => {
         const heightBeforeTransaction = await connection.height();
         const result = await connection.postTx(bytesToPost);
         expect(result).toBeTruthy();
-        expect(result.blockInfo!.value.state).toEqual(BcpTransactionState.Pending);
+        expect(result.blockInfo.value.state).toEqual(BcpTransactionState.Pending);
 
         const events = new Array<BcpBlockInfo>();
-        const subscription = result.blockInfo!.updates.subscribe({
+        const subscription = result.blockInfo.updates.subscribe({
           next: info => {
             events.push(info);
 

--- a/packages/iov-rise/src/riseconnection.spec.ts
+++ b/packages/iov-rise/src/riseconnection.spec.ts
@@ -1,4 +1,4 @@
-import { Algorithm, ChainId, PublicKeyBundle, PublicKeyBytes, SignatureBytes } from "@iov/base-types";
+import { Algorithm, ChainId, PublicKeyBundle, PublicKeyBytes, SignatureBytes, TxId } from "@iov/base-types";
 import {
   Address,
   BcpAccountQuery,
@@ -14,7 +14,7 @@ import { Ed25519Wallet } from "@iov/keycontrol";
 import { riseCodec } from "./risecodec";
 import { generateNonce, RiseConnection } from "./riseconnection";
 
-const { fromHex } = Encoding;
+const { fromHex, toAscii } = Encoding;
 const riseTestnet = "e90d39ac200c495b97deb6d9700745177c7fc4aa80a404108ec820cbeced054c" as ChainId;
 
 describe("RiseConnection", () => {
@@ -249,6 +249,38 @@ describe("RiseConnection", () => {
         .postTx(bytesToPost)
         .then(() => fail("must not resolve"))
         .catch(error => expect(error).toMatch(/Failed to verify signature/i));
+    });
+  });
+
+  describe("searchTx", () => {
+    it("can search transaction", async () => {
+      const connection = await RiseConnection.establish(base);
+
+      // by non-existing ID
+      {
+        const searchId = "98568736528934587";
+        const results = await connection.searchTx({ hash: toAscii(searchId) as TxId, tags: [] });
+        expect(results.length).toEqual(0);
+      }
+
+      // by existing ID (https://texplorer.rise.vision/tx/530955287567640950)
+      {
+        const searchId = "530955287567640950";
+        const results = await connection.searchTx({ hash: toAscii(searchId) as TxId, tags: [] });
+        expect(results.length).toEqual(1);
+        const result = results[0];
+        expect(result.height).toEqual(1156579);
+        expect(result.txid).toEqual(toAscii(searchId));
+        const transaction = result.transaction;
+        if (transaction.kind !== TransactionKind.Send) {
+          throw new Error("Unexpected transaction type");
+        }
+        expect(transaction.recipient).toEqual("10145108642177909005R");
+        expect(transaction.amount.whole).toEqual(0);
+        expect(transaction.amount.fractional).toEqual(14550000);
+      }
+
+      connection.disconnect();
     });
   });
 });

--- a/packages/iov-rise/src/riseconnection.spec.ts
+++ b/packages/iov-rise/src/riseconnection.spec.ts
@@ -210,64 +210,66 @@ describe("RiseConnection", () => {
       expect(result).toBeTruthy();
     });
 
-    xit("can post transaction and watch confirmations", async done => {
-      const wallet = new Ed25519Wallet();
-      const mainIdentity = await wallet.createIdentity(await defaultKeypair);
+    xit("can post transaction and watch confirmations", done => {
+      (async () => {
+        const wallet = new Ed25519Wallet();
+        const mainIdentity = await wallet.createIdentity(await defaultKeypair);
 
-      const sendTx: SendTx = {
-        kind: TransactionKind.Send,
-        chainId: riseTestnet,
-        signer: mainIdentity.pubkey,
-        recipient: defaultRecipientAddress,
-        amount: defaultSendAmount,
-      };
+        const sendTx: SendTx = {
+          kind: TransactionKind.Send,
+          chainId: riseTestnet,
+          signer: mainIdentity.pubkey,
+          recipient: defaultRecipientAddress,
+          amount: defaultSendAmount,
+        };
 
-      // Encode creation timestamp into nonce
-      const nonce = generateNonce();
-      const signingJob = riseCodec.bytesToSign(sendTx, nonce);
-      const signature = await wallet.createTransactionSignature(
-        mainIdentity,
-        signingJob.bytes,
-        signingJob.prehashType,
-        riseTestnet,
-      );
+        // Encode creation timestamp into nonce
+        const nonce = generateNonce();
+        const signingJob = riseCodec.bytesToSign(sendTx, nonce);
+        const signature = await wallet.createTransactionSignature(
+          mainIdentity,
+          signingJob.bytes,
+          signingJob.prehashType,
+          riseTestnet,
+        );
 
-      const signedTransaction: SignedTransaction = {
-        transaction: sendTx,
-        primarySignature: {
-          nonce: nonce,
-          pubkey: mainIdentity.pubkey,
-          signature: signature,
-        },
-        otherSignatures: [],
-      };
-      const bytesToPost = riseCodec.bytesToPost(signedTransaction);
+        const signedTransaction: SignedTransaction = {
+          transaction: sendTx,
+          primarySignature: {
+            nonce: nonce,
+            pubkey: mainIdentity.pubkey,
+            signature: signature,
+          },
+          otherSignatures: [],
+        };
+        const bytesToPost = riseCodec.bytesToPost(signedTransaction);
 
-      const connection = await RiseConnection.establish(base);
-      const heightBeforeTransaction = await connection.height();
-      const result = await connection.postTx(bytesToPost);
-      expect(result).toBeTruthy();
-      expect(result.blockInfo!.value.state).toEqual(BcpTransactionState.Pending);
+        const connection = await RiseConnection.establish(base);
+        const heightBeforeTransaction = await connection.height();
+        const result = await connection.postTx(bytesToPost);
+        expect(result).toBeTruthy();
+        expect(result.blockInfo!.value.state).toEqual(BcpTransactionState.Pending);
 
-      const events = new Array<BcpBlockInfo>();
-      const subscription = result.blockInfo!.updates.subscribe({
-        next: info => {
-          events.push(info);
+        const events = new Array<BcpBlockInfo>();
+        const subscription = result.blockInfo!.updates.subscribe({
+          next: info => {
+            events.push(info);
 
-          if (events.length === 2) {
-            expect(events[0]).toEqual({ state: BcpTransactionState.Pending });
-            expect(events[1]).toEqual({
-              state: BcpTransactionState.InBlock,
-              height: heightBeforeTransaction + 1,
-              confirmations: 1,
-            });
-            subscription.unsubscribe();
-            done();
-          }
-        },
-        complete: fail,
-        error: fail,
-      });
+            if (events.length === 2) {
+              expect(events[0]).toEqual({ state: BcpTransactionState.Pending });
+              expect(events[1]).toEqual({
+                state: BcpTransactionState.InBlock,
+                height: heightBeforeTransaction + 1,
+                confirmations: 1,
+              });
+              subscription.unsubscribe();
+              done();
+            }
+          },
+          complete: fail,
+          error: fail,
+        });
+      })().catch(fail);
     }, 80_000);
 
     it("throws for transaction with corrupted signature", async () => {

--- a/packages/iov-rise/src/riseconnection.ts
+++ b/packages/iov-rise/src/riseconnection.ts
@@ -1,4 +1,5 @@
 import axios from "axios";
+import equal from "fast-deep-equal";
 import { ReadonlyDate } from "readonly-date";
 import { Stream } from "xstream";
 
@@ -7,12 +8,14 @@ import {
   Address,
   BcpAccount,
   BcpAccountQuery,
+  BcpBlockInfo,
   BcpConnection,
   BcpNonce,
   BcpQueryEnvelope,
   BcpQueryTag,
   BcpTicker,
   BcpTransactionResponse,
+  BcpTransactionState,
   BcpTxQuery,
   ConfirmedTransaction,
   dummyEnvelope,
@@ -23,11 +26,12 @@ import {
 } from "@iov/bcp-types";
 import { Parse } from "@iov/dpos";
 import { Encoding, Int53 } from "@iov/encoding";
+import { DefaultValueProducer, ValueAndUpdates } from "@iov/stream";
 
 import { constants } from "./constants";
 import { riseCodec } from "./risecodec";
 
-const { fromAscii, toUtf8 } = Encoding;
+const { fromAscii, toAscii, toUtf8 } = Encoding;
 
 /**
  * Encodes the current date and time as a nonce
@@ -113,10 +117,38 @@ export class RiseConnection implements BcpConnection {
       throw new Error(`Expected one accepted transaction but got: ${JSON.stringify(response.data.accepted)}`);
     }
 
+    let blockInfoInterval: any;
+    const firstEvent: BcpBlockInfo = {
+      state: BcpTransactionState.Pending,
+    };
+    let lastEventSent: BcpBlockInfo = firstEvent;
+    const blockInfoProducer = new DefaultValueProducer<BcpBlockInfo>(firstEvent, {
+      onStarted: () => {
+        blockInfoInterval = setInterval(async () => {
+          const search = await this.searchTx({ hash: toAscii(transactionId) as TxId, tags: [] });
+          if (search.length > 0) {
+            const confirmedTransaction = search[0];
+            const event: BcpBlockInfo = {
+              state: BcpTransactionState.InBlock,
+              height: confirmedTransaction.height,
+              confirmations: confirmedTransaction.confirmations,
+            };
+
+            if (!equal(event, lastEventSent)) {
+              blockInfoProducer.update(event);
+              lastEventSent = event;
+            }
+          }
+        }, 10000);
+      },
+      onStop: () => clearInterval(blockInfoInterval),
+    });
+
     return {
       metadata: {
         height: undefined,
       },
+      blockInfo: new ValueAndUpdates(blockInfoProducer),
       data: {
         message: "",
         txid: Encoding.toAscii(transactionId) as TxId,

--- a/packages/iov-rise/src/riseconnection.ts
+++ b/packages/iov-rise/src/riseconnection.ts
@@ -33,6 +33,9 @@ import { riseCodec } from "./risecodec";
 
 const { fromAscii, toAscii, toUtf8 } = Encoding;
 
+// poll every 10 seconds (block time 30s)
+const transactionStatePollInterval = 10_000;
+
 /**
  * Encodes the current date and time as a nonce
  */
@@ -139,7 +142,7 @@ export class RiseConnection implements BcpConnection {
               lastEventSent = event;
             }
           }
-        }, 10000);
+        }, transactionStatePollInterval);
       },
       onStop: () => clearInterval(blockInfoInterval),
     });

--- a/packages/iov-rise/types/riseconnection.d.ts
+++ b/packages/iov-rise/types/riseconnection.d.ts
@@ -21,7 +21,7 @@ export declare class RiseConnection implements BcpConnection {
     changeBlock(): Stream<number>;
     watchAccount(_: BcpAccountQuery): Stream<BcpAccount | undefined>;
     watchNonce(_: BcpAccountQuery): Stream<BcpNonce | undefined>;
-    searchTx(_: BcpTxQuery): Promise<ReadonlyArray<ConfirmedTransaction>>;
+    searchTx(query: BcpTxQuery): Promise<ReadonlyArray<ConfirmedTransaction>>;
     listenTx(_: ReadonlyArray<BcpQueryTag>): Stream<ConfirmedTransaction>;
     liveTx(_: BcpTxQuery): Stream<ConfirmedTransaction>;
 }

--- a/packages/iov-stream/src/defaultvalueproducer.spec.ts
+++ b/packages/iov-stream/src/defaultvalueproducer.spec.ts
@@ -1,0 +1,95 @@
+import { Stream } from "xstream";
+
+import { DefaultValueProducer } from "./defaultvalueproducer";
+
+function oneTickLater(): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve));
+}
+
+describe("DefaultValueProducer", () => {
+  it("can be constructed", () => {
+    const producer = new DefaultValueProducer(1);
+    expect(producer.value).toEqual(1);
+  });
+
+  it("can be used as a stream backend", done => {
+    const producer = new DefaultValueProducer(42);
+    const stream = Stream.createWithMemory(producer);
+    stream.addListener({
+      next: value => {
+        expect(value).toEqual(42);
+        done();
+      },
+      error: fail,
+      complete: fail,
+    });
+  });
+
+  it("can send updates", done => {
+    const producer = new DefaultValueProducer(42);
+    const stream = Stream.createWithMemory(producer);
+
+    // tslint:disable-next-line:readonly-array
+    const events: number[] = [];
+    stream.addListener({
+      next: value => {
+        events.push(value);
+
+        if (events.length === 4) {
+          expect(events).toEqual([42, 43, 44, 45]);
+          done();
+        }
+      },
+      error: fail,
+      complete: fail,
+    });
+
+    producer.update(43);
+    producer.update(44);
+    producer.update(45);
+  });
+
+  it("calls callbacks", async () => {
+    // tslint:disable-next-line:readonly-array
+    const producerActive: boolean[] = [];
+
+    const producer = new DefaultValueProducer(42, {
+      onStarted: () => producerActive.push(true),
+      onStop: () => producerActive.push(false),
+    });
+    const stream = Stream.createWithMemory(producer);
+
+    expect(producerActive).toEqual([]);
+
+    const subscription1 = stream.subscribe({});
+    expect(producerActive).toEqual([true]);
+
+    const subscription2 = stream.subscribe({});
+    expect(producerActive).toEqual([true]);
+
+    subscription2.unsubscribe();
+    expect(producerActive).toEqual([true]);
+
+    subscription1.unsubscribe();
+    await oneTickLater();
+    expect(producerActive).toEqual([true, false]);
+
+    const subscription3 = stream.subscribe({});
+    expect(producerActive).toEqual([true, false, true]);
+
+    subscription3.unsubscribe();
+    await oneTickLater();
+    expect(producerActive).toEqual([true, false, true, false]);
+
+    const subscriptionA = stream.subscribe({});
+    expect(producerActive).toEqual([true, false, true, false, true]);
+
+    // unsubscribe and re-subscribe does not deactivate the producer (which is a xstream feature)
+    subscriptionA.unsubscribe();
+    const subscriptionB = stream.subscribe({});
+    expect(producerActive).toEqual([true, false, true, false, true]);
+
+    // cleanup
+    subscriptionB.unsubscribe();
+  });
+});

--- a/packages/iov-stream/src/defaultvalueproducer.ts
+++ b/packages/iov-stream/src/defaultvalueproducer.ts
@@ -1,0 +1,63 @@
+import { Listener, Producer } from "xstream";
+
+export interface DefaultValueProducerCallsbacks {
+  readonly onStarted: () => void;
+  readonly onStop: () => void;
+}
+
+// allows pre-producing values before anyone is listening
+export class DefaultValueProducer<T> implements Producer<T> {
+  public get value(): T {
+    return this.internalValue;
+  }
+
+  private readonly callbacks: DefaultValueProducerCallsbacks | undefined;
+  // tslint:disable-next-line:readonly-keyword
+  private internalValue: T;
+  // tslint:disable-next-line:readonly-keyword
+  private listener: Listener<T> | undefined;
+
+  constructor(value: T, callbacks?: DefaultValueProducerCallsbacks) {
+    this.callbacks = callbacks;
+    this.internalValue = value;
+  }
+
+  /**
+   * Update the current value.
+   *
+   * If producer is active (i.e. someone is listening), this emits an event.
+   * If not, just the current value is updated.
+   */
+  public update(value: T): void {
+    // tslint:disable-next-line:no-object-mutation
+    this.internalValue = value;
+    if (this.listener) {
+      this.listener.next(value);
+    }
+  }
+
+  /**
+   * Called by the stream. Do not call this directly.
+   */
+  public start(listener: Listener<T>): void {
+    // tslint:disable-next-line:no-object-mutation
+    this.listener = listener;
+    listener.next(this.internalValue);
+
+    if (this.callbacks) {
+      this.callbacks.onStarted();
+    }
+  }
+
+  /**
+   * Called by the stream. Do not call this directly.
+   */
+  public stop(): void {
+    if (this.callbacks) {
+      this.callbacks.onStop();
+    }
+
+    // tslint:disable-next-line:no-object-mutation
+    this.listener = undefined;
+  }
+}

--- a/packages/iov-stream/src/index.ts
+++ b/packages/iov-stream/src/index.ts
@@ -1,3 +1,4 @@
+export { DefaultValueProducer, DefaultValueProducerCallsbacks } from "./defaultvalueproducer";
 export * from "./promise";
 export * from "./reducer";
-export * from "./valueandupdates";
+export { ValueAndUpdates } from "./valueandupdates";

--- a/packages/iov-stream/src/valueandupdates.spec.ts
+++ b/packages/iov-stream/src/valueandupdates.spec.ts
@@ -1,6 +1,7 @@
 import { Listener } from "xstream";
 
-import { DefaultValueProducer, ValueAndUpdates } from "./valueandupdates";
+import { DefaultValueProducer } from "./defaultvalueproducer";
+import { ValueAndUpdates } from "./valueandupdates";
 
 describe("ValueAndUpdates", () => {
   it("can be constructed", () => {

--- a/packages/iov-stream/src/valueandupdates.spec.ts
+++ b/packages/iov-stream/src/valueandupdates.spec.ts
@@ -163,4 +163,19 @@ describe("ValueAndUpdates", () => {
     await vau.waitFor(44);
     expect(vau.value).toEqual(44);
   });
+
+  it("can wait for search function to return true", async () => {
+    const producer = new DefaultValueProducer(11);
+    const vau = new ValueAndUpdates(producer);
+
+    setTimeout(() => producer.update(22), 10);
+    setTimeout(() => producer.update(33), 20);
+    setTimeout(() => producer.update(44), 30);
+
+    await vau.waitFor(v => v > 30);
+    expect(vau.value).toEqual(33);
+
+    await vau.waitFor(v => v > 40);
+    expect(vau.value).toEqual(44);
+  });
 });

--- a/packages/iov-stream/src/valueandupdates.ts
+++ b/packages/iov-stream/src/valueandupdates.ts
@@ -1,4 +1,6 @@
-import { Listener, MemoryStream, Producer } from "xstream";
+import { MemoryStream } from "xstream";
+
+import { DefaultValueProducer } from "./defaultvalueproducer";
 
 /**
  * A read only wrapper around DefaultValueProducer that allows
@@ -37,40 +39,5 @@ export class ValueAndUpdates<T> {
         },
       });
     });
-  }
-}
-
-// allows pre-producing values before anyone is listening
-export class DefaultValueProducer<T> implements Producer<T> {
-  public get value(): T {
-    return this.internalValue;
-  }
-
-  // tslint:disable-next-line:readonly-keyword
-  private internalValue: T;
-  // tslint:disable-next-line:readonly-keyword
-  private listener: Listener<T> | undefined;
-
-  constructor(value: T) {
-    this.internalValue = value;
-  }
-
-  public update(value: T): void {
-    // tslint:disable-next-line:no-object-mutation
-    this.internalValue = value;
-    if (this.listener) {
-      this.listener.next(value);
-    }
-  }
-
-  public start(listener: Listener<T>): void {
-    // tslint:disable-next-line:no-object-mutation
-    this.listener = listener;
-    listener.next(this.internalValue);
-  }
-
-  public stop(): void {
-    // tslint:disable-next-line:no-object-mutation
-    this.listener = undefined;
   }
 }

--- a/packages/iov-stream/types/defaultvalueproducer.d.ts
+++ b/packages/iov-stream/types/defaultvalueproducer.d.ts
@@ -1,0 +1,27 @@
+import { Listener, Producer } from "xstream";
+export interface DefaultValueProducerCallsbacks {
+    readonly onStarted: () => void;
+    readonly onStop: () => void;
+}
+export declare class DefaultValueProducer<T> implements Producer<T> {
+    readonly value: T;
+    private readonly callbacks;
+    private internalValue;
+    private listener;
+    constructor(value: T, callbacks?: DefaultValueProducerCallsbacks);
+    /**
+     * Update the current value.
+     *
+     * If producer is active (i.e. someone is listening), this emits an event.
+     * If not, just the current value is updated.
+     */
+    update(value: T): void;
+    /**
+     * Called by the stream. Do not call this directly.
+     */
+    start(listener: Listener<T>): void;
+    /**
+     * Called by the stream. Do not call this directly.
+     */
+    stop(): void;
+}

--- a/packages/iov-stream/types/index.d.ts
+++ b/packages/iov-stream/types/index.d.ts
@@ -1,3 +1,4 @@
+export { DefaultValueProducer, DefaultValueProducerCallsbacks } from "./defaultvalueproducer";
 export * from "./promise";
 export * from "./reducer";
-export * from "./valueandupdates";
+export { ValueAndUpdates } from "./valueandupdates";

--- a/packages/iov-stream/types/valueandupdates.d.ts
+++ b/packages/iov-stream/types/valueandupdates.d.ts
@@ -1,5 +1,6 @@
 import { MemoryStream } from "xstream";
 import { DefaultValueProducer } from "./defaultvalueproducer";
+export declare type SearchFunction<T> = (value: T) => boolean;
 /**
  * A read only wrapper around DefaultValueProducer that allows
  * to synchonously get the current value using the .value property
@@ -10,5 +11,10 @@ export declare class ValueAndUpdates<T> {
     readonly value: T;
     private readonly producer;
     constructor(producer: DefaultValueProducer<T>);
-    waitFor(value: T): Promise<void>;
+    /**
+     * Resolves as soon as search value is found.
+     *
+     * @param search either a value or a function that must return true when found
+     */
+    waitFor(search: SearchFunction<T> | T): Promise<void>;
 }

--- a/packages/iov-stream/types/valueandupdates.d.ts
+++ b/packages/iov-stream/types/valueandupdates.d.ts
@@ -1,4 +1,5 @@
-import { Listener, MemoryStream, Producer } from "xstream";
+import { MemoryStream } from "xstream";
+import { DefaultValueProducer } from "./defaultvalueproducer";
 /**
  * A read only wrapper around DefaultValueProducer that allows
  * to synchonously get the current value using the .value property
@@ -10,13 +11,4 @@ export declare class ValueAndUpdates<T> {
     private readonly producer;
     constructor(producer: DefaultValueProducer<T>);
     waitFor(value: T): Promise<void>;
-}
-export declare class DefaultValueProducer<T> implements Producer<T> {
-    readonly value: T;
-    private internalValue;
-    private listener;
-    constructor(value: T);
-    update(value: T): void;
-    start(listener: Listener<T>): void;
-    stop(): void;
 }


### PR DESCRIPTION
Now we get

* immediate resolving promise when transaction was posted sucessfully
* a block info value (height, confirmations) for tendermint
* an `.updates` stream we can listen to if we care (no overhead if nobody is listening)

Closes #413 