### PR TITLE
Expose bns headers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,7 @@ script:
 branches:
   only:
   - master
+  - 0.9
 
 notifications:
   email: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.9.2
+
+* @iov/bns: Add `getHeader` and `watchHeaders` methods to access block headers
+
 ## 0.9.1
 
 * @iov/stream: Generalize `streamPromise` to take a promise of an iterable

--- a/packages/iov-bns/src/bnsconnection.spec.ts
+++ b/packages/iov-bns/src/bnsconnection.spec.ts
@@ -467,19 +467,21 @@ describe("BnsConnection", () => {
     const header = await connection.getHeader(3);
     expect(header.height).toEqual(3);
     expect(header.appHash.length).toEqual(20);
+    connection.disconnect();
   });
 
   it("throws if it cannot get header", async () => {
     pendingWithoutBnsd();
     const connection = await BnsConnection.establish(bnsdTendermintUrl);
-    connection
+    await connection
       .getHeader(123456)
       .then(() => fail("must not resolve"))
-      .catch(error => expect(error).toMatch(/123456 doesn't exist/i));
-    connection
+      .catch(() => 0);
+    await connection
       .getHeader(-3)
       .then(() => fail("must not resolve"))
-      .catch(error => expect(error).toMatch(/123456 doesn't exist/i));
+      .catch(() => 0);
+    connection.disconnect();
   });
 
   it("can register a blockchain", async () => {

--- a/packages/iov-bns/src/bnsconnection.spec.ts
+++ b/packages/iov-bns/src/bnsconnection.spec.ts
@@ -485,6 +485,7 @@ describe("BnsConnection", () => {
   });
 
   it("watches headers with same data as getHeader", async () => {
+    pendingWithoutBnsd();
     const connection = await BnsConnection.establish(bnsdTendermintUrl);
 
     const headers = lastValue(connection.watchHeaders().take(2));

--- a/packages/iov-bns/src/bnsconnection.spec.ts
+++ b/packages/iov-bns/src/bnsconnection.spec.ts
@@ -461,6 +461,27 @@ describe("BnsConnection", () => {
     connection.disconnect();
   });
 
+  it("can get a valid header", async () => {
+    pendingWithoutBnsd();
+    const connection = await BnsConnection.establish(bnsdTendermintUrl);
+    const header = await connection.getHeader(3);
+    expect(header.height).toEqual(3);
+    expect(header.appHash.length).toEqual(20);
+  });
+
+  it("throws if it cannot get header", async () => {
+    pendingWithoutBnsd();
+    const connection = await BnsConnection.establish(bnsdTendermintUrl);
+    connection
+      .getHeader(123456)
+      .then(() => fail("must not resolve"))
+      .catch(error => expect(error).toMatch(/123456 doesn't exist/i));
+    connection
+      .getHeader(-3)
+      .then(() => fail("must not resolve"))
+      .catch(error => expect(error).toMatch(/123456 doesn't exist/i));
+  });
+
   it("can register a blockchain", async () => {
     pendingWithoutBnsd();
     const connection = await BnsConnection.establish(bnsdTendermintUrl);

--- a/packages/iov-bns/src/bnsconnection.ts
+++ b/packages/iov-bns/src/bnsconnection.ts
@@ -437,7 +437,7 @@ export class BnsConnection implements BcpAtomicSwapConnection {
   }
 
   public async getHeader(height: number): Promise<Header> {
-    const {blockMetas} = await this.tmClient.blockchain(height, height);
+    const { blockMetas } = await this.tmClient.blockchain(height, height);
     if (blockMetas.length < 1) {
       throw new Error(`Header ${height} doesn't exist yet`);
     }

--- a/packages/iov-bns/src/bnsconnection.ts
+++ b/packages/iov-bns/src/bnsconnection.ts
@@ -33,6 +33,7 @@ import {
   Client as TendermintClient,
   getHeaderEventHeight,
   getTxEventHeight,
+  Header,
   StatusResponse,
   txCommitSuccess,
   TxEvent,
@@ -433,6 +434,22 @@ export class BnsConnection implements BcpAtomicSwapConnection {
    */
   public changeNonce(addr: Address): Stream<number> {
     return this.changeTx([bnsNonceTag(addr)]);
+  }
+
+  public async getHeader(height: number): Promise<Header> {
+    const {blockMetas} = await this.tmClient.blockchain(height, height);
+    if (blockMetas.length < 1) {
+      throw new Error(`Header ${height} doesn't exist yet`);
+    }
+    const { header } = blockMetas[0];
+    if (header.height !== height) {
+      throw new Error(`Requested header ${height} but got ${header.height}`);
+    }
+    return header;
+  }
+
+  public watchHeaders(): Stream<Header> {
+    return this.tmClient.subscribeNewBlockHeader();
   }
 
   /**

--- a/packages/iov-bns/types/bnsconnection.d.ts
+++ b/packages/iov-bns/types/bnsconnection.d.ts
@@ -1,7 +1,7 @@
 import { Stream } from "xstream";
 import { ChainId, PostableBytes } from "@iov/base-types";
 import { Address, BcpAccount, BcpAccountQuery, BcpAtomicSwap, BcpAtomicSwapConnection, BcpNonce, BcpQueryEnvelope, BcpQueryTag, BcpSwapQuery, BcpTicker, BcpTransactionResponse, BcpTxQuery, ConfirmedTransaction, TokenTicker, TxReadCodec } from "@iov/bcp-types";
-import { Client as TendermintClient, StatusResponse } from "@iov/tendermint-rpc";
+import { Client as TendermintClient, Header, StatusResponse } from "@iov/tendermint-rpc";
 import { InitData } from "./normalize";
 import { BnsBlockchainNft, BnsBlockchainsQuery, BnsUsernameNft, BnsUsernamesQuery, Result } from "./types";
 /**
@@ -72,6 +72,8 @@ export declare class BnsConnection implements BcpAtomicSwapConnection {
      * A helper that triggers if the nonce every changes
      */
     changeNonce(addr: Address): Stream<number>;
+    getHeader(height: number): Promise<Header>;
+    watchHeaders(): Stream<Header>;
     /**
      * Gets current balance and emits an update every time it changes
      */


### PR DESCRIPTION
Closes #568 

Quick patch for a 0.9.2 release.

Expose tendermint headers in BnsConnection. Also allow for subscriptions.
This should be exposed in BcpConnection as well, but that requires more design time and working with other blockchains (lisk, rise, ethereum) to find a common abstraction