### PR TITLE
Fix encoding of transaction hash (lower to upper hex)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Breaking changes
   in favour of just `Nonce`.
 * @iov/bcp-types: `BcpConnection.getNonce`/`.watchNonce` now only accept
   `BcpAddressQuery` or `BcpPubkeyQuery` as argument type.
+* @iov/bcp-types: `BcpConnection.listenTx` now takes an `BcpTxQuery` argument
+  analogue to `.searchTx` and `.liveTx`.
 * @iov/crpto: the new types `Secp256k1Signature` and `ExtendedSecp256k1Signature` replace DER encoded signatures in `Secp256k1`.
 * @iov/faucets: Remove `BovFaucet`. Use `IovFaucet` instead.
 * @iov/keycontrol: `Secp256k1HdWallet.createTransactionSignature` now uses the custom fixed length encoding instead of DER to allow blockchains utilizing the recovery parameter.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * @iov/bcp-types: `BcpTransactionResponse` now contains a `blockInfo` property
   that allows you to get block related data associated with the transactions
   and subscribing to updates. `metadata` was deprecated in favour of `blockInfo`.
+* @iov/bns: Fix encoding of `BcpTxQuery.hash` in `listenTx` and `liveTx`
 
 Breaking changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Breaking changes
 * @iov/tendermint-rpc: Change type of `BroadcastTxSyncResponse.hash` to `TxId`
 * @iov/tendermint-rpc: Un-export interface `RpcTxEvent`
 * @iov/tendermint-rpc: Change all `Method` enum names to PascalCase
+* @iov/tendermint-rpc: `Client.subscribeTx` now takes a `QueryString` argument
 
 ## 0.9.3
 

--- a/packages/iov-bcp-types/src/bcp.ts
+++ b/packages/iov-bcp-types/src/bcp.ts
@@ -195,8 +195,10 @@ export interface BcpConnection {
 
   // searchTx searches for all tx that match these tags and subscribes to new ones
   readonly searchTx: (query: BcpTxQuery) => Promise<ReadonlyArray<ConfirmedTransaction>>;
-  // listenTx subscribes to all newly added transactions with these tags
-  readonly listenTx: (tags: ReadonlyArray<BcpQueryTag>) => Stream<ConfirmedTransaction>;
+  /**
+   * Subscribes to all newly added transactions that match the query
+   */
+  readonly listenTx: (query: BcpTxQuery) => Stream<ConfirmedTransaction>;
   // liveTx returns a stream for all historical transactions that match
   // the query, along with all new transactions arriving from listenTx
   readonly liveTx: (txQuery: BcpTxQuery) => Stream<ConfirmedTransaction>;

--- a/packages/iov-bcp-types/types/bcp.d.ts
+++ b/packages/iov-bcp-types/types/bcp.d.ts
@@ -110,7 +110,10 @@ export interface BcpConnection {
     readonly watchAccount: (account: BcpAccountQuery) => Stream<BcpAccount | undefined>;
     readonly watchNonce: (query: BcpAddressQuery | BcpPubkeyQuery) => Stream<Nonce | undefined>;
     readonly searchTx: (query: BcpTxQuery) => Promise<ReadonlyArray<ConfirmedTransaction>>;
-    readonly listenTx: (tags: ReadonlyArray<BcpQueryTag>) => Stream<ConfirmedTransaction>;
+    /**
+     * Subscribes to all newly added transactions that match the query
+     */
+    readonly listenTx: (query: BcpTxQuery) => Stream<ConfirmedTransaction>;
     readonly liveTx: (txQuery: BcpTxQuery) => Stream<ConfirmedTransaction>;
 }
 export interface ChainConnector {

--- a/packages/iov-bns/src/bnsconnection.ts
+++ b/packages/iov-bns/src/bnsconnection.ts
@@ -364,7 +364,7 @@ export class BnsConnection implements BcpAtomicSwapConnection {
    */
   public listenTx(tags: ReadonlyArray<BcpQueryTag>): Stream<ConfirmedTransaction> {
     const chainId = this.chainId();
-    const txs = this.tmClient.subscribeTx(tags);
+    const txs = this.tmClient.subscribeTx(buildTxQuery({ tags: tags }));
 
     // destructuring ftw (or is it too confusing?)
     const mapper = ({ hash, height, tx, result }: TxEvent): ConfirmedTransaction => ({
@@ -451,7 +451,7 @@ export class BnsConnection implements BcpAtomicSwapConnection {
    */
   public changeTx(tags: ReadonlyArray<BcpQueryTag>): Stream<number> {
     return this.tmClient
-      .subscribeTx(tags)
+      .subscribeTx(buildTxQuery({ tags: tags }))
       .map(getTxEventHeight)
       .filter(onChange<number>());
   }

--- a/packages/iov-bns/src/bnsconnection.ts
+++ b/packages/iov-bns/src/bnsconnection.ts
@@ -362,9 +362,9 @@ export class BnsConnection implements BcpAtomicSwapConnection {
   /**
    * A stream of all transactions that match the tags from the present moment on
    */
-  public listenTx(tags: ReadonlyArray<BcpQueryTag>): Stream<ConfirmedTransaction> {
+  public listenTx(query: BcpTxQuery): Stream<ConfirmedTransaction> {
     const chainId = this.chainId();
-    const txs = this.tmClient.subscribeTx(buildTxQuery({ tags: tags }));
+    const txs = this.tmClient.subscribeTx(buildTxQuery(query));
 
     // destructuring ftw (or is it too confusing?)
     const mapper = ({ hash, height, tx, result }: TxEvent): ConfirmedTransaction => ({
@@ -398,7 +398,7 @@ export class BnsConnection implements BcpAtomicSwapConnection {
         let doneSendingHistory = false;
         const queue = new Array<ConfirmedTransaction>();
 
-        updatesSubscription = this.listenTx(txQuery.tags).subscribe({
+        updatesSubscription = this.listenTx(txQuery).subscribe({
           next: value => {
             if (doneSendingHistory) {
               listener.next(value);

--- a/packages/iov-bns/src/util.spec.ts
+++ b/packages/iov-bns/src/util.spec.ts
@@ -1,3 +1,4 @@
+import { TxId } from "@iov/base-types";
 import { Address } from "@iov/bcp-types";
 import { Encoding } from "@iov/encoding";
 
@@ -132,6 +133,11 @@ describe("Util", () => {
     it("handles height with tags", () => {
       const query = buildTxQuery({ minHeight: 77, tags: [{ key: "some", value: "info" }] });
       expect(query).toEqual("some='info' AND tx.height>77");
+    });
+
+    it("handles hash", () => {
+      const query = buildTxQuery({ hash: new Uint8Array([0xaa, 0xbb, 0x33]) as TxId, tags: [] });
+      expect(query).toEqual("tx.hash='AABB33'");
     });
   });
 });

--- a/packages/iov-bns/src/util.ts
+++ b/packages/iov-bns/src/util.ts
@@ -112,7 +112,8 @@ export function buildTxQuery(query: BcpTxQuery): QueryString {
     !!query.height && `tx.height=${query.height}`,
     !!query.minHeight && `tx.height>${query.minHeight}`,
     !!query.maxHeight && `tx.height<${query.maxHeight}`,
-    !!query.hash && `tx.hash='${Encoding.toHex(query.hash)}'`,
+    // In Tendermint, hash can be lower case for search queries but must be upper case for subscribe queries
+    !!query.hash && `tx.hash='${Encoding.toHex(query.hash).toUpperCase()}'`,
   ];
   const result: string = [...tags, ...opts.filter(x => !!x)].join(" AND ");
   return result as QueryString;

--- a/packages/iov-bns/types/bnsconnection.d.ts
+++ b/packages/iov-bns/types/bnsconnection.d.ts
@@ -56,7 +56,7 @@ export declare class BnsConnection implements BcpAtomicSwapConnection {
     /**
      * A stream of all transactions that match the tags from the present moment on
      */
-    listenTx(tags: ReadonlyArray<BcpQueryTag>): Stream<ConfirmedTransaction>;
+    listenTx(query: BcpTxQuery): Stream<ConfirmedTransaction>;
     /**
      * Does a search and then subscribes to all future changes.
      *

--- a/packages/iov-ethereum/src/ethereumconnection.ts
+++ b/packages/iov-ethereum/src/ethereumconnection.ts
@@ -11,7 +11,6 @@ import {
   BcpConnection,
   BcpPubkeyQuery,
   BcpQueryEnvelope,
-  BcpQueryTag,
   BcpTicker,
   BcpTransactionResponse,
   BcpTransactionState,
@@ -250,7 +249,7 @@ export class EthereumConnection implements BcpConnection {
     }
   }
 
-  public listenTx(_: ReadonlyArray<BcpQueryTag>): Stream<ConfirmedTransaction> {
+  public listenTx(_: BcpTxQuery): Stream<ConfirmedTransaction> {
     throw new Error("Not implemented");
   }
 

--- a/packages/iov-ethereum/types/ethereumconnection.d.ts
+++ b/packages/iov-ethereum/types/ethereumconnection.d.ts
@@ -1,6 +1,6 @@
 import { Stream } from "xstream";
 import { ChainId, PostableBytes } from "@iov/base-types";
-import { BcpAccount, BcpAccountQuery, BcpAddressQuery, BcpConnection, BcpPubkeyQuery, BcpQueryEnvelope, BcpQueryTag, BcpTicker, BcpTransactionResponse, BcpTxQuery, ConfirmedTransaction, Nonce, TokenTicker } from "@iov/bcp-types";
+import { BcpAccount, BcpAccountQuery, BcpAddressQuery, BcpConnection, BcpPubkeyQuery, BcpQueryEnvelope, BcpTicker, BcpTransactionResponse, BcpTxQuery, ConfirmedTransaction, Nonce, TokenTicker } from "@iov/bcp-types";
 export declare class EthereumConnection implements BcpConnection {
     static establish(baseUrl: string): Promise<EthereumConnection>;
     private readonly baseUrl;
@@ -18,6 +18,6 @@ export declare class EthereumConnection implements BcpConnection {
     watchAccount(_: BcpAccountQuery): Stream<BcpAccount | undefined>;
     watchNonce(_: BcpAddressQuery | BcpPubkeyQuery): Stream<Nonce | undefined>;
     searchTx(query: BcpTxQuery): Promise<ReadonlyArray<ConfirmedTransaction>>;
-    listenTx(_: ReadonlyArray<BcpQueryTag>): Stream<ConfirmedTransaction>;
+    listenTx(_: BcpTxQuery): Stream<ConfirmedTransaction>;
     liveTx(_: BcpTxQuery): Stream<ConfirmedTransaction>;
 }

--- a/packages/iov-lisk/src/liskconnection.ts
+++ b/packages/iov-lisk/src/liskconnection.ts
@@ -13,7 +13,6 @@ import {
   BcpConnection,
   BcpPubkeyQuery,
   BcpQueryEnvelope,
-  BcpQueryTag,
   BcpTicker,
   BcpTransactionResponse,
   BcpTransactionState,
@@ -250,7 +249,7 @@ export class LiskConnection implements BcpConnection {
     }
   }
 
-  public listenTx(_: ReadonlyArray<BcpQueryTag>): Stream<ConfirmedTransaction> {
+  public listenTx(_: BcpTxQuery): Stream<ConfirmedTransaction> {
     throw new Error("Not implemented");
   }
 

--- a/packages/iov-lisk/types/liskconnection.d.ts
+++ b/packages/iov-lisk/types/liskconnection.d.ts
@@ -1,6 +1,6 @@
 import { Stream } from "xstream";
 import { ChainId, PostableBytes } from "@iov/base-types";
-import { BcpAccount, BcpAccountQuery, BcpAddressQuery, BcpConnection, BcpPubkeyQuery, BcpQueryEnvelope, BcpQueryTag, BcpTicker, BcpTransactionResponse, BcpTxQuery, ConfirmedTransaction, Nonce, TokenTicker } from "@iov/bcp-types";
+import { BcpAccount, BcpAccountQuery, BcpAddressQuery, BcpConnection, BcpPubkeyQuery, BcpQueryEnvelope, BcpTicker, BcpTransactionResponse, BcpTxQuery, ConfirmedTransaction, Nonce, TokenTicker } from "@iov/bcp-types";
 /**
  * Encodes the current date and time as a nonce
  */
@@ -22,6 +22,6 @@ export declare class LiskConnection implements BcpConnection {
     watchAccount(_: BcpAccountQuery): Stream<BcpAccount | undefined>;
     watchNonce(_: BcpAddressQuery | BcpPubkeyQuery): Stream<Nonce | undefined>;
     searchTx(query: BcpTxQuery): Promise<ReadonlyArray<ConfirmedTransaction>>;
-    listenTx(_: ReadonlyArray<BcpQueryTag>): Stream<ConfirmedTransaction>;
+    listenTx(_: BcpTxQuery): Stream<ConfirmedTransaction>;
     liveTx(_: BcpTxQuery): Stream<ConfirmedTransaction>;
 }

--- a/packages/iov-rise/src/riseconnection.ts
+++ b/packages/iov-rise/src/riseconnection.ts
@@ -13,7 +13,6 @@ import {
   BcpConnection,
   BcpPubkeyQuery,
   BcpQueryEnvelope,
-  BcpQueryTag,
   BcpTicker,
   BcpTransactionResponse,
   BcpTransactionState,
@@ -268,7 +267,7 @@ export class RiseConnection implements BcpConnection {
     }
   }
 
-  public listenTx(_: ReadonlyArray<BcpQueryTag>): Stream<ConfirmedTransaction> {
+  public listenTx(_: BcpTxQuery): Stream<ConfirmedTransaction> {
     throw new Error("Not implemented");
   }
 

--- a/packages/iov-rise/types/riseconnection.d.ts
+++ b/packages/iov-rise/types/riseconnection.d.ts
@@ -1,6 +1,6 @@
 import { Stream } from "xstream";
 import { ChainId, PostableBytes } from "@iov/base-types";
-import { BcpAccount, BcpAccountQuery, BcpAddressQuery, BcpConnection, BcpPubkeyQuery, BcpQueryEnvelope, BcpQueryTag, BcpTicker, BcpTransactionResponse, BcpTxQuery, ConfirmedTransaction, Nonce, TokenTicker } from "@iov/bcp-types";
+import { BcpAccount, BcpAccountQuery, BcpAddressQuery, BcpConnection, BcpPubkeyQuery, BcpQueryEnvelope, BcpTicker, BcpTransactionResponse, BcpTxQuery, ConfirmedTransaction, Nonce, TokenTicker } from "@iov/bcp-types";
 /**
  * Encodes the current date and time as a nonce
  */
@@ -22,6 +22,6 @@ export declare class RiseConnection implements BcpConnection {
     watchAccount(_: BcpAccountQuery): Stream<BcpAccount | undefined>;
     watchNonce(_: BcpAddressQuery | BcpPubkeyQuery): Stream<Nonce | undefined>;
     searchTx(query: BcpTxQuery): Promise<ReadonlyArray<ConfirmedTransaction>>;
-    listenTx(_: ReadonlyArray<BcpQueryTag>): Stream<ConfirmedTransaction>;
+    listenTx(_: BcpTxQuery): Stream<ConfirmedTransaction>;
     liveTx(_: BcpTxQuery): Stream<ConfirmedTransaction>;
 }

--- a/packages/iov-tendermint-rpc/src/client.spec.ts
+++ b/packages/iov-tendermint-rpc/src/client.spec.ts
@@ -7,7 +7,7 @@ import { Encoding } from "@iov/encoding";
 import { Adaptor, adatorForVersion } from "./adaptor";
 import { Client } from "./client";
 import { randomId } from "./common";
-import { buildTagsQuery, QueryTag } from "./requests";
+import { buildQuery, QueryTag } from "./requests";
 import * as responses from "./responses";
 import { HttpClient, RpcClient, WebsocketClient } from "./rpcclient";
 
@@ -147,7 +147,7 @@ function defaultTestSuite(rpcFactory: () => RpcClient, adaptor: Adaptor): void {
 
     // txSearch - you must enable the indexer when running
     // tendermint, else you get empty results
-    const query = buildTagsQuery([{ key: "app.key", value: find }]);
+    const query = buildQuery({ tags: [{ key: "app.key", value: find }] });
 
     const s = await client.txSearch({ query, page: 1, per_page: 30 });
     // should find the tx
@@ -178,7 +178,7 @@ function defaultTestSuite(rpcFactory: () => RpcClient, adaptor: Adaptor): void {
     const client = new Client(rpcFactory(), adaptor);
 
     const find = randomId();
-    const query = buildTagsQuery([{ key: "app.key", value: find }]);
+    const query = buildQuery({ tags: [{ key: "app.key", value: find }] });
 
     const sendTx = async () => {
       const me = randomId();

--- a/packages/iov-tendermint-rpc/src/client.spec.ts
+++ b/packages/iov-tendermint-rpc/src/client.spec.ts
@@ -7,7 +7,7 @@ import { Encoding } from "@iov/encoding";
 import { Adaptor, adatorForVersion } from "./adaptor";
 import { Client } from "./client";
 import { randomId } from "./common";
-import { buildQuery, QueryTag } from "./requests";
+import { buildQuery } from "./requests";
 import * as responses from "./responses";
 import { HttpClient, RpcClient, WebsocketClient } from "./rpcclient";
 
@@ -385,8 +385,8 @@ function websocketTestSuite(rpcFactory: () => RpcClient, adaptor: Adaptor): void
     (async () => {
       const events: responses.TxEvent[] = [];
       const client = new Client(rpcFactory(), adaptor);
-      const tags: ReadonlyArray<QueryTag> = [{ key: "app.creator", value: "jae" }];
-      const stream = client.subscribeTx(tags);
+      const query = buildQuery({ tags: [{ key: "app.creator", value: "jae" }] });
+      const stream = client.subscribeTx(query);
       expect(stream).toBeTruthy();
       const subscription = stream.subscribe({
         next: event => {

--- a/packages/iov-tendermint-rpc/src/client.ts
+++ b/packages/iov-tendermint-rpc/src/client.ts
@@ -126,12 +126,12 @@ export class Client {
     return this.subscribe(request, this.r.decodeNewBlockHeaderEvent);
   }
 
-  public subscribeTx(tags?: ReadonlyArray<requests.QueryTag>): Stream<responses.TxEvent> {
+  public subscribeTx(query?: requests.QueryString): Stream<responses.TxEvent> {
     const request: requests.SubscribeRequest = {
       method: requests.Method.Subscribe,
       query: {
         type: requests.SubscriptionEventType.Tx,
-        tags: tags,
+        raw: query,
       },
     };
     return this.subscribe(request, this.r.decodeTxEvent);

--- a/packages/iov-tendermint-rpc/src/requests.spec.ts
+++ b/packages/iov-tendermint-rpc/src/requests.spec.ts
@@ -1,20 +1,33 @@
-import { buildTagsQuery } from "./requests";
+import { buildQuery, QueryString } from "./requests";
 
 describe("Requests", () => {
-  describe("buildTagsQuery", () => {
-    it("works for no tags", () => {
-      const query = buildTagsQuery([]);
+  describe("buildQuery", () => {
+    it("works for no input", () => {
+      const query = buildQuery({});
       expect(query).toEqual("");
     });
 
     it("works for one tags", () => {
-      const query = buildTagsQuery([{ key: "abc", value: "def" }]);
+      const query = buildQuery({ tags: [{ key: "abc", value: "def" }] });
       expect(query).toEqual("abc='def'");
     });
 
     it("works for two tags", () => {
-      const query = buildTagsQuery([{ key: "k", value: "9" }, { key: "L", value: "7" }]);
+      const query = buildQuery({ tags: [{ key: "k", value: "9" }, { key: "L", value: "7" }] });
       expect(query).toEqual("k='9' AND L='7'");
+    });
+
+    it("works for raw input", () => {
+      const query = buildQuery({ raw: "aabbCCDD" as QueryString });
+      expect(query).toEqual("aabbCCDD");
+    });
+
+    it("works for mixed input", () => {
+      const query = buildQuery({
+        tags: [{ key: "k", value: "9" }, { key: "L", value: "7" }],
+        raw: "aabbCCDD" as QueryString,
+      });
+      expect(query).toEqual("k='9' AND L='7' AND aabbCCDD");
     });
   });
 });

--- a/packages/iov-tendermint-rpc/src/requests.ts
+++ b/packages/iov-tendermint-rpc/src/requests.ts
@@ -180,6 +180,15 @@ export class DefaultParams {
   }
 }
 
-export function buildTagsQuery(tags: ReadonlyArray<QueryTag>): QueryString {
-  return tags.map(tag => `${tag.key}='${tag.value}'`).join(" AND ") as QueryString;
+export interface BuildQueryComponents {
+  readonly tags?: ReadonlyArray<QueryTag>;
+  readonly raw?: QueryString;
+}
+
+export function buildQuery(components: BuildQueryComponents): QueryString {
+  const tags = components.tags ? components.tags : [];
+  const tagComponents = tags.map(tag => `${tag.key}='${tag.value}'`);
+  const rawComponents = components.raw ? [components.raw] : [];
+
+  return [...tagComponents, ...rawComponents].join(" AND ") as QueryString;
 }

--- a/packages/iov-tendermint-rpc/src/requests.ts
+++ b/packages/iov-tendermint-rpc/src/requests.ts
@@ -122,7 +122,7 @@ export interface SubscribeRequest {
   readonly method: Method.Subscribe;
   readonly query: {
     readonly type: SubscriptionEventType;
-    readonly tags?: ReadonlyArray<QueryTag>;
+    readonly raw?: QueryString;
   };
 }
 

--- a/packages/iov-tendermint-rpc/src/v0-20/requests.ts
+++ b/packages/iov-tendermint-rpc/src/v0-20/requests.ts
@@ -32,13 +32,9 @@ export class Params extends requests.DefaultParams {
   }
 
   public static encodeSubscribe(req: requests.SubscribeRequest): JsonRpcRequest {
-    const allTags: ReadonlyArray<requests.QueryTag> = [
-      { key: "tm.event", value: req.query.type },
-      ...(req.query.tags ? req.query.tags : []),
-    ];
-
-    const queryString = requests.buildQuery({ tags: allTags });
-    return jsonRpcWith("subscribe", { query: queryString });
+    const eventTag = { key: "tm.event", value: req.query.type };
+    const query = requests.buildQuery({ tags: [eventTag], raw: req.query.raw });
+    return jsonRpcWith("subscribe", { query: query });
   }
 
   public static encodeTx(req: requests.TxRequest): JsonRpcRequest {

--- a/packages/iov-tendermint-rpc/src/v0-20/requests.ts
+++ b/packages/iov-tendermint-rpc/src/v0-20/requests.ts
@@ -37,7 +37,7 @@ export class Params extends requests.DefaultParams {
       ...(req.query.tags ? req.query.tags : []),
     ];
 
-    const queryString = requests.buildTagsQuery(allTags);
+    const queryString = requests.buildQuery({ tags: allTags });
     return jsonRpcWith("subscribe", { query: queryString });
   }
 

--- a/packages/iov-tendermint-rpc/src/v0-25/requests.ts
+++ b/packages/iov-tendermint-rpc/src/v0-25/requests.ts
@@ -32,13 +32,9 @@ export class Params extends requests.DefaultParams {
   }
 
   public static encodeSubscribe(req: requests.SubscribeRequest): JsonRpcRequest {
-    const allTags: ReadonlyArray<requests.QueryTag> = [
-      { key: "tm.event", value: req.query.type },
-      ...(req.query.tags ? req.query.tags : []),
-    ];
-
-    const queryString = requests.buildQuery({ tags: allTags });
-    return jsonRpcWith("subscribe", { query: queryString });
+    const eventTag = { key: "tm.event", value: req.query.type };
+    const query = requests.buildQuery({ tags: [eventTag], raw: req.query.raw });
+    return jsonRpcWith("subscribe", { query: query });
   }
 
   public static encodeTx(req: requests.TxRequest): JsonRpcRequest {

--- a/packages/iov-tendermint-rpc/src/v0-25/requests.ts
+++ b/packages/iov-tendermint-rpc/src/v0-25/requests.ts
@@ -37,7 +37,7 @@ export class Params extends requests.DefaultParams {
       ...(req.query.tags ? req.query.tags : []),
     ];
 
-    const queryString = requests.buildTagsQuery(allTags);
+    const queryString = requests.buildQuery({ tags: allTags });
     return jsonRpcWith("subscribe", { query: queryString });
   }
 

--- a/packages/iov-tendermint-rpc/types/client.d.ts
+++ b/packages/iov-tendermint-rpc/types/client.d.ts
@@ -40,7 +40,7 @@ export declare class Client {
     status(): Promise<responses.StatusResponse>;
     subscribeNewBlock(): Stream<responses.NewBlockEvent>;
     subscribeNewBlockHeader(): Stream<responses.NewBlockHeaderEvent>;
-    subscribeTx(tags?: ReadonlyArray<requests.QueryTag>): Stream<responses.TxEvent>;
+    subscribeTx(query?: requests.QueryString): Stream<responses.TxEvent>;
     tx(params: requests.TxParams): Promise<responses.TxResponse>;
     /**
      * Search for transactions that are in a block

--- a/packages/iov-tendermint-rpc/types/requests.d.ts
+++ b/packages/iov-tendermint-rpc/types/requests.d.ts
@@ -132,4 +132,8 @@ export declare class DefaultParams {
     static encodeHealth(req: HealthRequest): JsonRpcRequest;
     static encodeStatus(req: StatusRequest): JsonRpcRequest;
 }
-export declare function buildTagsQuery(tags: ReadonlyArray<QueryTag>): QueryString;
+export interface BuildQueryComponents {
+    readonly tags?: ReadonlyArray<QueryTag>;
+    readonly raw?: QueryString;
+}
+export declare function buildQuery(components: BuildQueryComponents): QueryString;

--- a/packages/iov-tendermint-rpc/types/requests.d.ts
+++ b/packages/iov-tendermint-rpc/types/requests.d.ts
@@ -94,7 +94,7 @@ export interface SubscribeRequest {
     readonly method: Method.Subscribe;
     readonly query: {
         readonly type: SubscriptionEventType;
-        readonly tags?: ReadonlyArray<QueryTag>;
+        readonly raw?: QueryString;
     };
 }
 export declare type QueryString = string & As<"query">;


### PR DESCRIPTION
Based on #586

This bug existed all the time but was never revealed because before #586 we could not subscribe to transaction hash updates.