### PR TITLE
Run tslint explicitly

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "bootstrap": "lerna bootstrap",
     "format": "lerna run format",
     "lint": "lerna run lint",
-    "lint-fix": "lerna run lint-fix",
     "test": "lerna run test",
     "build": "lerna run build",
     "docs": "lerna run docs",

--- a/packages/iov-base-types/package.json
+++ b/packages/iov-base-types/package.json
@@ -17,7 +17,7 @@
     "docs": "shx rm -rf docs && typedoc --options typedoc.js",
     "format": "prettier --write --loglevel warn \"./src/**/*.ts\"",
     "lint": "cross-env-shell \"tslint -t verbose --project . ${TSLINT_FLAGS}\"",
-    "prebuild": "yarn format && yarn lint",
+    "prebuild": "yarn format",
     "move-types": "shx rm -r ./types/* && shx mv build/types/* ./types",
     "build": "shx rm -rf ./build && tsc && yarn move-types",
     "build-or-skip": "[ -n \"$SKIP_BUILD\" ] || yarn build",

--- a/packages/iov-base-types/package.json
+++ b/packages/iov-base-types/package.json
@@ -17,7 +17,6 @@
     "docs": "shx rm -rf docs && typedoc --options typedoc.js",
     "format": "prettier --write --loglevel warn \"./src/**/*.ts\"",
     "lint": "cross-env-shell \"tslint -t verbose --project . ${TSLINT_FLAGS}\"",
-    "lint-fix": "yarn lint --fix",
     "prebuild": "yarn format && yarn lint",
     "move-types": "shx rm -r ./types/* && shx mv build/types/* ./types",
     "build": "shx rm -rf ./build && tsc && yarn move-types",

--- a/packages/iov-bcp-types/package.json
+++ b/packages/iov-bcp-types/package.json
@@ -17,7 +17,7 @@
     "docs": "shx rm -rf docs && typedoc --options typedoc.js",
     "format": "prettier --write --loglevel warn \"./src/**/*.ts\"",
     "lint": "cross-env-shell \"tslint -t verbose --project . ${TSLINT_FLAGS}\"",
-    "prebuild": "yarn format && yarn lint",
+    "prebuild": "yarn format",
     "move-types": "shx rm -r ./types/* && shx mv build/types/* ./types",
     "build": "shx rm -rf ./build && tsc && yarn move-types",
     "build-or-skip": "[ -n \"$SKIP_BUILD\" ] || yarn build",

--- a/packages/iov-bcp-types/package.json
+++ b/packages/iov-bcp-types/package.json
@@ -17,7 +17,6 @@
     "docs": "shx rm -rf docs && typedoc --options typedoc.js",
     "format": "prettier --write --loglevel warn \"./src/**/*.ts\"",
     "lint": "cross-env-shell \"tslint -t verbose --project . ${TSLINT_FLAGS}\"",
-    "lint-fix": "yarn lint --fix",
     "prebuild": "yarn format && yarn lint",
     "move-types": "shx rm -r ./types/* && shx mv build/types/* ./types",
     "build": "shx rm -rf ./build && tsc && yarn move-types",

--- a/packages/iov-bns/package.json
+++ b/packages/iov-bns/package.json
@@ -23,7 +23,7 @@
     "test-chrome": "yarn pack-web && karma start --single-run --browsers ChromeHeadless",
     "test-safari": "yarn pack-web && karma start --single-run --browsers Safari",
     "test": "yarn build-or-skip && yarn test-node",
-    "prebuild": "yarn format && yarn lint",
+    "prebuild": "yarn format",
     "move-types": "shx rm -r ./types/* && shx mv build/types/* ./types && shx rm ./types/*.spec.d.ts",
     "build": "shx rm -rf ./build && tsc && shx mkdir -p build/generated && shx cp ./src/generated/*.js ./build/generated && shx mkdir -p ./build/types/generated && shx cp ./src/generated/*.d.ts ./build/types/generated && yarn move-types",
     "build-or-skip": "[ -n \"$SKIP_BUILD\" ] || yarn build",

--- a/packages/iov-cli/package.json
+++ b/packages/iov-cli/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "format": "prettier --write --loglevel warn \"./src/**/*.ts\"",
     "lint": "cross-env-shell \"tslint -t verbose --project . ${TSLINT_FLAGS}\"",
-    "prebuild": "yarn format && yarn lint",
+    "prebuild": "yarn format",
     "build": "tsc",
     "build-or-skip": "[ -n \"$SKIP_BUILD\" ] || yarn build",
     "test-node": "node jasmine-testrunner.js",

--- a/packages/iov-core/package.json
+++ b/packages/iov-core/package.json
@@ -23,7 +23,7 @@
     "test-chrome": "yarn pack-web && karma start --single-run --browsers ChromeHeadless",
     "test-safari": "yarn pack-web && karma start --single-run --browsers Safari",
     "test": "yarn build-or-skip && yarn test-node",
-    "prebuild": "yarn format && yarn lint",
+    "prebuild": "yarn format",
     "move-types": "shx rm -r ./types/* && shx mv build/types/* ./types && shx rm ./types/*.spec.d.ts",
     "build": "shx rm -rf ./build && tsc && yarn move-types",
     "build-or-skip": "[ -n \"$SKIP_BUILD\" ] || yarn build",

--- a/packages/iov-crypto/package.json
+++ b/packages/iov-crypto/package.json
@@ -23,7 +23,7 @@
     "test-chrome": "yarn pack-web && karma start --single-run --browsers ChromeHeadless",
     "test-safari": "yarn pack-web && karma start --single-run --browsers Safari",
     "test": "yarn build-or-skip && yarn test-node",
-    "prebuild": "yarn format && yarn lint",
+    "prebuild": "yarn format",
     "move-types": "shx rm -r ./types/* && shx mv build/types/* ./types && shx rm ./types/*.spec.d.ts",
     "build": "shx rm -rf ./build && tsc && yarn move-types",
     "build-or-skip": "[ -n \"$SKIP_BUILD\" ] || yarn build",

--- a/packages/iov-dpos/package.json
+++ b/packages/iov-dpos/package.json
@@ -17,7 +17,7 @@
     "docs": "shx rm -rf docs && typedoc --options typedoc.js",
     "format": "prettier --write --loglevel warn \"./src/**/*.ts\"",
     "lint": "cross-env-shell \"tslint -t verbose --project . ${TSLINT_FLAGS}\"",
-    "prebuild": "yarn format && yarn lint",
+    "prebuild": "yarn format",
     "move-types": "shx rm -r ./types/* && shx mv build/types/* ./types && shx rm ./types/*.spec.d.ts",
     "build": "shx rm -rf ./build && tsc && yarn move-types",
     "build-or-skip": "[ -n \"$SKIP_BUILD\" ] || yarn build",

--- a/packages/iov-encoding/package.json
+++ b/packages/iov-encoding/package.json
@@ -23,7 +23,7 @@
     "test-chrome": "yarn pack-web && karma start --single-run --browsers ChromeHeadless",
     "test-safari": "yarn pack-web && karma start --single-run --browsers Safari",
     "test": "yarn build-or-skip && yarn test-node",
-    "prebuild": "yarn format && yarn lint",
+    "prebuild": "yarn format",
     "move-types": "shx rm -r ./types/* && shx mv build/types/* ./types && shx rm ./types/*.spec.d.ts",
     "build": "shx rm -rf ./build && tsc && yarn move-types",
     "build-or-skip": "[ -n \"$SKIP_BUILD\" ] || yarn build",

--- a/packages/iov-ethereum/package.json
+++ b/packages/iov-ethereum/package.json
@@ -18,7 +18,7 @@
     "docs": "shx rm -rf docs && typedoc --options typedoc.js",
     "format": "prettier --write --loglevel warn \"./src/**/*.ts\"",
     "lint": "cross-env-shell \"tslint -t verbose --project . ${TSLINT_FLAGS}\"",
-    "prebuild": "yarn format && yarn lint",
+    "prebuild": "yarn format",
     "move-types": "shx rm -r ./types/* && shx mv build/types/* ./types && shx rm ./types/*.spec.d.ts",
     "build": "shx rm -rf ./build && tsc && yarn move-types",
     "build-or-skip": "[ -n \"$SKIP_BUILD\" ] || yarn build",

--- a/packages/iov-faucets/package.json
+++ b/packages/iov-faucets/package.json
@@ -17,7 +17,7 @@
     "docs": "shx rm -rf docs && typedoc --options typedoc.js",
     "format": "prettier --write --loglevel warn \"./src/**/*.ts\"",
     "lint": "cross-env-shell \"tslint -t verbose --project . ${TSLINT_FLAGS}\"",
-    "prebuild": "yarn format && yarn lint",
+    "prebuild": "yarn format",
     "move-types": "shx rm -r ./types/* && shx mv build/types/* ./types && shx rm ./types/*.spec.d.ts",
     "build": "shx rm -rf ./build && tsc && yarn move-types",
     "build-or-skip": "[ -n \"$SKIP_BUILD\" ] || yarn build",

--- a/packages/iov-keycontrol/package.json
+++ b/packages/iov-keycontrol/package.json
@@ -17,7 +17,6 @@
     "docs": "shx rm -rf docs && typedoc --options typedoc.js",
     "format": "prettier --write --loglevel warn \"./src/**/*.ts\"",
     "lint": "cross-env-shell \"tslint -t verbose --project . ${TSLINT_FLAGS}\"",
-    "lint-fix": "yarn lint --fix",
     "test-node": "node jasmine-testrunner.js",
     "test-edge": "yarn pack-web && karma start --single-run --browsers Edge",
     "test-firefox": "yarn pack-web && karma start --single-run --browsers Firefox",

--- a/packages/iov-keycontrol/package.json
+++ b/packages/iov-keycontrol/package.json
@@ -23,7 +23,7 @@
     "test-chrome": "yarn pack-web && karma start --single-run --browsers ChromeHeadless",
     "test-safari": "yarn pack-web && karma start --single-run --browsers Safari",
     "test": "yarn build-or-skip && yarn test-node",
-    "prebuild": "yarn format && yarn lint",
+    "prebuild": "yarn format",
     "move-types": "shx rm -r ./types/* && shx mv build/types/* ./types && shx rm ./types/*.spec.d.ts && shx rm ./types/**/*.spec.d.ts",
     "build": "shx rm -rf ./build && tsc && yarn move-types",
     "build-or-skip": "[ -n \"$SKIP_BUILD\" ] || yarn build",

--- a/packages/iov-ledger-bns/package.json
+++ b/packages/iov-ledger-bns/package.json
@@ -19,7 +19,7 @@
     "format": "prettier --write --loglevel warn \"./src/**/*.ts\"",
     "test-node": "node jasmine-testrunner.js",
     "test": "yarn build-or-skip && yarn test-node",
-    "prebuild": "yarn format && yarn lint",
+    "prebuild": "yarn format",
     "move-types": "shx rm -r ./types/* && shx mv build/types/* ./types && shx rm ./types/*.spec.d.ts",
     "build": "shx rm -rf ./build && tsc && yarn move-types",
     "build-or-skip": "[ -n \"$SKIP_BUILD\" ] || yarn build",

--- a/packages/iov-lisk/package.json
+++ b/packages/iov-lisk/package.json
@@ -17,7 +17,7 @@
     "docs": "shx rm -rf docs && typedoc --options typedoc.js",
     "format": "prettier --write --loglevel warn \"./src/**/*.ts\"",
     "lint": "cross-env-shell \"tslint -t verbose --project . ${TSLINT_FLAGS}\"",
-    "prebuild": "yarn format && yarn lint",
+    "prebuild": "yarn format",
     "move-types": "shx rm -r ./types/* && shx mv build/types/* ./types && shx rm ./types/*.spec.d.ts",
     "build": "shx rm -rf ./build && tsc && yarn move-types",
     "build-or-skip": "[ -n \"$SKIP_BUILD\" ] || yarn build",

--- a/packages/iov-rise/package.json
+++ b/packages/iov-rise/package.json
@@ -17,7 +17,7 @@
     "docs": "shx rm -rf docs && typedoc --options typedoc.js",
     "format": "prettier --write --loglevel warn \"./src/**/*.ts\"",
     "lint": "cross-env-shell \"tslint -t verbose --project . ${TSLINT_FLAGS}\"",
-    "prebuild": "yarn format && yarn lint",
+    "prebuild": "yarn format",
     "move-types": "shx rm -r ./types/* && shx mv build/types/* ./types && shx rm ./types/*.spec.d.ts",
     "build": "shx rm -rf ./build && tsc && yarn move-types",
     "build-or-skip": "[ -n \"$SKIP_BUILD\" ] || yarn build",

--- a/packages/iov-stream/package.json
+++ b/packages/iov-stream/package.json
@@ -23,7 +23,7 @@
     "test-chrome": "yarn pack-web && karma start --single-run --browsers ChromeHeadless",
     "test-safari": "yarn pack-web && karma start --single-run --browsers Safari",
     "test": "yarn build-or-skip && yarn test-node",
-    "prebuild": "yarn format && yarn lint",
+    "prebuild": "yarn format",
     "move-types": "shx rm -r ./types/* && shx mv build/types/* ./types && shx rm ./types/*.spec.d.ts",
     "build": "shx rm -rf ./build && tsc && yarn move-types",
     "build-or-skip": "[ -n \"$SKIP_BUILD\" ] || yarn build",

--- a/packages/iov-tendermint-rpc/package.json
+++ b/packages/iov-tendermint-rpc/package.json
@@ -23,7 +23,7 @@
     "test-chrome": "yarn pack-web && karma start --single-run --browsers ChromeHeadless",
     "test-safari": "yarn pack-web && karma start --single-run --browsers Safari",
     "test": "yarn build-or-skip && yarn test-node",
-    "prebuild": "yarn format && yarn lint",
+    "prebuild": "yarn format",
     "move-types": "shx rm -r ./types/* && shx mv build/types/* ./types && shx rm ./types/*.spec.d.ts && shx rm ./types/**/*.spec.d.ts",
     "build": "shx rm -rf ./build && tsc && yarn move-types",
     "build-or-skip": "[ -n \"$SKIP_BUILD\" ] || yarn build",

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -91,6 +91,10 @@ fold_start "update-npmipgnore"
 ./scripts/update_npmignore.sh
 fold_end
 
+fold_start "yarn-lint"
+yarn lint
+fold_end
+
 fold_start "yarn-build"
 yarn build
 fold_end


### PR DESCRIPTION
This reduces build times by 22-28 %, which is super valuable especially because caching/incremental builds are non-existend if you don't use `--watch` mode.

With tslint support in VS Code it is easy to avoid tslint fails at build time. In combination with tslint in the CI and the ability to run `yarn lint` manually, this should do the job.