### PR TITLE
Add bcp domain to SendTransaction

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ script:
 branches:
   only:
   - master
-  - 0.9
+  - decentralize-transaction-types
 
 notifications:
   email: false

--- a/packages/iov-bcp-types/src/transactions.ts
+++ b/packages/iov-bcp-types/src/transactions.ts
@@ -45,8 +45,15 @@ export interface UnsignedTransaction {
    * This should be used for type detection only and not be encoded somewhere.
    * Right now we use "bns", "ethereum", "lisk" and "rise" but this could also
    * be migrated to a Java-style package names like "io.lisk.mainnet" later on.
+   *
+   * We also use the special domain "bcp" for any kind that can be supported in multiple chains
    */
   readonly domain: string;
+  /**
+   * kind is the type of transaction (send, setName, etc)
+   * A (domain, kind) pair will uniquely define the expected shape of any transaction type
+   */
+  readonly kind: string;
   /** the chain on which the transaction should be valid */
   readonly chainId: ChainId;
   readonly fee?: Amount;
@@ -57,6 +64,7 @@ export interface UnsignedTransaction {
 }
 
 export interface SendTransaction extends UnsignedTransaction {
+  readonly domain: "bcp";
   readonly kind: "send";
   readonly amount: Amount;
   readonly recipient: Address;
@@ -94,7 +102,7 @@ export interface SwapTimeoutTransaction extends UnsignedTransaction {
 }
 
 export function isSendTransaction(transaction: UnsignedTransaction): transaction is SendTransaction {
-  return (transaction as SendTransaction).kind === "send";
+  return transaction.domain === "bcp" && transaction.kind === "send";
 }
 
 export function isSwapOfferTransaction(

--- a/packages/iov-bcp-types/types/transactions.d.ts
+++ b/packages/iov-bcp-types/types/transactions.d.ts
@@ -37,8 +37,15 @@ export interface UnsignedTransaction {
      * This should be used for type detection only and not be encoded somewhere.
      * Right now we use "bns", "ethereum", "lisk" and "rise" but this could also
      * be migrated to a Java-style package names like "io.lisk.mainnet" later on.
+     *
+     * We also use the special domain "bcp" for any kind that can be supported in multiple chains
      */
     readonly domain: string;
+    /**
+     * kind is the type of transaction (send, setName, etc)
+     * A (domain, kind) pair will uniquely define the expected shape of any transaction type
+     */
+    readonly kind: string;
     /** the chain on which the transaction should be valid */
     readonly chainId: ChainId;
     readonly fee?: Amount;
@@ -47,6 +54,7 @@ export interface UnsignedTransaction {
     readonly signer: PublicKeyBundle;
 }
 export interface SendTransaction extends UnsignedTransaction {
+    readonly domain: "bcp";
     readonly kind: "send";
     readonly amount: Amount;
     readonly recipient: Address;

--- a/packages/iov-bns/src/bnsconnection.spec.ts
+++ b/packages/iov-bns/src/bnsconnection.spec.ts
@@ -12,6 +12,7 @@ import {
   BcpTxQuery,
   Nonce,
   PostTxResponse,
+  SendTransaction,
   SwapIdBytes,
   SwapState,
   TokenTicker,
@@ -40,7 +41,6 @@ import {
   RegisterBlockchainTx,
   RegisterUsernameTx,
   RemoveAddressFromUsernameTx,
-  SendTx,
   SwapClaimTx,
   SwapCounterTx,
   SwapOfferTx,
@@ -86,8 +86,8 @@ async function ensureNonceNonZero(
   identity: PublicIdentity,
 ): Promise<void> {
   const nonce = await getNonce(connection, keyToAddress(identity.pubkey));
-  const sendTx: SendTx = {
-    domain: "bns",
+  const sendTx: SendTransaction = {
+    domain: "bcp",
     kind: "send",
     chainId: await connection.chainId(),
     signer: identity.pubkey,
@@ -284,8 +284,8 @@ describe("BnsConnection", () => {
       const recipient = await randomBnsAddress();
 
       // construct a sendtx, this is normally used in the MultiChainSigner api
-      const sendTx: SendTx = {
-        domain: "bns",
+      const sendTx: SendTransaction = {
+        domain: "bcp",
         kind: "send",
         chainId,
         signer: faucet.pubkey,
@@ -346,8 +346,8 @@ describe("BnsConnection", () => {
         const recipient = await randomBnsAddress();
 
         // construct a sendtx, this is normally used in the MultiChainSigner api
-        const sendTx: SendTx = {
-          domain: "bns",
+        const sendTx: SendTransaction = {
+          domain: "bcp",
           kind: "send",
           chainId,
           signer: faucet.pubkey,
@@ -735,8 +735,8 @@ describe("BnsConnection", () => {
 
       // construct a sendtx, this is normally used in the MultiChainSigner api
       const memo = `Payment ${Math.random()}`;
-      const sendTx: SendTx = {
-        domain: "bns",
+      const sendTx: SendTransaction = {
+        domain: "bcp",
         kind: "send",
         chainId: chainId,
         signer: faucet.pubkey,
@@ -757,7 +757,7 @@ describe("BnsConnection", () => {
       expect(results.length).toBeGreaterThanOrEqual(1);
       const mostRecentResult = results[results.length - 1];
       expect((mostRecentResult.transaction as BnsTx).kind).toEqual("send");
-      expect((mostRecentResult.transaction as SendTx).memo).toEqual(memo);
+      expect((mostRecentResult.transaction as SendTransaction).memo).toEqual(memo);
 
       connection.disconnect();
     });
@@ -773,8 +773,8 @@ describe("BnsConnection", () => {
 
       // construct a sendtx, this is normally used in the MultiChainSigner api
       const memo = `Payment ${Math.random()}`;
-      const sendTx: SendTx = {
-        domain: "bns",
+      const sendTx: SendTransaction = {
+        domain: "bcp",
         kind: "send",
         chainId: chainId,
         signer: faucet.pubkey,
@@ -796,7 +796,7 @@ describe("BnsConnection", () => {
       expect(results.length).toBeGreaterThanOrEqual(1);
       const mostRecentResult = results[results.length - 1];
       expect((mostRecentResult.transaction as BnsTx).kind).toEqual("send");
-      expect((mostRecentResult.transaction as SendTx).memo).toEqual(memo);
+      expect((mostRecentResult.transaction as SendTransaction).memo).toEqual(memo);
 
       connection.disconnect();
     });
@@ -810,8 +810,8 @@ describe("BnsConnection", () => {
       const faucetAddress = keyToAddress(faucet.pubkey);
 
       const memo = `Payment ${Math.random()}`;
-      const sendTx: SendTx = {
-        domain: "bns",
+      const sendTx: SendTransaction = {
+        domain: "bcp",
         kind: "send",
         chainId: chainId,
         signer: faucet.pubkey,
@@ -837,7 +837,7 @@ describe("BnsConnection", () => {
       expect(searchResults.length).toEqual(1);
       expect(searchResults[0].transactionId).toEqual(transactionIdToSearch);
       expect((searchResults[0].transaction as BnsTx).kind).toEqual("send");
-      expect((searchResults[0].transaction as SendTx).memo).toEqual(memo);
+      expect((searchResults[0].transaction as SendTransaction).memo).toEqual(memo);
 
       connection.disconnect();
     });
@@ -856,8 +856,8 @@ describe("BnsConnection", () => {
 
       // construct a sendtx, this is normally used in the MultiChainSigner api
       const memo = `Payment ${Math.random()}`;
-      const sendTx: SendTx = {
-        domain: "bns",
+      const sendTx: SendTransaction = {
+        domain: "bcp",
         kind: "send",
         chainId: chainId,
         signer: faucet.pubkey,
@@ -883,7 +883,7 @@ describe("BnsConnection", () => {
         expect(results.length).toBeGreaterThanOrEqual(1);
         const mostRecentResult = results[results.length - 1];
         expect((mostRecentResult.transaction as BnsTx).kind).toEqual("send");
-        expect((mostRecentResult.transaction as SendTx).memo).toEqual(memo);
+        expect((mostRecentResult.transaction as SendTransaction).memo).toEqual(memo);
       }
 
       {
@@ -895,7 +895,7 @@ describe("BnsConnection", () => {
         expect(results.length).toBeGreaterThanOrEqual(1);
         const mostRecentResult = results[results.length - 1];
         expect((mostRecentResult.transaction as BnsTx).kind).toEqual("send");
-        expect((mostRecentResult.transaction as SendTx).memo).toEqual(memo);
+        expect((mostRecentResult.transaction as SendTransaction).memo).toEqual(memo);
       }
 
       {
@@ -907,7 +907,7 @@ describe("BnsConnection", () => {
         expect(results.length).toBeGreaterThanOrEqual(1);
         const mostRecentResult = results[results.length - 1];
         expect((mostRecentResult.transaction as BnsTx).kind).toEqual("send");
-        expect((mostRecentResult.transaction as SendTx).memo).toEqual(memo);
+        expect((mostRecentResult.transaction as SendTransaction).memo).toEqual(memo);
       }
 
       {
@@ -919,7 +919,7 @@ describe("BnsConnection", () => {
         expect(results.length).toBeGreaterThanOrEqual(1);
         const mostRecentResult = results[results.length - 1];
         expect((mostRecentResult.transaction as BnsTx).kind).toEqual("send");
-        expect((mostRecentResult.transaction as SendTx).memo).toEqual(memo);
+        expect((mostRecentResult.transaction as SendTransaction).memo).toEqual(memo);
       }
 
       connection.disconnect();
@@ -938,8 +938,8 @@ describe("BnsConnection", () => {
         const faucetAddress = keyToAddress(faucet.pubkey);
 
         const memo = `Payment ${Math.random()}`;
-        const sendTx: SendTx = {
-          domain: "bns",
+        const sendTx: SendTransaction = {
+          domain: "bcp",
           kind: "send",
           chainId: chainId,
           signer: faucet.pubkey,
@@ -1246,8 +1246,8 @@ describe("BnsConnection", () => {
     const chainId = await connection.chainId();
     const faucetAddr = keyToAddress(faucet.pubkey);
     const nonce = await getNonce(connection, faucetAddr);
-    const sendTx: SendTx = {
-      domain: "bns",
+    const sendTx: SendTransaction = {
+      domain: "bcp",
       kind: "send",
       chainId,
       signer: faucet.pubkey,

--- a/packages/iov-bns/src/decode.spec.ts
+++ b/packages/iov-bns/src/decode.spec.ts
@@ -230,7 +230,9 @@ describe("Decode", () => {
 
   describe("parseMsg", () => {
     const defaultBaseTx: UnsignedTransaction = {
-      domain: "bns",
+      // these two should be overriden by parseMsg
+      domain: "",
+      kind: "",
       chainId: "bns-chain" as ChainId,
       signer: {
         algo: Algorithm.Ed25519,

--- a/packages/iov-bns/src/decode.ts
+++ b/packages/iov-bns/src/decode.ts
@@ -7,6 +7,7 @@ import {
   BcpTicker,
   FullSignature,
   Nonce,
+  SendTransaction,
   SignedTransaction,
   SwapIdBytes,
   TokenTicker,
@@ -29,7 +30,6 @@ import {
   RegisterBlockchainTx,
   RegisterUsernameTx,
   RemoveAddressFromUsernameTx,
-  SendTx,
   SetNameTx,
   SwapClaimTx,
   SwapCounterTx,
@@ -143,7 +143,7 @@ export function parseMsg(base: UnsignedTransaction, tx: codecImpl.app.ITx): Unsi
   if (tx.addUsernameAddressNftMsg) {
     return parseAddAddressToUsernameTx(base, tx.addUsernameAddressNftMsg);
   } else if (tx.sendMsg) {
-    return parseSendTx(base, tx.sendMsg);
+    return parseSendTransaction(base, tx.sendMsg);
   } else if (tx.setNameMsg) {
     return parseSetNameTx(base, tx.setNameMsg);
   } else if (tx.createEscrowMsg) {
@@ -178,12 +178,12 @@ function parseAddAddressToUsernameTx(
   };
 }
 
-function parseSendTx(base: UnsignedTransaction, msg: codecImpl.cash.ISendMsg): SendTx {
+function parseSendTransaction(base: UnsignedTransaction, msg: codecImpl.cash.ISendMsg): SendTransaction {
   return {
     // TODO: would we want to ensure these match?
     //    src: await keyToAddress(tx.signer),
     ...base,
-    domain: "bns",
+    domain: "bcp",
     kind: "send",
     recipient: encodeBnsAddress(ensure(msg.dest, "recipient")),
     amount: decodeAmount(ensure(msg.amount)),
@@ -247,7 +247,8 @@ function parseSwapTimeoutTx(
 
 function parseBaseTx(tx: codecImpl.app.ITx, sig: FullSignature, chainId: ChainId): UnsignedTransaction {
   const base: UnsignedTransaction = {
-    domain: "bns",
+    domain: "",
+    kind: "",
     chainId: chainId,
     signer: sig.pubkey,
   };

--- a/packages/iov-bns/src/encode.ts
+++ b/packages/iov-bns/src/encode.ts
@@ -1,5 +1,11 @@
 import { Algorithm, PublicKeyBundle, SignatureBytes } from "@iov/base-types";
-import { Amount, FullSignature, SignedTransaction, UnsignedTransaction } from "@iov/bcp-types";
+import {
+  Amount,
+  FullSignature,
+  SendTransaction,
+  SignedTransaction,
+  UnsignedTransaction,
+} from "@iov/bcp-types";
 import { Encoding, Int53 } from "@iov/encoding";
 
 import * as codecImpl from "./generated/codecimpl";
@@ -10,7 +16,6 @@ import {
   RegisterBlockchainTx,
   RegisterUsernameTx,
   RemoveAddressFromUsernameTx,
-  SendTx,
   SetNameTx,
   SwapClaimTx,
   SwapCounterTx,
@@ -107,7 +112,7 @@ export function buildMsg(tx: UnsignedTransaction): codecImpl.app.ITx {
     case "add_address_to_username":
       return buildAddAddressToUsernameTx(tx);
     case "send":
-      return buildSendTx(tx);
+      return buildSendTransaction(tx);
     case "set_name":
       return buildSetNameTx(tx);
     case "swap_offer":
@@ -139,7 +144,7 @@ function buildAddAddressToUsernameTx(tx: AddAddressToUsernameTx): codecImpl.app.
   };
 }
 
-function buildSendTx(tx: SendTx): codecImpl.app.ITx {
+function buildSendTransaction(tx: SendTransaction): codecImpl.app.ITx {
   return {
     sendMsg: codecImpl.cash.SendMsg.create({
       src: decodeBnsAddress(keyToAddress(tx.signer)).data,

--- a/packages/iov-bns/src/testdata.ts
+++ b/packages/iov-bns/src/testdata.ts
@@ -4,6 +4,7 @@ import {
   Amount,
   FullSignature,
   Nonce,
+  SendTransaction,
   SignedTransaction,
   SwapIdBytes,
   TokenTicker,
@@ -13,7 +14,6 @@ import { Encoding, Int53 } from "@iov/encoding";
 import {
   PrivateKeyBundle,
   PrivateKeyBytes,
-  SendTx,
   SetNameTx,
   SwapClaimTx,
   SwapCounterTx,
@@ -68,10 +68,10 @@ export const chainId = "test-123" as ChainId;
 // the sender in this tx is the above pubkey, pubkey->address should match
 // recipient address generated using https://github.com/nym-zone/bech32
 // bech32 -e -h tiov 6f0a3e37845b6a3c8ccbe6219199abc3ae0b26d9
-export const sendTxJson: SendTx = {
+export const sendTxJson: SendTransaction = {
   chainId,
   signer: pubJson,
-  domain: "bns",
+  domain: "bcp",
   kind: "send",
   recipient: "tiov1du9ruduytd4rerxtucserxdtcwhqkfkezjy4w0" as Address,
   memo: "Test payment",
@@ -117,10 +117,10 @@ const sig2: FullSignature = {
 };
 // recipient address generated using https://github.com/nym-zone/bech32
 // bech32 -e -h tiov 009985cb38847474fe9febfd56ab67e14bcd56f3
-const randomMsg: SendTx = {
+const randomMsg: SendTransaction = {
   chainId: "foo-bar-baz" as ChainId,
   signer: pubJson,
-  domain: "bns",
+  domain: "bcp",
   kind: "send",
   recipient: "tiov1qzvctjecs368fl5la074d2m8u99u64hn8q7kyn" as Address,
   memo: "One more fix!",

--- a/packages/iov-bns/types/testdata.d.ts
+++ b/packages/iov-bns/types/testdata.d.ts
@@ -1,6 +1,6 @@
 import { ChainId, PublicKeyBundle } from "@iov/base-types";
-import { Address, Amount, FullSignature, SignedTransaction } from "@iov/bcp-types";
-import { PrivateKeyBundle, SendTx } from "./types";
+import { Address, Amount, FullSignature, SendTransaction, SignedTransaction } from "@iov/bcp-types";
+import { PrivateKeyBundle } from "./types";
 export declare const pubJson: PublicKeyBundle;
 export declare const pubBin: Uint8Array;
 export declare const privJson: PrivateKeyBundle;
@@ -9,7 +9,7 @@ export declare const address: Address;
 export declare const coinJson: Amount;
 export declare const coinBin: Uint8Array;
 export declare const chainId: ChainId;
-export declare const sendTxJson: SendTx;
+export declare const sendTxJson: SendTransaction;
 export declare const sendTxBin: Uint8Array;
 export declare const signBytes: Uint8Array;
 export declare const sig: FullSignature;

--- a/packages/iov-bns/types/types.d.ts
+++ b/packages/iov-bns/types/types.d.ts
@@ -1,7 +1,7 @@
 import * as Long from "long";
 import { As } from "type-tagger";
 import { Algorithm, ChainId, PublicKeyBundle, SignatureBytes } from "@iov/base-types";
-import { Address, Amount, FullSignature, SendTransaction, SwapClaimTransaction, SwapCounterTransaction, SwapOfferTransaction, SwapTimeoutTransaction, TokenTicker, UnsignedTransaction } from "@iov/bcp-types";
+import { Address, FullSignature, SendTransaction, SwapClaimTransaction, SwapCounterTransaction, SwapOfferTransaction, SwapTimeoutTransaction, TokenTicker, UnsignedTransaction } from "@iov/bcp-types";
 import { Int53 } from "@iov/encoding";
 import * as codecImpl from "./generated/codecimpl";
 export interface ChainAddressPair {
@@ -83,13 +83,6 @@ export interface AddAddressToUsernameTx extends UnsignedTransaction {
     readonly username: string;
     readonly payload: ChainAddressPair;
 }
-export interface SendTx extends SendTransaction {
-    readonly domain: bnsDomain;
-    readonly kind: "send";
-    readonly amount: Amount;
-    readonly recipient: Address;
-    readonly memo?: string;
-}
 /**
  * Associates a simple name to an account on a weave-based blockchain.
  *
@@ -148,10 +141,9 @@ export interface RemoveAddressFromUsernameTx extends UnsignedTransaction {
     readonly username: string;
     readonly payload: ChainAddressPair;
 }
-export declare type BnsTx = AddAddressToUsernameTx | SendTx | SetNameTx | SwapOfferTx | SwapCounterTx | SwapClaimTx | SwapTimeoutTx | RegisterBlockchainTx | RegisterUsernameTx | RemoveAddressFromUsernameTx;
+export declare type BnsTx = SendTransaction | AddAddressToUsernameTx | SetNameTx | SwapOfferTx | SwapCounterTx | SwapClaimTx | SwapTimeoutTx | RegisterBlockchainTx | RegisterUsernameTx | RemoveAddressFromUsernameTx;
 export declare function isBnsTx(transaction: UnsignedTransaction): transaction is BnsTx;
 export declare function isAddAddressToUsernameTx(transaction: UnsignedTransaction): transaction is AddAddressToUsernameTx;
-export declare function isSendTx(transaction: UnsignedTransaction): transaction is SendTx;
 export declare function isSetNameTx(transaction: UnsignedTransaction): transaction is SetNameTx;
 export declare function isSwapOfferTx(transaction: UnsignedTransaction): transaction is SwapOfferTx;
 export declare function isSwapCounterTx(transaction: UnsignedTransaction): transaction is SwapCounterTx;

--- a/packages/iov-core/src/multichainsigner.spec.ts
+++ b/packages/iov-core/src/multichainsigner.spec.ts
@@ -74,7 +74,7 @@ describe("MultiChainSigner", () => {
       // construct a sendtx, this mirrors the MultiChainSigner api
       const memo = `MultiChainSigner style (${Math.random()})`;
       const sendTx: SendTransaction = {
-        domain: "bns",
+        domain: "bcp",
         kind: "send",
         chainId,
         signer: faucet.pubkey,

--- a/packages/iov-dpos/src/serialization.spec.ts
+++ b/packages/iov-dpos/src/serialization.spec.ts
@@ -82,7 +82,7 @@ describe("Serialization", () => {
       const pubkey = fromHex("00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff");
 
       const tx: SendTransaction = {
-        domain: "rise",
+        domain: "bcp",
         kind: "send",
         chainId: riseTestnet,
         signer: {
@@ -109,7 +109,7 @@ describe("Serialization", () => {
       const pubkey = fromHex("00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff");
 
       const tx: SendTransaction = {
-        domain: "lisk",
+        domain: "bcp",
         kind: "send",
         chainId: liskTestnet as ChainId,
         signer: {
@@ -136,7 +136,7 @@ describe("Serialization", () => {
       const pubkey = fromHex("00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff");
 
       const tx: SendTransaction = {
-        domain: "lisk",
+        domain: "bcp",
         kind: "send",
         chainId: liskTestnet as ChainId,
         signer: {
@@ -169,7 +169,7 @@ describe("Serialization", () => {
           algo: Algorithm.Ed25519,
           data: pubkey as PublicKeyBytes,
         },
-        domain: "lisk",
+        domain: "bcp",
         kind: "send",
         amount: {
           quantity: "123456789",
@@ -194,7 +194,7 @@ describe("Serialization", () => {
           algo: Algorithm.Ed25519,
           data: pubkey as PublicKeyBytes,
         },
-        domain: "lisk",
+        domain: "bcp",
         kind: "send",
         amount: {
           quantity: "123456789",
@@ -220,7 +220,7 @@ describe("Serialization", () => {
           algo: Algorithm.Ed25519,
           data: pubkey as PublicKeyBytes,
         },
-        domain: "xnet",
+        domain: "bcp",
         kind: "send",
         amount: {
           quantity: "123456789",
@@ -251,7 +251,7 @@ describe("Serialization", () => {
           algo: Algorithm.Ed25519,
           data: pubkey as PublicKeyBytes,
         },
-        domain: "lisk",
+        domain: "bcp",
         kind: "send",
         amount: {
           quantity: "123456789",

--- a/packages/iov-ethereum/src/ethereumcodec.ts
+++ b/packages/iov-ethereum/src/ethereumcodec.ts
@@ -108,7 +108,7 @@ export const ethereumCodec: TxCodec = {
     switch (json.type) {
       case 0:
         unsignedTransaction = {
-          domain: "ethereum",
+          domain: "bcp",
           kind: "send",
           chainId: chainId,
           fee: {

--- a/packages/iov-ethereum/src/ethereumconnection.spec.ts
+++ b/packages/iov-ethereum/src/ethereumconnection.spec.ts
@@ -112,7 +112,7 @@ describe("EthereumConnection", () => {
       const recipientAddress = "0xE137f5264b6B528244E1643a2D570b37660B7F14" as Address;
 
       const sendTx: SendTransaction = {
-        domain: "ethereum",
+        domain: "bcp",
         kind: "send",
         chainId: nodeChainId,
         signer: mainIdentity.pubkey,
@@ -195,7 +195,7 @@ describe("EthereumConnection", () => {
       const recipientAddress = "0xE137f5264b6B528244E1643a2D570b37660B7F14" as Address;
 
       const sendTx: SendTransaction = {
-        domain: "ethereum",
+        domain: "bcp",
         kind: "send",
         chainId: nodeChainId,
         signer: mainIdentity.pubkey,

--- a/packages/iov-ethereum/src/parse.ts
+++ b/packages/iov-ethereum/src/parse.ts
@@ -28,7 +28,7 @@ export class Scraper {
     const signature = new Uint8Array([]) as SignatureBytes;
 
     const unsigned: SendTransaction = {
-      domain: "ethereum",
+      domain: "bcp",
       kind: "send",
       chainId: chainId,
       fee: {

--- a/packages/iov-ethereum/src/serialization.spec.ts
+++ b/packages/iov-ethereum/src/serialization.spec.ts
@@ -16,7 +16,7 @@ describe("Serialization", () => {
       );
 
       const tx: SendTransaction = {
-        domain: "ethereum",
+        domain: "bcp",
         kind: "send",
         chainId: TestConfig.chainId,
         signer: {
@@ -54,7 +54,7 @@ describe("Serialization", () => {
       );
 
       const tx: SendTransaction = {
-        domain: "ethereum",
+        domain: "bcp",
         kind: "send",
         chainId: TestConfig.chainId,
         signer: {

--- a/packages/iov-keycontrol/src/userprofile.spec.ts
+++ b/packages/iov-keycontrol/src/userprofile.spec.ts
@@ -429,7 +429,7 @@ describe("UserProfile", () => {
       pubkey: { algo: Algorithm.Ed25519, data: new Uint8Array([0xaa]) as PublicKeyBytes },
     };
     const fakeTransaction: SendTransaction = {
-      domain: "ethereum",
+      domain: "bcp",
       kind: "send",
       chainId: "ethereum" as ChainId,
       signer: fakeIdentity.pubkey,
@@ -508,7 +508,7 @@ describe("UserProfile", () => {
     const profile = new UserProfile({ createdAt, keyring });
 
     const fakeTransaction: SendTransaction = {
-      domain: "ethereum",
+      domain: "bcp",
       kind: "send",
       chainId: "ethereum" as ChainId,
       signer: mainIdentity.pubkey,

--- a/packages/iov-ledger-bns/src/app.spec.ts
+++ b/packages/iov-ledger-bns/src/app.spec.ts
@@ -107,7 +107,7 @@ describe("Sign with ledger app", () => {
     };
 
     const tx: SendTransaction = {
-      domain: "bns",
+      domain: "bcp",
       kind: "send",
       chainId: "test-bns-ledger" as ChainId,
       recipient: "tiov1qy352eufqy352eufqy352eufqy352eufpralqn" as Address,
@@ -153,7 +153,7 @@ describe("Sign with ledger app", () => {
     };
 
     const tx: SendTransaction = {
-      domain: "bns",
+      domain: "bcp",
       kind: "send",
       chainId: "test-ledger-paths" as ChainId,
       recipient: "tiov1zg62hngqqz4qqq8lluqqp2sqqqfrf27dzrrmea" as Address,

--- a/packages/iov-ledger-bns/src/ledgersimpleaddresswallet.spec.ts
+++ b/packages/iov-ledger-bns/src/ledgersimpleaddresswallet.spec.ts
@@ -201,7 +201,7 @@ describe("LedgerSimpleAddressWallet", () => {
     await wallet.canSign.waitFor(true);
 
     const tx: SendTransaction = {
-      domain: "bns",
+      domain: "bcp",
       kind: "send",
       chainId: "test-ledger-paths" as ChainId,
       recipient: "tiov1zg62hngqqz4qqq8lluqqp2sqqqfrf27dzrrmea" as Address,

--- a/packages/iov-lisk/src/liskcodec.spec.ts
+++ b/packages/iov-lisk/src/liskcodec.spec.ts
@@ -39,7 +39,7 @@ describe("liskCodec", () => {
     const pubkey = fromHex("00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff");
 
     const tx: SendTransaction = {
-      domain: "lisk",
+      domain: "bcp",
       kind: "send",
       chainId: liskTestnet,
       signer: {

--- a/packages/iov-lisk/src/liskcodec.ts
+++ b/packages/iov-lisk/src/liskcodec.ts
@@ -105,7 +105,7 @@ export const liskCodec: TxCodec = {
     switch (json.type) {
       case 0:
         unignedTransaction = {
-          domain: "lisk",
+          domain: "bcp",
           kind: "send",
           chainId: chainId,
           fee: {

--- a/packages/iov-lisk/src/liskconnection.spec.ts
+++ b/packages/iov-lisk/src/liskconnection.spec.ts
@@ -281,7 +281,7 @@ describe("LiskConnection", () => {
       const mainIdentity = await wallet.createIdentity(await devnetDefaultKeypair);
 
       const sendTx: SendTransaction = {
-        domain: "lisk",
+        domain: "bcp",
         kind: "send",
         chainId: devnetChainId,
         signer: mainIdentity.pubkey,
@@ -324,7 +324,7 @@ describe("LiskConnection", () => {
         const mainIdentity = await wallet.createIdentity(await devnetDefaultKeypair);
 
         const sendTx: SendTransaction = {
-          domain: "lisk",
+          domain: "bcp",
           kind: "send",
           chainId: devnetChainId,
           signer: mainIdentity.pubkey,
@@ -389,7 +389,7 @@ describe("LiskConnection", () => {
       const mainIdentity = await wallet.createIdentity(await devnetDefaultKeypair);
 
       const sendTx: SendTransaction = {
-        domain: "lisk",
+        domain: "bcp",
         kind: "send",
         chainId: devnetChainId,
         signer: mainIdentity.pubkey,
@@ -440,7 +440,7 @@ describe("LiskConnection", () => {
       const mainIdentity = await wallet.createIdentity(await devnetDefaultKeypair);
 
       const sendTx: SendTransaction = {
-        domain: "lisk",
+        domain: "bcp",
         kind: "send",
         chainId: devnetChainId,
         signer: mainIdentity.pubkey,

--- a/packages/iov-rise/src/risecodec.spec.ts
+++ b/packages/iov-rise/src/risecodec.spec.ts
@@ -39,7 +39,7 @@ describe("riseCodec", () => {
     const pubkey = fromHex("00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff");
 
     const tx: SendTransaction = {
-      domain: "rise",
+      domain: "bcp",
       kind: "send",
       chainId: riseTestnet,
       signer: {

--- a/packages/iov-rise/src/risecodec.ts
+++ b/packages/iov-rise/src/risecodec.ts
@@ -103,7 +103,7 @@ export const riseCodec: TxCodec = {
     switch (json.type) {
       case 0:
         unsignedTransaction = {
-          domain: "lisk",
+          domain: "bcp",
           kind: "send",
           chainId: chainId,
           fee: {

--- a/packages/iov-rise/src/riseconnection.spec.ts
+++ b/packages/iov-rise/src/riseconnection.spec.ts
@@ -259,7 +259,7 @@ describe("RiseConnection", () => {
       const mainIdentity = await wallet.createIdentity(await defaultKeypair);
 
       const sendTx: SendTransaction = {
-        domain: "rise",
+        domain: "bcp",
         kind: "send",
         chainId: riseTestnet,
         signer: mainIdentity.pubkey,
@@ -299,7 +299,7 @@ describe("RiseConnection", () => {
         const mainIdentity = await wallet.createIdentity(await defaultKeypair);
 
         const sendTx: SendTransaction = {
-          domain: "rise",
+          domain: "bcp",
           kind: "send",
           chainId: riseTestnet,
           signer: mainIdentity.pubkey,
@@ -361,7 +361,7 @@ describe("RiseConnection", () => {
       const mainIdentity = await wallet.createIdentity(await defaultKeypair);
 
       const sendTx: SendTransaction = {
-        domain: "rise",
+        domain: "bcp",
         kind: "send",
         chainId: riseTestnet,
         signer: mainIdentity.pubkey,


### PR DESCRIPTION
Demonstrate using some transactions that use a global domain (`bcp`) alongside blockchain-specific transaction extensions (`bns`).

Update SendTransaction usage:

- [x] Bns
- [x] Lisk
- [x] Rise
- [x] Ethereum