### PR TITLE
Generic signer profile interface

### DIFF
--- a/packages/iov-core/src/multichainsigner.ts
+++ b/packages/iov-core/src/multichainsigner.ts
@@ -60,8 +60,8 @@ and calculate chain-specific addresses from public keys,
 even if bcp-proxy will handle translating all reads.
 */
 export class MultiChainSigner {
-  public readonly profile: Profile;
   private readonly knownChains: Map<string, Chain>;
+  private readonly profile: Profile;
 
   // initialize a write with a userProfile with secret info,
   // chains we want to connect to added with addChain (to keep async out of constructor)

--- a/packages/iov-core/src/multichainsigner.ts
+++ b/packages/iov-core/src/multichainsigner.ts
@@ -3,12 +3,14 @@ import {
   BcpConnection,
   ChainConnector,
   ChainId,
+  Nonce,
   PostTxResponse,
   PublicKeyBundle,
+  SignedTransaction,
   TxCodec,
   UnsignedTransaction,
 } from "@iov/bcp-types";
-import { PublicIdentity, UserProfile, WalletId } from "@iov/keycontrol";
+import { PublicIdentity, WalletId } from "@iov/keycontrol";
 
 /**
  * An internal helper to pass around the tuple
@@ -28,6 +30,29 @@ async function connectChain(x: ChainConnector): Promise<Chain> {
   };
 }
 
+/**
+ * TransactionSigner is just the methods on `UserProfile` that we need in `MultiChainSigner`.
+ * By only requiring this interface, we allow the use of other implementations with custom
+ * logic for key derivation, etc.
+ */
+export interface Profile {
+  readonly signTransaction: (
+    id: WalletId,
+    identity: PublicIdentity,
+    transaction: UnsignedTransaction,
+    codec: TxCodec,
+    nonce: Nonce,
+  ) => Promise<SignedTransaction>;
+
+  readonly appendSignature: (
+    id: WalletId,
+    identity: PublicIdentity,
+    originalTransaction: SignedTransaction,
+    codec: TxCodec,
+    nonce: Nonce,
+  ) => Promise<SignedTransaction>;
+}
+
 /*
 MultiChainSigner handles all private key material, as well as connections to multiple chains.
 It must have a codec along with each chain to properly encode the transactions,
@@ -35,12 +60,12 @@ and calculate chain-specific addresses from public keys,
 even if bcp-proxy will handle translating all reads.
 */
 export class MultiChainSigner {
-  public readonly profile: UserProfile;
+  public readonly profile: Profile;
   private readonly knownChains: Map<string, Chain>;
 
   // initialize a write with a userProfile with secret info,
   // chains we want to connect to added with addChain (to keep async out of constructor)
-  constructor(profile: UserProfile) {
+  constructor(profile: Profile) {
     this.profile = profile;
     this.knownChains = new Map<string, Chain>();
   }

--- a/packages/iov-core/types/multichainsigner.d.ts
+++ b/packages/iov-core/types/multichainsigner.d.ts
@@ -1,9 +1,18 @@
-import { Address, BcpConnection, ChainConnector, ChainId, PostTxResponse, PublicKeyBundle, UnsignedTransaction } from "@iov/bcp-types";
-import { UserProfile, WalletId } from "@iov/keycontrol";
+import { Address, BcpConnection, ChainConnector, ChainId, Nonce, PostTxResponse, PublicKeyBundle, SignedTransaction, TxCodec, UnsignedTransaction } from "@iov/bcp-types";
+import { PublicIdentity, WalletId } from "@iov/keycontrol";
+/**
+ * TransactionSigner is just the methods on `UserProfile` that we need in `MultiChainSigner`.
+ * By only requiring this interface, we allow the use of other implementations with custom
+ * logic for key derivation, etc.
+ */
+export interface Profile {
+    readonly signTransaction: (id: WalletId, identity: PublicIdentity, transaction: UnsignedTransaction, codec: TxCodec, nonce: Nonce) => Promise<SignedTransaction>;
+    readonly appendSignature: (id: WalletId, identity: PublicIdentity, originalTransaction: SignedTransaction, codec: TxCodec, nonce: Nonce) => Promise<SignedTransaction>;
+}
 export declare class MultiChainSigner {
-    readonly profile: UserProfile;
+    readonly profile: Profile;
     private readonly knownChains;
-    constructor(profile: UserProfile);
+    constructor(profile: Profile);
     chainIds(): ReadonlyArray<ChainId>;
     connection(chainId: ChainId): BcpConnection;
     /**

--- a/packages/iov-core/types/multichainsigner.d.ts
+++ b/packages/iov-core/types/multichainsigner.d.ts
@@ -10,8 +10,8 @@ export interface Profile {
     readonly appendSignature: (id: WalletId, identity: PublicIdentity, originalTransaction: SignedTransaction, codec: TxCodec, nonce: Nonce) => Promise<SignedTransaction>;
 }
 export declare class MultiChainSigner {
-    readonly profile: Profile;
     private readonly knownChains;
+    private readonly profile;
     constructor(profile: Profile);
     chainIds(): ReadonlyArray<ChainId>;
     connection(chainId: ChainId): BcpConnection;


### PR DESCRIPTION
Allow us to plug in other KeyManagement solutions that extend the UserProfile with app-specific logic.

As discussed in https://github.com/iov-one/iov-core/issues/621#issuecomment-449076733