### PR TITLE
Make TypeScripts libs config explicit

### DIFF
--- a/packages/iov-core/tsconfig.json
+++ b/packages/iov-core/tsconfig.json
@@ -5,7 +5,6 @@
     "outDir": "build",
     "declarationDir": "build/types",
     "rootDir": "src",
-    "lib": ["es6"]
   },
   "include": [
     "src/**/*"

--- a/packages/iov-core/tsconfig.workers.json
+++ b/packages/iov-core/tsconfig.workers.json
@@ -4,8 +4,7 @@
     "baseUrl": ".",
     "outDir": "build",
     "declarationDir": "build/types",
-    "rootDir": "src",
-    "lib": ["es6"]
+    "rootDir": "src"
   },
   "include": [
     "src/workers/**/*"

--- a/packages/iov-encoding/src/encoding.ts
+++ b/packages/iov-encoding/src/encoding.ts
@@ -2,6 +2,12 @@ import * as base64js from "base64-js";
 import * as bech32 from "bech32";
 import { ReadonlyDate } from "readonly-date";
 
+// Global symbols in some environments
+// https://developer.mozilla.org/en-US/docs/Web/API/TextEncoder
+// https://developer.mozilla.org/en-US/docs/Web/API/TextDecoder
+declare const TextEncoder: any | undefined;
+declare const TextDecoder: any | undefined;
+
 export class Encoding {
   public static toHex(data: Uint8Array): string {
     let out: string = "";

--- a/packages/iov-jsonrpc/tsconfig.json
+++ b/packages/iov-jsonrpc/tsconfig.json
@@ -4,8 +4,7 @@
     "baseUrl": ".",
     "outDir": "build",
     "declarationDir": "build/types",
-    "rootDir": "src",
-    "lib": ["es6"]
+    "rootDir": "src"
   },
   "include": [
     "src/**/*"

--- a/packages/iov-jsonrpc/tsconfig.workers.json
+++ b/packages/iov-jsonrpc/tsconfig.workers.json
@@ -4,8 +4,7 @@
     "baseUrl": ".",
     "outDir": "build",
     "declarationDir": "build/types",
-    "rootDir": "src",
-    "lib": ["es6"]
+    "rootDir": "src"
   },
   "include": [
     "src/workers/**/*"

--- a/packages/iov-stream/src/defaultvalueproducer.spec.ts
+++ b/packages/iov-stream/src/defaultvalueproducer.spec.ts
@@ -3,7 +3,7 @@ import { Stream } from "xstream";
 import { DefaultValueProducer } from "./defaultvalueproducer";
 
 function oneTickLater(): Promise<void> {
-  return new Promise(resolve => setTimeout(resolve));
+  return new Promise(resolve => setTimeout(resolve, 0));
 }
 
 describe("DefaultValueProducer", () => {

--- a/packages/iov-stream/src/promise.spec.ts
+++ b/packages/iov-stream/src/promise.spec.ts
@@ -6,7 +6,7 @@ import { fromListPromise, toListPromise } from "./promise";
 import { asArray, countStream } from "./reducer";
 
 function oneTickLater(): Promise<void> {
-  return new Promise(resolve => setTimeout(resolve));
+  return new Promise(resolve => setTimeout(resolve, 0));
 }
 
 describe("promise", () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,7 @@
     "sourceMap": true,
     "strict": true,
     "target": "es6",
+    "lib": ["es6"],
     "typeRoots": [
       "./node_modules/@types",
       "./custom_types"


### PR DESCRIPTION
This changes the default `lib` value DOM,ES6,DOM.Iterable,ScriptHost to the explicit "es6". We don't have DOM available in all supported environments.

Closes #643