### PR TITLE
Implement buffering stream concat and use in BNS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   response parsers. This is used for out-of-process signing and can be reused
   in @iov/ethereum and @iov/tendermint-rpc later on.
 * @iov/keycontrol: Add `HdPaths.bip44Like` and `HdPaths.iov`
+* @iov/stream: Add an implementation of `concat` that buffers stream events
 
 Breaking changes
 

--- a/packages/iov-bns/src/bnsconnection.ts
+++ b/packages/iov-bns/src/bnsconnection.ts
@@ -40,7 +40,7 @@ import {
   TxReadCodec,
 } from "@iov/bcp-types";
 import { Encoding, Int53, Uint53 } from "@iov/encoding";
-import { concat, DefaultValueProducer, toListPromise, ValueAndUpdates } from "@iov/stream";
+import { concat, DefaultValueProducer, fromListPromise, toListPromise, ValueAndUpdates } from "@iov/stream";
 import {
   broadcastTxSyncSuccess,
   Client as TendermintClient,
@@ -467,61 +467,17 @@ export class BnsConnection implements BcpAtomicSwapConnection {
    * and then continuing with live feeds
    */
   public liveTx(txQuery: BcpTxQuery): Stream<ConfirmedTransaction> {
-    let updatesSubscription: Subscription | undefined;
+    const historyStream = fromListPromise(this.searchTx(txQuery));
+    const updatesStream = this.listenTx(txQuery);
+    const combinedStream = concat(historyStream, updatesStream);
 
-    const producer: Producer<ConfirmedTransaction> = {
-      start: listener => {
-        // called as soon as anyone subscribes to the stream
+    // remove duplicates
+    const alreadySent = new Set<TransactionId>();
+    const deduplicatedStream = combinedStream
+      .filter(ct => !alreadySent.has(ct.transactionId))
+      .debug(ct => alreadySent.add(ct.transactionId));
 
-        // 1. subscribe to updates before queying history to ensure we don't miss something; store updates in queue
-        // 2. when history is there, send history and process queue
-        // 3. skip queue and send updates directly
-
-        let doneSendingHistory = false;
-        const queue = new Array<ConfirmedTransaction>();
-
-        updatesSubscription = this.listenTx(txQuery).subscribe({
-          next: value => {
-            if (doneSendingHistory) {
-              listener.next(value);
-            } else {
-              queue.push(value);
-            }
-          },
-          error: error => listener.error(error),
-        });
-
-        this.searchTx(txQuery)
-          .then(history => {
-            for (const transaction of history) {
-              listener.next(transaction);
-            }
-
-            const historyIds = history.map(transaction => transaction.transactionId);
-
-            let element: ConfirmedTransaction | undefined;
-            // tslint:disable-next-line:no-conditional-assignment
-            while ((element = queue.shift())) {
-              const elementId = element.transactionId;
-              if (historyIds.indexOf(elementId) !== -1) {
-                // only do this for elements not already sent
-                listener.next(element);
-              }
-            }
-
-            doneSendingHistory = true;
-          })
-          .catch(error => listener.error(error));
-      },
-      stop: () => {
-        if (!updatesSubscription) {
-          throw new Error("stop() was clled before start(). This is not expected to happen.");
-        }
-        updatesSubscription.unsubscribe();
-      },
-    };
-
-    return Stream.create(producer);
+    return deduplicatedStream;
   }
 
   /**

--- a/packages/iov-bns/src/bnsconnection.ts
+++ b/packages/iov-bns/src/bnsconnection.ts
@@ -40,7 +40,7 @@ import {
   TxReadCodec,
 } from "@iov/bcp-types";
 import { Encoding, Int53, Uint53 } from "@iov/encoding";
-import { DefaultValueProducer, toListPromise, ValueAndUpdates } from "@iov/stream";
+import { concat, DefaultValueProducer, toListPromise, ValueAndUpdates } from "@iov/stream";
 import {
   broadcastTxSyncSuccess,
   Client as TendermintClient,
@@ -638,7 +638,7 @@ export class BnsConnection implements BcpAtomicSwapConnection {
       return acct.data.length < 1 ? undefined : acct.data[0];
     };
 
-    return Stream.merge(
+    return concat(
       Stream.fromPromise(oneAccount()),
       this.changeBalance(account.address)
         .map(() => Stream.fromPromise(oneAccount()))
@@ -659,7 +659,7 @@ export class BnsConnection implements BcpAtomicSwapConnection {
       .map(() => Stream.fromPromise(this.getNonce(query)))
       .flatten();
 
-    return Stream.merge(currentStream, updatesStream);
+    return concat(currentStream, updatesStream);
   }
 
   public async getBlockchains(query: BnsBlockchainsQuery): Promise<ReadonlyArray<BnsBlockchainNft>> {

--- a/packages/iov-stream/src/concat.spec.ts
+++ b/packages/iov-stream/src/concat.spec.ts
@@ -156,9 +156,9 @@ describe("concat", () => {
 
     let producerInterval: NodeJS.Timeout;
     let producerValue = 0;
-    const loggingProducer: Producer<number> = {
+    const loggingProducer: Producer<string> = {
       start: listener => {
-        producerInterval = setInterval(() => listener.next(producerValue++), 25);
+        producerInterval = setInterval(() => listener.next(`event${producerValue++}`), 25);
         producerActiveLog.push(true);
       },
       stop: () => {
@@ -169,7 +169,7 @@ describe("concat", () => {
 
     const stream1 = Stream.create(loggingProducer);
     const concatenatedStream = concat(stream1);
-    const expected = [0, 1, 2, 3, 4, 5];
+    const expected = ["event0", "event1", "event2", "event3", "event4", "event5"];
 
     expect(producerActiveLog).toEqual([]);
 

--- a/packages/iov-stream/src/concat.spec.ts
+++ b/packages/iov-stream/src/concat.spec.ts
@@ -86,22 +86,6 @@ describe("concat", () => {
     });
   });
 
-  it("changes output order when order of streams switch", done => {
-    const stream1 = Stream.of("1", "2", "3");
-    const stream2 = Stream.of("a", "b", "c");
-    const concatenatedStream = concat(stream2, stream1);
-    const expected = ["a", "b", "c", "1", "2", "3"];
-
-    concatenatedStream.addListener({
-      next: value => expect(value).toEqual(expected.shift()!),
-      complete: () => {
-        expect(expected.length).toEqual(0);
-        done();
-      },
-      error: done.fail,
-    });
-  });
-
   it("should concat two asynchronous short streams together", done => {
     const stream1 = Stream.periodic(25).take(3);
     const stream2 = Stream.periodic(50).take(2);

--- a/packages/iov-stream/src/concat.spec.ts
+++ b/packages/iov-stream/src/concat.spec.ts
@@ -4,7 +4,7 @@ import { Producer, Stream } from "xstream";
 import { concat } from "./concat";
 
 function producerIsStopped(): Promise<void> {
-  return new Promise(resolve => setTimeout(resolve, 5));
+  return new Promise(resolve => setTimeout(resolve, 50));
 }
 
 describe("concat", () => {
@@ -136,13 +136,16 @@ describe("concat", () => {
   });
 
   it("unsubscribes and re-subscribes from source streams", done => {
+    // For browsers and CI, clocks and runtimes are very unreliable.
+    // Especialls Mac+Firefox on Travis is makes big trouble. Thus we need huge intervals.
+    const intervalDuration = 1000;
     const producerActiveLog = new Array<boolean>();
 
     let producerInterval: NodeJS.Timeout;
     let producerValue = 0;
     const loggingProducer: Producer<string> = {
       start: listener => {
-        producerInterval = setInterval(() => listener.next(`event${producerValue++}`), 25);
+        producerInterval = setInterval(() => listener.next(`event${producerValue++}`), intervalDuration);
         producerActiveLog.push(true);
       },
       stop: () => {
@@ -171,7 +174,7 @@ describe("concat", () => {
       subscription.unsubscribe();
       await producerIsStopped();
       expect(producerActiveLog).toEqual([true, false]);
-    }, 90);
+    }, 3.75 * intervalDuration);
 
     // re-subscribe
     setTimeout(() => {
@@ -194,7 +197,7 @@ describe("concat", () => {
 
         expect(expected.length).toEqual(0);
         done();
-      }, 90);
-    }, 200);
+      }, 3.75 * intervalDuration);
+    }, 6 * intervalDuration);
   });
 });

--- a/packages/iov-stream/src/concat.spec.ts
+++ b/packages/iov-stream/src/concat.spec.ts
@@ -3,7 +3,7 @@ import { Producer, Stream } from "xstream";
 
 import { concat } from "./concat";
 
-function waitForUnsubscription(): Promise<void> {
+function producerIsStopped(): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, 5));
 }
 
@@ -185,7 +185,7 @@ describe("concat", () => {
     setTimeout(async () => {
       expect(producerActiveLog).toEqual([true]);
       subscription.unsubscribe();
-      await waitForUnsubscription();
+      await producerIsStopped();
       expect(producerActiveLog).toEqual([true, false]);
     }, 90);
 
@@ -205,7 +205,7 @@ describe("concat", () => {
       setTimeout(async () => {
         expect(producerActiveLog).toEqual([true, false, true]);
         subscription2.unsubscribe();
-        await waitForUnsubscription();
+        await producerIsStopped();
         expect(producerActiveLog).toEqual([true, false, true, false]);
 
         expect(expected.length).toEqual(0);

--- a/packages/iov-stream/src/concat.spec.ts
+++ b/packages/iov-stream/src/concat.spec.ts
@@ -1,0 +1,216 @@
+// tslint:disable:readonly-array no-submodule-imports
+import { Producer, Stream } from "xstream";
+
+import { concat } from "./concat";
+
+function waitForUnsubscription(): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, 5));
+}
+
+describe("concat", () => {
+  it("can concat 0 streams", done => {
+    const concatenatedStream = concat();
+    const expected: string[] = [];
+
+    concatenatedStream.addListener({
+      next: value => expect(value).toEqual(expected.shift()!),
+      complete: () => {
+        expect(expected.length).toEqual(0);
+        done();
+      },
+      error: done.fail,
+    });
+  });
+
+  it("can concat 1 streams", done => {
+    const stream1 = Stream.of("1", "2", "3");
+    const concatenatedStream = concat(stream1);
+    const expected = ["1", "2", "3"];
+
+    concatenatedStream.addListener({
+      next: value => expect(value).toEqual(expected.shift()!),
+      complete: () => {
+        expect(expected.length).toEqual(0);
+        done();
+      },
+      error: done.fail,
+    });
+  });
+
+  it("can concat 2 streams", done => {
+    const stream1 = Stream.of("1", "2", "3");
+    const stream2 = Stream.of("a", "b", "c");
+    const concatenatedStream = concat(stream1, stream2);
+    const expected = ["1", "2", "3", "a", "b", "c"];
+
+    concatenatedStream.addListener({
+      next: value => expect(value).toEqual(expected.shift()!),
+      complete: () => {
+        expect(expected.length).toEqual(0);
+        done();
+      },
+      error: done.fail,
+    });
+  });
+
+  it("can concat 3 streams", done => {
+    const stream1 = Stream.of("1", "2", "3");
+    const stream2 = Stream.of("a", "b", "c");
+    const stream3 = Stream.of("X", "Y", "Z");
+    const concatenatedStream = concat(stream1, stream2, stream3);
+    const expected = ["1", "2", "3", "a", "b", "c", "X", "Y", "Z"];
+
+    concatenatedStream.addListener({
+      next: value => expect(value).toEqual(expected.shift()!),
+      complete: () => {
+        expect(expected.length).toEqual(0);
+        done();
+      },
+      error: done.fail,
+    });
+  });
+
+  it("changes output order when order of streams switch", done => {
+    const stream1 = Stream.of("1", "2", "3");
+    const stream2 = Stream.of("a", "b", "c");
+    const concatenatedStream = concat(stream2, stream1);
+    const expected = ["a", "b", "c", "1", "2", "3"];
+
+    concatenatedStream.addListener({
+      next: value => expect(value).toEqual(expected.shift()!),
+      complete: () => {
+        expect(expected.length).toEqual(0);
+        done();
+      },
+      error: done.fail,
+    });
+  });
+
+  it("changes output order when order of streams switch", done => {
+    const stream1 = Stream.of("1", "2", "3");
+    const stream2 = Stream.of("a", "b", "c");
+    const concatenatedStream = concat(stream2, stream1);
+    const expected = ["a", "b", "c", "1", "2", "3"];
+
+    concatenatedStream.addListener({
+      next: value => expect(value).toEqual(expected.shift()!),
+      complete: () => {
+        expect(expected.length).toEqual(0);
+        done();
+      },
+      error: done.fail,
+    });
+  });
+
+  it("should concat two asynchronous short streams together", done => {
+    const stream1 = Stream.periodic(25).take(3);
+    const stream2 = Stream.periodic(50).take(2);
+    const concatenatedStream = concat(stream1, stream2);
+    const expected = [0, 1, 2, 0, 1];
+
+    concatenatedStream.addListener({
+      next: value => expect(value).toEqual(expected.shift()!),
+      complete: () => {
+        expect(expected.length).toEqual(0);
+        done();
+      },
+      error: done.fail,
+    });
+  });
+
+  it("should append a synchronous stream after an asynchronous stream", done => {
+    const stream1 = Stream.periodic(25).take(3);
+    const stream2 = Stream.of(30, 40, 50, 60);
+    const concatenatedStream = concat(stream1, stream2);
+    const expected = [0, 1, 2, 30, 40, 50, 60];
+
+    concatenatedStream.addListener({
+      next: value => expect(value).toEqual(expected.shift()!),
+      complete: () => {
+        expect(expected.length).toEqual(0);
+        done();
+      },
+      error: done.fail,
+    });
+  });
+
+  it("buffers asynchonous events of second stream until first stream completes", done => {
+    const sourceStream = Stream.periodic(25);
+    const stream1 = sourceStream.take(3);
+    const stream2 = sourceStream.take(3);
+    const concatenatedStream = concat(stream1, stream2);
+    const expected = [0, 1, 2, 0, 1, 2];
+
+    concatenatedStream.addListener({
+      next: value => expect(value).toEqual(expected.shift()!),
+      complete: () => {
+        expect(expected.length).toEqual(0);
+        done();
+      },
+      error: done.fail,
+    });
+  });
+
+  it("unsubscribes and re-subscribes from source streams", done => {
+    const producerActiveLog = new Array<boolean>();
+
+    let producerInterval: NodeJS.Timeout;
+    let producerValue = 0;
+    const loggingProducer: Producer<number> = {
+      start: listener => {
+        producerInterval = setInterval(() => listener.next(producerValue++), 25);
+        producerActiveLog.push(true);
+      },
+      stop: () => {
+        clearInterval(producerInterval);
+        producerActiveLog.push(false);
+      },
+    };
+
+    const stream1 = Stream.create(loggingProducer);
+    const concatenatedStream = concat(stream1);
+    const expected = [0, 1, 2, 3, 4, 5];
+
+    expect(producerActiveLog).toEqual([]);
+
+    const subscription = concatenatedStream.subscribe({
+      next: value => expect(value).toEqual(expected.shift()!),
+      complete: () => done.fail(),
+      error: done.fail,
+    });
+
+    expect(producerActiveLog).toEqual([true]);
+
+    // unsubscribe
+    setTimeout(async () => {
+      expect(producerActiveLog).toEqual([true]);
+      subscription.unsubscribe();
+      await waitForUnsubscription();
+      expect(producerActiveLog).toEqual([true, false]);
+    }, 90);
+
+    // re-subscribe
+    setTimeout(() => {
+      expect(producerActiveLog).toEqual([true, false]);
+
+      const subscription2 = concatenatedStream.subscribe({
+        next: value => expect(value).toEqual(expected.shift()!),
+        complete: () => done.fail(),
+        error: done.fail,
+      });
+
+      expect(producerActiveLog).toEqual([true, false, true]);
+
+      // unsubscribe again
+      setTimeout(async () => {
+        expect(producerActiveLog).toEqual([true, false, true]);
+        subscription2.unsubscribe();
+        await waitForUnsubscription();
+        expect(producerActiveLog).toEqual([true, false, true, false]);
+
+        expect(expected.length).toEqual(0);
+        done();
+      }, 90);
+    }, 200);
+  });
+});

--- a/packages/iov-stream/src/concat.ts
+++ b/packages/iov-stream/src/concat.ts
@@ -1,0 +1,102 @@
+// tslint:disable:readonly-array
+import { Producer, Stream, Subscription } from "xstream";
+
+/**
+ * An implementation of concat that buffers all source stream events
+ *
+ * Marble diagram:
+ *
+ * ```text
+ * --1--2---3---4-|
+ * -a--b-c--d-|
+ * --------X---------Y---------Z-
+ *           concat
+ * --1--2---3---4-abcdXY-------Z-
+ * ```
+ *
+ * This is inspired by RxJS's concat as documented at http://rxmarbles.com/#concat and behaves
+ * differently than xstream's concat as discussed in https://github.com/staltz/xstream/issues/170.
+ *
+ */
+export function concat<T>(...streams: Array<Stream<T>>): Stream<T> {
+  const subscriptions = new Array<Subscription>();
+  const queues = new Array<T[]>(); // one queue per stream
+  const completedStreams = new Set<number>();
+  let activeStreamIndex = 0;
+
+  function reset(): void {
+    while (subscriptions.length > 0) {
+      const subscription = subscriptions.shift()!;
+      subscription.unsubscribe();
+    }
+
+    // tslint:disable-next-line:no-object-mutation
+    queues.length = 0;
+    completedStreams.clear();
+    activeStreamIndex = 0;
+  }
+
+  const producer: Producer<T> = {
+    start: listener => {
+      streams.forEach(_ => queues.push([]));
+
+      function emitAllQueuesEvents(streamIndex: number): void {
+        while (true) {
+          const element = queues[streamIndex].shift();
+          if (element === undefined) {
+            return;
+          }
+          listener.next(element);
+        }
+      }
+
+      function isDone(): boolean {
+        return activeStreamIndex >= streams.length;
+      }
+
+      if (isDone()) {
+        listener.complete();
+        return;
+      }
+
+      streams.forEach((stream, index) => {
+        subscriptions.push(
+          stream.subscribe({
+            next: value => {
+              if (index === activeStreamIndex) {
+                listener.next(value);
+              } else {
+                queues[index].push(value);
+              }
+            },
+            complete: () => {
+              completedStreams.add(index);
+
+              while (completedStreams.has(activeStreamIndex)) {
+                // this stream completed: emit all and move on
+                emitAllQueuesEvents(activeStreamIndex);
+                activeStreamIndex++;
+              }
+
+              if (isDone()) {
+                listener.complete();
+              } else {
+                // now active stream can have some events queued but did not yet complete
+                emitAllQueuesEvents(activeStreamIndex);
+              }
+            },
+            error: error => {
+              listener.error(error);
+              reset();
+            },
+          }),
+        );
+      });
+    },
+    stop: () => {
+      reset();
+    },
+  };
+
+  return Stream.create(producer);
+}

--- a/packages/iov-stream/src/index.ts
+++ b/packages/iov-stream/src/index.ts
@@ -1,4 +1,5 @@
 export { DefaultValueProducer, DefaultValueProducerCallsbacks } from "./defaultvalueproducer";
+export { concat } from "./concat";
 export { fromListPromise, toListPromise } from "./promise";
 export * from "./reducer";
 export { ValueAndUpdates } from "./valueandupdates";

--- a/packages/iov-stream/types/concat.d.ts
+++ b/packages/iov-stream/types/concat.d.ts
@@ -1,0 +1,19 @@
+import { Stream } from "xstream";
+/**
+ * An implementation of concat that buffers all source stream events
+ *
+ * Marble diagram:
+ *
+ * ```text
+ * --1--2---3---4-|
+ * -a--b-c--d-|
+ * --------X---------Y---------Z-
+ *           concat
+ * --1--2---3---4-abcdXY-------Z-
+ * ```
+ *
+ * This is inspired by RxJS's concat as documented at http://rxmarbles.com/#concat and behaves
+ * differently than xstream's concat as discussed in https://github.com/staltz/xstream/issues/170.
+ *
+ */
+export declare function concat<T>(...streams: Array<Stream<T>>): Stream<T>;

--- a/packages/iov-stream/types/index.d.ts
+++ b/packages/iov-stream/types/index.d.ts
@@ -1,4 +1,5 @@
 export { DefaultValueProducer, DefaultValueProducerCallsbacks } from "./defaultvalueproducer";
+export { concat } from "./concat";
 export { fromListPromise, toListPromise } from "./promise";
 export * from "./reducer";
 export { ValueAndUpdates } from "./valueandupdates";


### PR DESCRIPTION
This splits the logic of liveTx() into

1. Stream concatenation
2. Event deduplication

where 1. is implemented in a reusable fashion as `concat` in @iov/stream.

The last commit (https://github.com/iov-one/iov-core/pull/664/commits/0d14198a30751f609b83518d5c9b3ce5f9832780) is not strictly related to the PR topic but something I found by failing tests while working on the rest.