### PR TITLE
Make watchAccount independent of scraper

### DIFF
--- a/packages/iov-ethereum/package.json
+++ b/packages/iov-ethereum/package.json
@@ -39,6 +39,7 @@
     "@types/long": "^4.0.0",
     "axios": "^0.18.0",
     "bn.js": "^4.11.8",
+    "fast-deep-equal": "^2.0.1",
     "long": "^4.0.0",
     "readonly-date": "^1.0.0",
     "rlp": "^2.2.1",

--- a/packages/iov-ethereum/src/ethereumconnection.spec.ts
+++ b/packages/iov-ethereum/src/ethereumconnection.spec.ts
@@ -338,12 +338,9 @@ describe("EthereumConnection", () => {
   describe("watchAccount", () => {
     it("can watch an account", done => {
       pendingWithoutEthereum();
-      pendingWithoutEthereumScraper();
 
       (async () => {
-        const connection = await EthereumConnection.establish(testConfig.base, {
-          scraperApiUrl: testConfig.scraper!.apiUrl,
-        });
+        const connection = await EthereumConnection.establish(testConfig.base);
 
         const recipient = await randomAddress();
 


### PR DESCRIPTION
this also allows us running the watchAccount locally and in the CI.

Closes #690