### PR TITLE
Avoid extra query in block header events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ Breaking changes
 * @iov/bcp-types: Convert `BcpQueryEnvelope` to `BcpTicker | undefined` in return
   type of `BcpConnection.getTicker`.
 * @iov/bns: Convert `.owner` in `BnsUsernameNft` and `BnsBlockchainNft` to `Address`
+* @iov/bns: In `BncConnection.watchBlockHeaders`, the block header events
+  temporarily contain a dummy `id` string until ID calculation is implemented
 * @iov/core: Remove `MultiChainSigner.getNonce`. If you really need this, use
   `signer.connection(chainId).getNonce({ address: addr })` instead.
 * @iov/core: Removed BNS re-exports `bnsConnector`, `bnsFromOrToTag`,


### PR DESCRIPTION
This was creating some annoying race condition test fails in the wallet:

The execution order is:
- header `n` is produced
- missing information of header `n` is requested
- full BlockHeader `n` event arrives in test code
- test code unsubscribes
- test code disconnects
- socket is disconnected
- header `n + 1` is produced
- missing information of header `n + 1`  is requested
- Boooom! Trying to send on disconnected WebSocket