### PR TITLE
Assert 8 fractional digits in dpos serialization

### DIFF
--- a/packages/iov-dpos/src/serialization.spec.ts
+++ b/packages/iov-dpos/src/serialization.spec.ts
@@ -143,6 +143,29 @@ describe("Serialization", () => {
       );
     });
 
+    it("throws error is fractionalDigits are not correct", () => {
+      const pubkey = fromHex("00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff");
+      const tx: SendTransaction = {
+        kind: "bcp/send",
+        creator: {
+          chainId: riseTestnet,
+          pubkey: {
+            algo: Algorithm.Ed25519,
+            data: pubkey as PublicKeyBytes,
+          },
+        },
+        amount: {
+          quantity: "123456789",
+          fractionalDigits: 9,
+          tokenTicker: "RISE" as TokenTicker,
+        },
+        recipient: "10010344879730196491R" as Address,
+      };
+      expect(() =>
+        serializeTransaction(tx, defaultCreationDate, riseTransactionSerializationOptions),
+      ).toThrowError(/Requires 8/);
+    });
+
     it("can serialize Lisk transaction of type 0 with memo", () => {
       const pubkey = fromHex("00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff");
 

--- a/packages/iov-dpos/src/serialization.ts
+++ b/packages/iov-dpos/src/serialization.ts
@@ -46,6 +46,12 @@ export class Serialization {
         (timestamp >> 16) & 0xff,
         (timestamp >> 24) & 0xff,
       ]);
+      // assert that there are 8 fractionalDigits so this makes sense
+      if (unsigned.amount.fractionalDigits !== 8) {
+        throw new Error(
+          `Requires 8 fractional digits on Amount, received ${unsigned.amount.fractionalDigits}`,
+        );
+      }
       const amount = Uint64.fromString(unsigned.amount.quantity);
       const fullRecipientString = unsigned.recipient;
 

--- a/packages/iov-lisk/src/liskcodec.spec.ts
+++ b/packages/iov-lisk/src/liskcodec.spec.ts
@@ -36,6 +36,51 @@ describe("liskCodec", () => {
     expect(liskCodec.identityToAddress(identity)).toEqual("6076671634347365051L");
   });
 
+  it("can create bytes to sign", () => {
+    const pubkey = fromHex("00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff");
+
+    const tx: SendTransaction = {
+      kind: "bcp/send",
+      creator: {
+        chainId: liskTestnet,
+        pubkey: {
+          algo: Algorithm.Ed25519,
+          data: pubkey as PublicKeyBytes,
+        },
+      },
+      amount: {
+        quantity: "123456789",
+        fractionalDigits: 8,
+        tokenTicker: "LSK" as TokenTicker,
+      },
+      recipient: "10010344879730196491L" as Address,
+    };
+    const bytes = liskCodec.bytesToSign(tx, defaultCreationTimestamp as Nonce);
+    expect(bytes).toBeTruthy();
+  });
+
+  it("requires 8 fractional digits in bytes to sign", () => {
+    const pubkey = fromHex("00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff");
+
+    const tx: SendTransaction = {
+      kind: "bcp/send",
+      creator: {
+        chainId: liskTestnet,
+        pubkey: {
+          algo: Algorithm.Ed25519,
+          data: pubkey as PublicKeyBytes,
+        },
+      },
+      amount: {
+        quantity: "123456789",
+        fractionalDigits: 7,
+        tokenTicker: "LSK" as TokenTicker,
+      },
+      recipient: "10010344879730196491L" as Address,
+    };
+    expect(() => liskCodec.bytesToSign(tx, defaultCreationTimestamp as Nonce)).toThrowError(/Requires 8/);
+  });
+
   it("can create bytes to post", () => {
     const pubkey = fromHex("00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff");
 

--- a/packages/iov-rise/src/risecodec.spec.ts
+++ b/packages/iov-rise/src/risecodec.spec.ts
@@ -36,6 +36,51 @@ describe("riseCodec", () => {
     expect(riseCodec.identityToAddress(identity)).toEqual("10145108642177909005R");
   });
 
+  it("can create bytes to sign", () => {
+    const pubkey = fromHex("00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff");
+
+    const tx: SendTransaction = {
+      kind: "bcp/send",
+      creator: {
+        chainId: riseTestnet,
+        pubkey: {
+          algo: Algorithm.Ed25519,
+          data: pubkey as PublicKeyBytes,
+        },
+      },
+      amount: {
+        quantity: "123456789",
+        fractionalDigits: 8,
+        tokenTicker: "RISE" as TokenTicker,
+      },
+      recipient: "10010344879730196491R" as Address,
+    };
+    const bytes = riseCodec.bytesToSign(tx, defaultCreationTimestamp as Nonce);
+    expect(bytes).toBeTruthy();
+  });
+
+  it("requires 8 fractional digits in bytes to sign", () => {
+    const pubkey = fromHex("00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff");
+
+    const tx: SendTransaction = {
+      kind: "bcp/send",
+      creator: {
+        chainId: riseTestnet,
+        pubkey: {
+          algo: Algorithm.Ed25519,
+          data: pubkey as PublicKeyBytes,
+        },
+      },
+      amount: {
+        quantity: "123456789",
+        fractionalDigits: 6,
+        tokenTicker: "RISE" as TokenTicker,
+      },
+      recipient: "10010344879730196491R" as Address,
+    };
+    expect(() => riseCodec.bytesToSign(tx, defaultCreationTimestamp as Nonce)).toThrowError(/Requires 8/);
+  });
+
   it("can create bytes to post", () => {
     const pubkey = fromHex("00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff");
 


### PR DESCRIPTION
Closes #723 

Also addresses the same issue in Rise