### PR TITLE
Kill "bnsd-app" "bnsd-tendermint" together

### DIFF
--- a/scripts/bnsd/stop.sh
+++ b/scripts/bnsd/stop.sh
@@ -2,7 +2,5 @@
 set -o errexit -o nounset -o pipefail
 command -v shellcheck > /dev/null && shellcheck "$0"
 
-for NAME in "bnsd-app" "bnsd-tendermint"; do
-  echo "Killing container named '$NAME' ..."
-  docker container kill "$NAME"
-done
+echo "Killing BNSd containers ..."
+docker container kill "bnsd-app" "bnsd-tendermint"


### PR DESCRIPTION
to avoid error:

```
Killing container named 'bnsd-app' ...
bnsd-app
Killing container named 'bnsd-tendermint' ...
Error response from daemon: Cannot kill container: bnsd-tendermint:
Container
8eb0c47fc27435c22adc7e65539e5f36e9d9d046779d47d4359adfd87f1da6ac is not
running
```