### PR TITLE
Create ReadonlyWallet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ Breaking changes
 * @iov/ethereum: The `options` parameter of `ethereumConnector` does not allow
   strings anymore. Use `{ wsUrl: myWebsocketUrl }` instead.
 * @iov/keycontrol: Remove `HdPaths.metamaskHdKeyTree`. Use `HdPaths.ethereum` instead.
+* @iov/keycontrol: `Keyring.getWallet` and `Keyring.getWallets` return the
+  immutable type ReadonlyWallet now. New functions to mutate wallets are added:
+  `Keyring.setWalletLabel`, `.createIdentity`, `.setIdentityLabel` are added.
 * @iov/ledger-bns: Package removed from this monorepo and now available at
   https://github.com/iov-one/iov-ledger-bns
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Breaking changes
 * @iov/keycontrol: `Keyring.getWallet` and `Keyring.getWallets` return the
   immutable type ReadonlyWallet now. New functions to mutate wallets are added:
   `Keyring.setWalletLabel`, `.createIdentity`, `.setIdentityLabel` are added.
+* @iov/keycontrol: Let `Keyring.addWallet` return a `WalletInfo` object
 * @iov/ledger-bns: Package removed from this monorepo and now available at
   https://github.com/iov-one/iov-ledger-bns
 

--- a/packages/iov-keycontrol/src/index.ts
+++ b/packages/iov-keycontrol/src/index.ts
@@ -1,5 +1,5 @@
 export { HdPaths } from "./hdpaths";
-export { Keyring } from "./keyring";
-export { UserProfile, WalletInfo } from "./userprofile";
+export { Keyring, WalletInfo } from "./keyring";
+export { UserProfile } from "./userprofile";
 export { Wallet, WalletId, WalletImplementationIdString, WalletSerializationString } from "./wallet";
 export { Ed25519HdWallet, Ed25519Wallet, Secp256k1HdWallet } from "./wallets";

--- a/packages/iov-keycontrol/src/keyring.ts
+++ b/packages/iov-keycontrol/src/keyring.ts
@@ -14,6 +14,14 @@ import { Ed25519HdWallet, Ed25519Wallet, Secp256k1HdWallet } from "./wallets";
 
 export type KeyringSerializationString = string & As<"keyring-serialization">;
 
+/**
+ * Read-only information about one wallet in a keyring
+ */
+export interface WalletInfo {
+  readonly id: WalletId;
+  readonly label: string | undefined;
+}
+
 interface WalletSerialization {
   readonly implementationId: WalletImplementationIdString;
   readonly data: WalletSerializationString;
@@ -91,8 +99,12 @@ export class Keyring {
     }
   }
 
-  public add(wallet: Wallet): void {
+  public add(wallet: Wallet): WalletInfo {
     this.wallets.push(wallet);
+    return {
+      id: wallet.id,
+      label: wallet.label.value,
+    };
   }
 
   /**

--- a/packages/iov-keycontrol/src/keyring.ts
+++ b/packages/iov-keycontrol/src/keyring.ts
@@ -1,5 +1,8 @@
 import { As } from "type-tagger";
 
+import { ChainId, PublicIdentity } from "@iov/bcp";
+import { Ed25519Keypair, Slip10RawIndex } from "@iov/crypto";
+
 import { Wallet, WalletId, WalletImplementationIdString, WalletSerializationString } from "./wallet";
 import { Ed25519HdWallet, Ed25519Wallet, Secp256k1HdWallet } from "./wallets";
 
@@ -102,6 +105,42 @@ export class Keyring {
    */
   public getWallet(id: WalletId): Wallet | undefined {
     return this.wallets.find(wallet => wallet.id === id);
+  }
+
+  /** Sets the label of the wallet with the given ID in the primary keyring  */
+  public setWalletLabel(walletId: WalletId, label: string | undefined): void {
+    const wallet = this.getWallet(walletId);
+    if (!wallet) {
+      throw new Error(`Wallet of id '${walletId}' does not exist in keyring`);
+    }
+    wallet.setLabel(label);
+  }
+
+  /**
+   * Creates an identitiy in the wallet with the given ID in the primary keyring
+   *
+   * The identity is bound to one chain ID to encourage using different
+   * keypairs on different chains.
+   */
+  public async createIdentity(
+    walletId: WalletId,
+    chainId: ChainId,
+    options: Ed25519Keypair | ReadonlyArray<Slip10RawIndex> | number,
+  ): Promise<PublicIdentity> {
+    const wallet = this.getWallet(walletId);
+    if (!wallet) {
+      throw new Error(`Wallet of id '${walletId}' does not exist in keyring`);
+    }
+    return wallet.createIdentity(chainId, options);
+  }
+
+  /** Assigns a label to one of the identities in the wallet with the given ID in the primary keyring */
+  public setIdentityLabel(walletId: WalletId, identity: PublicIdentity, label: string | undefined): void {
+    const wallet = this.getWallet(walletId);
+    if (!wallet) {
+      throw new Error(`Wallet of id '${walletId}' does not exist in keyring`);
+    }
+    wallet.setIdentityLabel(identity, label);
   }
 
   // serialize will produce a representation that can be writen to disk.

--- a/packages/iov-keycontrol/src/userprofile.spec.ts
+++ b/packages/iov-keycontrol/src/userprofile.spec.ts
@@ -552,7 +552,7 @@ describe("UserProfile", () => {
       "melt wisdom mesh wash item catalog talk enjoy gaze hat brush wash",
     );
     keyring.add(wallet);
-    const mainIdentity = await keyring.getWallets()[0].createIdentity(defaultChain, HdPaths.simpleAddress(0));
+    const mainIdentity = await keyring.createIdentity(wallet.id, defaultChain, HdPaths.simpleAddress(0));
     const profile = new UserProfile({ createdAt, keyring });
 
     const fakeTransaction: SendTransaction = {

--- a/packages/iov-keycontrol/src/userprofile.spec.ts
+++ b/packages/iov-keycontrol/src/userprofile.spec.ts
@@ -548,10 +548,9 @@ describe("UserProfile", () => {
   it("can sign and append signature", async () => {
     const createdAt = new ReadonlyDate(ReadonlyDate.now());
     const keyring = new Keyring();
-    const wallet = Ed25519HdWallet.fromMnemonic(
-      "melt wisdom mesh wash item catalog talk enjoy gaze hat brush wash",
+    const wallet = keyring.add(
+      Ed25519HdWallet.fromMnemonic("melt wisdom mesh wash item catalog talk enjoy gaze hat brush wash"),
     );
-    keyring.add(wallet);
     const mainIdentity = await keyring.createIdentity(wallet.id, defaultChain, HdPaths.simpleAddress(0));
     const profile = new UserProfile({ createdAt, keyring });
 

--- a/packages/iov-keycontrol/src/userprofile.ts
+++ b/packages/iov-keycontrol/src/userprofile.ts
@@ -16,7 +16,7 @@ import { Argon2id, Argon2idOptions, Ed25519Keypair, Slip10RawIndex } from "@iov/
 import { Encoding, Int53 } from "@iov/encoding";
 import { DefaultValueProducer, ValueAndUpdates } from "@iov/stream";
 
-import { Keyring } from "./keyring";
+import { Keyring, WalletInfo } from "./keyring";
 import { EncryptedKeyring, KeyringEncryptor } from "./keyringencryptor";
 import { DatabaseUtils } from "./utils";
 import { ReadonlyWallet, Wallet, WalletId } from "./wallet";
@@ -41,14 +41,6 @@ const userProfileSalt = toAscii("core-userprofile");
 export interface UserProfileOptions {
   readonly createdAt: ReadonlyDate;
   readonly keyring: Keyring;
-}
-
-/**
- * Read-only information about one wallet in a keyring/user profile
- */
-export interface WalletInfo {
-  readonly id: WalletId;
-  readonly label: string | undefined;
 }
 
 /**
@@ -149,12 +141,9 @@ export class UserProfile {
     }
 
     const copy = wallet.clone();
-    this.keyring.add(copy);
+    const info = this.keyring.add(copy);
     this.walletsProducer.update(this.walletInfos());
-    return {
-      id: copy.id,
-      label: copy.label.value,
-    };
+    return info;
   }
 
   /** Sets the label of the wallet with the given ID in the primary keyring  */

--- a/packages/iov-keycontrol/src/wallet.ts
+++ b/packages/iov-keycontrol/src/wallet.ts
@@ -8,44 +8,14 @@ export type WalletId = string & As<"wallet-id">;
 export type WalletImplementationIdString = string & As<"wallet-implementation-id">;
 export type WalletSerializationString = string & As<"wallet-serialization">;
 
-/**
- * A is a generic interface for managing a set of keys and signing
- * data with them.
- *
- * A Wallet is responsible for storing private keys securely and
- * signing with them. Wallet can be implemented in software or as
- * a bridge to a hardware wallet.
- */
-export interface Wallet {
+/** An interface that does not allow mutating any internal state of the Wallet */
+export interface ReadonlyWallet {
   readonly label: ValueAndUpdates<string | undefined>;
 
   // id is a unique identifier based on the content of the keyring
   // the same implementation with same seed/secret should have same identifier
   // otherwise, they will be different
   readonly id: WalletId;
-
-  /**
-   * Sets a label for this wallet to be displayed in the UI.
-   * To clear the label, set it to undefined.
-   */
-  readonly setLabel: (label: string | undefined) => void;
-
-  /**
-   * Creates a new identity in the wallet.
-   *
-   * The identity is bound to one chain ID to encourage using different
-   * keypairs on different chains.
-   */
-  readonly createIdentity: (
-    chainId: ChainId,
-    options: Ed25519Keypair | ReadonlyArray<Slip10RawIndex> | number,
-  ) => Promise<PublicIdentity>;
-
-  /**
-   * Sets a local label associated with the public identity to be displayed in the UI.
-   * To clear a label, set it to undefined
-   */
-  readonly setIdentityLabel: (identity: PublicIdentity, label: string | undefined) => void;
 
   /**
    * Gets a local label associated with the public identity to be displayed in the UI.
@@ -93,4 +63,37 @@ export interface Wallet {
   readonly serialize: () => WalletSerializationString;
 
   readonly clone: () => Wallet;
+}
+
+/**
+ * A is a generic interface for managing a set of keys and signing
+ * data with them.
+ *
+ * A Wallet is responsible for storing private keys securely and
+ * signing with them. Wallet can be implemented in software or as
+ * a bridge to a hardware wallet.
+ */
+export interface Wallet extends ReadonlyWallet {
+  /**
+   * Sets a label for this wallet to be displayed in the UI.
+   * To clear the label, set it to undefined.
+   */
+  readonly setLabel: (label: string | undefined) => void;
+
+  /**
+   * Creates a new identity in the wallet.
+   *
+   * The identity is bound to one chain ID to encourage using different
+   * keypairs on different chains.
+   */
+  readonly createIdentity: (
+    chainId: ChainId,
+    options: Ed25519Keypair | ReadonlyArray<Slip10RawIndex> | number,
+  ) => Promise<PublicIdentity>;
+
+  /**
+   * Sets a local label associated with the public identity to be displayed in the UI.
+   * To clear a label, set it to undefined
+   */
+  readonly setIdentityLabel: (identity: PublicIdentity, label: string | undefined) => void;
 }

--- a/packages/iov-keycontrol/types/index.d.ts
+++ b/packages/iov-keycontrol/types/index.d.ts
@@ -1,5 +1,5 @@
 export { HdPaths } from "./hdpaths";
-export { Keyring } from "./keyring";
-export { UserProfile, WalletInfo } from "./userprofile";
+export { Keyring, WalletInfo } from "./keyring";
+export { UserProfile } from "./userprofile";
 export { Wallet, WalletId, WalletImplementationIdString, WalletSerializationString } from "./wallet";
 export { Ed25519HdWallet, Ed25519Wallet, Secp256k1HdWallet } from "./wallets";

--- a/packages/iov-keycontrol/types/keyring.d.ts
+++ b/packages/iov-keycontrol/types/keyring.d.ts
@@ -3,6 +3,13 @@ import { ChainId, PublicIdentity } from "@iov/bcp";
 import { Ed25519Keypair, Slip10RawIndex } from "@iov/crypto";
 import { ReadonlyWallet, Wallet, WalletId, WalletImplementationIdString, WalletSerializationString } from "./wallet";
 export declare type KeyringSerializationString = string & As<"keyring-serialization">;
+/**
+ * Read-only information about one wallet in a keyring
+ */
+export interface WalletInfo {
+    readonly id: WalletId;
+    readonly label: string | undefined;
+}
 export declare type WalletDeserializer = (data: WalletSerializationString) => Wallet;
 /**
  * A collection of wallets
@@ -13,7 +20,7 @@ export declare class Keyring {
     private static deserializeWallet;
     private readonly wallets;
     constructor(data?: KeyringSerializationString);
-    add(wallet: Wallet): void;
+    add(wallet: Wallet): WalletInfo;
     /**
      * Returns an array with immutable references.
      */

--- a/packages/iov-keycontrol/types/keyring.d.ts
+++ b/packages/iov-keycontrol/types/keyring.d.ts
@@ -1,7 +1,7 @@
 import { As } from "type-tagger";
 import { ChainId, PublicIdentity } from "@iov/bcp";
 import { Ed25519Keypair, Slip10RawIndex } from "@iov/crypto";
-import { Wallet, WalletId, WalletImplementationIdString, WalletSerializationString } from "./wallet";
+import { ReadonlyWallet, Wallet, WalletId, WalletImplementationIdString, WalletSerializationString } from "./wallet";
 export declare type KeyringSerializationString = string & As<"keyring-serialization">;
 export declare type WalletDeserializer = (data: WalletSerializationString) => Wallet;
 /**
@@ -15,17 +15,15 @@ export declare class Keyring {
     constructor(data?: KeyringSerializationString);
     add(wallet: Wallet): void;
     /**
-     * this returns an array with mutable element references. Thus e.g.
-     * .getWallets().createIdentity() will change the keyring.
+     * Returns an array with immutable references.
      */
-    getWallets(): ReadonlyArray<Wallet>;
+    getWallets(): ReadonlyArray<ReadonlyWallet>;
     /**
-     * Finds a wallet and returns a mutable references. Thus e.g.
-     * .getWallet(xyz).createIdentity() will change the keyring.
+     * Finds a wallet and returns an immutable references.
      *
      * @returns a wallet if ID is found, undefined otherwise
      */
-    getWallet(id: WalletId): Wallet | undefined;
+    getWallet(id: WalletId): ReadonlyWallet | undefined;
     /** Sets the label of the wallet with the given ID in the primary keyring  */
     setWalletLabel(walletId: WalletId, label: string | undefined): void;
     /**
@@ -39,4 +37,11 @@ export declare class Keyring {
     setIdentityLabel(walletId: WalletId, identity: PublicIdentity, label: string | undefined): void;
     serialize(): KeyringSerializationString;
     clone(): Keyring;
+    /**
+     * Finds a wallet and returns a mutable references. Thus e.g.
+     * .getMutableWallet(xyz).createIdentity(...) will change the keyring.
+     *
+     * @returns a wallet if ID is found, undefined otherwise
+     */
+    private getMutableWallet;
 }

--- a/packages/iov-keycontrol/types/keyring.d.ts
+++ b/packages/iov-keycontrol/types/keyring.d.ts
@@ -1,4 +1,6 @@
 import { As } from "type-tagger";
+import { ChainId, PublicIdentity } from "@iov/bcp";
+import { Ed25519Keypair, Slip10RawIndex } from "@iov/crypto";
 import { Wallet, WalletId, WalletImplementationIdString, WalletSerializationString } from "./wallet";
 export declare type KeyringSerializationString = string & As<"keyring-serialization">;
 export declare type WalletDeserializer = (data: WalletSerializationString) => Wallet;
@@ -24,6 +26,17 @@ export declare class Keyring {
      * @returns a wallet if ID is found, undefined otherwise
      */
     getWallet(id: WalletId): Wallet | undefined;
+    /** Sets the label of the wallet with the given ID in the primary keyring  */
+    setWalletLabel(walletId: WalletId, label: string | undefined): void;
+    /**
+     * Creates an identitiy in the wallet with the given ID in the primary keyring
+     *
+     * The identity is bound to one chain ID to encourage using different
+     * keypairs on different chains.
+     */
+    createIdentity(walletId: WalletId, chainId: ChainId, options: Ed25519Keypair | ReadonlyArray<Slip10RawIndex> | number): Promise<PublicIdentity>;
+    /** Assigns a label to one of the identities in the wallet with the given ID in the primary keyring */
+    setIdentityLabel(walletId: WalletId, identity: PublicIdentity, label: string | undefined): void;
     serialize(): KeyringSerializationString;
     clone(): Keyring;
 }

--- a/packages/iov-keycontrol/types/userprofile.d.ts
+++ b/packages/iov-keycontrol/types/userprofile.d.ts
@@ -40,16 +40,16 @@ export declare class UserProfile {
      */
     addWallet(wallet: Wallet): WalletInfo;
     /** Sets the label of the wallet with the given ID in the primary keyring  */
-    setWalletLabel(id: WalletId, label: string | undefined): void;
+    setWalletLabel(walletId: WalletId, label: string | undefined): void;
     /**
      * Creates an identitiy in the wallet with the given ID in the primary keyring
      *
      * The identity is bound to one chain ID to encourage using different
      * keypairs on different chains.
      */
-    createIdentity(id: WalletId, chainId: ChainId, options: Ed25519Keypair | ReadonlyArray<Slip10RawIndex> | number): Promise<PublicIdentity>;
+    createIdentity(walletId: WalletId, chainId: ChainId, options: Ed25519Keypair | ReadonlyArray<Slip10RawIndex> | number): Promise<PublicIdentity>;
     /** Assigns a label to one of the identities in the wallet with the given ID in the primary keyring */
-    setIdentityLabel(id: WalletId, identity: PublicIdentity, label: string | undefined): void;
+    setIdentityLabel(walletId: WalletId, identity: PublicIdentity, label: string | undefined): void;
     /**
      * Gets the local label of one of the identities in the wallet with the given ID
      * in the primary keyring
@@ -68,6 +68,8 @@ export declare class UserProfile {
      * how the result looks like.
      */
     printableSecret(id: WalletId): string;
+    /** Throws if the primary keyring is not set, i.e. UserProfile is locked. */
+    private primaryKeyring;
     /** Throws if wallet does not exist in primary keyring */
     private findWalletInPrimaryKeyring;
     private walletInfos;

--- a/packages/iov-keycontrol/types/userprofile.d.ts
+++ b/packages/iov-keycontrol/types/userprofile.d.ts
@@ -4,18 +4,11 @@ import { ReadonlyDate } from "readonly-date";
 import { ChainId, Nonce, PublicIdentity, SignedTransaction, TxCodec, UnsignedTransaction } from "@iov/bcp";
 import { Ed25519Keypair, Slip10RawIndex } from "@iov/crypto";
 import { ValueAndUpdates } from "@iov/stream";
-import { Keyring } from "./keyring";
+import { Keyring, WalletInfo } from "./keyring";
 import { Wallet, WalletId } from "./wallet";
 export interface UserProfileOptions {
     readonly createdAt: ReadonlyDate;
     readonly keyring: Keyring;
-}
-/**
- * Read-only information about one wallet in a keyring/user profile
- */
-export interface WalletInfo {
-    readonly id: WalletId;
-    readonly label: string | undefined;
 }
 /**
  * All calls must go though the UserProfile. A newly created UserProfile

--- a/packages/iov-keycontrol/types/wallet.d.ts
+++ b/packages/iov-keycontrol/types/wallet.d.ts
@@ -5,34 +5,10 @@ import { ValueAndUpdates } from "@iov/stream";
 export declare type WalletId = string & As<"wallet-id">;
 export declare type WalletImplementationIdString = string & As<"wallet-implementation-id">;
 export declare type WalletSerializationString = string & As<"wallet-serialization">;
-/**
- * A is a generic interface for managing a set of keys and signing
- * data with them.
- *
- * A Wallet is responsible for storing private keys securely and
- * signing with them. Wallet can be implemented in software or as
- * a bridge to a hardware wallet.
- */
-export interface Wallet {
+/** An interface that does not allow mutating any internal state of the Wallet */
+export interface ReadonlyWallet {
     readonly label: ValueAndUpdates<string | undefined>;
     readonly id: WalletId;
-    /**
-     * Sets a label for this wallet to be displayed in the UI.
-     * To clear the label, set it to undefined.
-     */
-    readonly setLabel: (label: string | undefined) => void;
-    /**
-     * Creates a new identity in the wallet.
-     *
-     * The identity is bound to one chain ID to encourage using different
-     * keypairs on different chains.
-     */
-    readonly createIdentity: (chainId: ChainId, options: Ed25519Keypair | ReadonlyArray<Slip10RawIndex> | number) => Promise<PublicIdentity>;
-    /**
-     * Sets a local label associated with the public identity to be displayed in the UI.
-     * To clear a label, set it to undefined
-     */
-    readonly setIdentityLabel: (identity: PublicIdentity, label: string | undefined) => void;
     /**
      * Gets a local label associated with the public identity to be displayed in the UI.
      */
@@ -61,4 +37,31 @@ export interface Wallet {
     readonly printableSecret: () => string;
     readonly serialize: () => WalletSerializationString;
     readonly clone: () => Wallet;
+}
+/**
+ * A is a generic interface for managing a set of keys and signing
+ * data with them.
+ *
+ * A Wallet is responsible for storing private keys securely and
+ * signing with them. Wallet can be implemented in software or as
+ * a bridge to a hardware wallet.
+ */
+export interface Wallet extends ReadonlyWallet {
+    /**
+     * Sets a label for this wallet to be displayed in the UI.
+     * To clear the label, set it to undefined.
+     */
+    readonly setLabel: (label: string | undefined) => void;
+    /**
+     * Creates a new identity in the wallet.
+     *
+     * The identity is bound to one chain ID to encourage using different
+     * keypairs on different chains.
+     */
+    readonly createIdentity: (chainId: ChainId, options: Ed25519Keypair | ReadonlyArray<Slip10RawIndex> | number) => Promise<PublicIdentity>;
+    /**
+     * Sets a local label associated with the public identity to be displayed in the UI.
+     * To clear a label, set it to undefined
+     */
+    readonly setIdentityLabel: (identity: PublicIdentity, label: string | undefined) => void;
 }


### PR DESCRIPTION
First step of #652

With this change, all wallet mutation goes through

1. `Keyring.add(wallet: Wallet)`
2. `Keyring.setWalletLabel(walletId: WalletId, label: string | undefined)`
3. `Keyring.createIdentity(walletId: WalletId, chainId: ChainId, options: Ed25519Keypair | ReadonlyArray<Slip10RawIndex> | number)`
4. `Keyring.setIdentityLabel(walletId: WalletId, identity: PublicIdentity, label: string | undefined)`

Given that we know that only 1. and 3. change the keyring's identities. So we have only 2 places where we need to ensure an identity is unique within a Keyring.