### PR TITLE
Add atomic swap protocol

### DIFF
--- a/docs/atomic-swap-protocol-v1.md
+++ b/docs/atomic-swap-protocol-v1.md
@@ -81,7 +81,23 @@ data with `hash = sha256(preimage)`.
 
 ### Timeouts
 
-TODO
+A timeout is the first point in time, when the HTLC is expired. It is measured
+in one of the two types absolute times or block height.
+
+- **Absolute time** is a second resolution
+  [UNIX time](https://en.wikipedia.org/wiki/Unix_time). It is used for
+  blockchains that have a strong guarantee for correct and fair timestamps with
+  reasonable precision.
+- **Block height** is an integer counting the number of blocks created. It is
+  used when absolute time is not appropriate.
+
+Note: Since the type of timeout is fixed in the HTLC, which belongs to the
+blockchain, a cross-chain atomic swap may need to use different types of
+timeouts for the initial offer and the counter offer.
+
+The counter offer is claimed first. I.e. the time between the counter offer's
+timeout and the initial offer's timeout is the minimal time the actor in short
+position has to claim the initial offer.
 
 ### Swap offer actions
 
@@ -160,7 +176,24 @@ locked tokens until the timeout is reached.
 
 ### Half executed atomic swaps
 
-TODO: timeout issue etc.
+1. **Timeout difference:** The actor in short position needs to ensure to have a
+   sufficient amount of time to claim the initial offer, even if the preimage
+   was revealed by claiming the counter offer at the very last possible point in
+   time. This should cover all risks that can delay the execution of the claim
+   transaction like different time zones, downtimes of the default blockchain
+   nodes, temporary loss of power, internet connection and access to key
+   material.
+2. **Block height based timeout calculation:** The above timeout difference is
+   even harder to calculate when timeouts are measured in block height.
+   Especially with non-constant block times one needs to calculate the expected
+   block height at the desired timeout time and take into account a safety
+   margin.
+3. **Chain stops:** When one chain in a cross-chain atomic swap stops, two
+   things can happen that lead to half executed atomic swaps. (a) A timeout
+   measured in absolute time is reached without the chance to get a claim
+   transaction processed. (b) An initial offer's block height based timeout is
+   pushed unexpectedly far into the future, such that the timeout difference for
+   the actor in short position to claim is 0 or negative.
 
 ## License
 

--- a/docs/atomic-swap-protocol-v1.md
+++ b/docs/atomic-swap-protocol-v1.md
@@ -18,21 +18,21 @@ specification to build compatible components.
 Two actors Alice (A) and Bob (B) agreed on a token exchange off-chain. Both have
 one address on each blockchain X and Y.
 
-- Alice creates a secret key locally (called preimage) and stores it.
+- Alice creates a secret key locally (called a "preimage") and stores it.
 - Alice creates a swap offer on X, the blockchain where her tokens live. This is
-  a HLTC that contains the recipient address of Bob on X (b<sub>X</sub>), the
+  a HTLC that contains the recipient address of Bob on X (b<sub>X</sub>), the
   amount of tokens offered, the hash of the preimage and a timeout. This
   contract locks her tokens and sends them to b<sub>X</sub> if the preimage is
-  releaved on-chain.
+  revealed on-chain.
 - Bob creates a swap offer on Y, the blockchain where his tokens live. This is a
-  HLTC that contains the recipient address of Alice on Y (a<sub>Y</sub>), the
+  HTLC that contains the recipient address of Alice on Y (a<sub>Y</sub>), the
   amount of tokens offered, the hash copied from Alice's offer and a timeout.
   This contract locks his tokens and sends them to a<sub>Y</sub> if the preimage
-  is releaved on-chain.
+  is revealed on-chain.
 - (Variant 1): Alice now uses her preimage to claim Bob's swap offer on Y,
-  causing the token transfer from b<sub>Y</sub> to a<sub>Y</sub>. Bob looks up
-  this now public preimage on Y to claim Alice's swap offer on X, causing the
-  token transfer from a<sub>X</sub> to b<sub>X</sub>.
+  triggering the token transfer from b<sub>Y</sub> to a<sub>Y</sub>. Bob looks
+  up this now public preimage on Y to claim Alice's swap offer on X, triggering
+  the token transfer from a<sub>X</sub> to b<sub>X</sub>.
 - (Variant 2): Alice decides not to reveal her preimage before the timeout of
   Bob's offer is reached. As soon as the timeout is reached, Bob aborts his
   offer and gets back his tokens. Alice also needs to wait for the timeout of
@@ -42,16 +42,16 @@ one address on each blockchain X and Y.
 
 As soon as both offers are created, the actor that created the preimage has the
 one-sided option to execute the atomic swap or to let it expire. Thus this actor
-is called to be _in long position_. The other actor is called to be _in short
-position_.
+is described as being _in long position_. The other actor is described as being
+_in short position_.
 
 Being in long position has two advantages:
 
 1. having the free option to execute the swap or not and
-2. claiming the other actor's swap offer first, which reduces the risk of
-   loosing tokens in the case of a half executed swap.
+2. claiming the other actor's swap offer first, which reduces the risk of losing
+   tokens in the case of a half executed swap.
 
-Being in short position has that advantage to be able to review the other
+Being in short position has the advantage of being able to review the other
 actor's swap offer before creating an offer oneself.
 
 ## The swap offer
@@ -71,10 +71,10 @@ Common synonyms: _swap_, _contract_, _escrow_.
 
 ### Preimage and hashing
 
-The preimage is 32 bytes of raw binary data. It is locally created by the long
-position and must be kept a secret. It is in the creator's own interest to use a
-sufficiently good source of entropy to generate it, but this is not required by
-the protocol.
+The preimage is exactly 32 bytes of raw binary data. It is locally created by
+the long position and must be kept a secret. It is in the creator's own interest
+to use a sufficiently good source of entropy to generate it, but this is not
+required by the protocol.
 
 The hashing algorithm is fixed to SHA-256. The hash is 32 bytes of raw binary
 data with `hash = sha256(preimage)`.
@@ -132,18 +132,19 @@ Others need to be mitigated by smart choice of parameters.
 
 ### Pre-image attacks
 
-The short position copies the hash without knowing the preimage. Now the long
-position could use a very long preimage that is either expensive or impossible
-to process on one chain but works easily on the other chain. This can make it
-unprofitable or impossible for short to claim their tokens, leading to free
-tokens for long.
+The short position copies the hash without knowing the preimage. This means the
+long position could use a very long preimage that is either expensive or
+impossible to process on one chain but works easily on the other chain. This can
+make it unprofitable or impossible for short to claim their tokens, leading to
+free tokens for long.
 
 This risk is avoided in this protocol by having a fixed preimage length.
 
 ### No counter offer created
 
-The short position can pretend to create a counter offer but not do it. In this
-case long loses access to the locked tokens until the timeout is reached.
+The short position can pretend to have the intention to create a counter offer
+but not do it. In this case long loses access to the locked tokens until the
+timeout is reached.
 
 ### Half executed atomic swaps
 

--- a/docs/atomic-swap-protocol-v1.md
+++ b/docs/atomic-swap-protocol-v1.md
@@ -117,10 +117,11 @@ automatically changes on-chain as the underlying time (wall time or block
 height) increases. A state can switch from _non-expired_ to _expired_ but not
 vice versa.
 
-- **Non-expired:** In the range `[creation, timeout)`, the swap offer is
-  _non-expired_. This is the default state for most offers. However, an offer
-  can be created in _expired_ state directly if the above interval is empty.
-- **Expired** In the range `[timeout, ∞)`, the swap offer is _expired_.
+- **Non-expired:** In the half-open interval `[creation, timeout)`, the swap
+  offer is _non-expired_. This is the default state for most offers. However, an
+  offer can be created in _expired_ state directly if the above interval is
+  empty.
+- **Expired** In the interval `[timeout, ∞)`, the swap offer is _expired_.
 
 Common synonym: _abortable = expired_.
 

--- a/docs/atomic-swap-protocol-v1.md
+++ b/docs/atomic-swap-protocol-v1.md
@@ -2,7 +2,7 @@
 
 | Status | Authors                                | Created    | Last updated | License   |
 | ------ | -------------------------------------- | ---------- | ------------ | --------- |
-| Draft  | Simon Warta, Ethan Frey, Isabella Dell | 2019-03-27 | 2019-04-08   | CC-BY-4.0 |
+| Draft  | Simon Warta, Ethan Frey, Isabella Dell | 2019-03-27 | 2019-04-24   | CC-BY-4.0 |
 
 ## Abstract
 
@@ -91,9 +91,11 @@ Actions are mutations of the on-chain state triggered by transactions.
   timeout and a hash must be specified.
 - **Claim:** By revealing a preimage for the hash before the timeout is reached,
   the contract transfers the tokens to the recipient. Requires a preimage of
-  exactly 32 bytes. Common synonyms: _release_, _execute_.
+  exactly 32 bytes.
 - **Abort:** Withdraws the tokens from the contract to the creator. Requires
   timeout to be reached.
+
+Common synonyms: _release = claim_, _execute = claim_.
 
 ### Swap offer process state
 

--- a/docs/atomic-swap-protocol-v1.md
+++ b/docs/atomic-swap-protocol-v1.md
@@ -134,7 +134,7 @@ at the same time.
 
 The following risks for cross-chain atomic swaps have been identified. Some of
 them are fully avoided by this protocol but still documented for tranparancy.
-Others need to be mitigated by smart choice of parameters.
+Others need to be mitigated by the user's choice of parameters.
 
 ### Pre-image attacks
 

--- a/docs/atomic-swap-protocol-v1.md
+++ b/docs/atomic-swap-protocol-v1.md
@@ -58,8 +58,8 @@ actor's swap offer before creating an offer oneself.
 
 A swap offer is a HTLC with the following properties:
 
-- The amount of tokens is fixed. Implementation may support a group of multiple
-  amounts.
+- The amount of tokens is fixed. Implementations may support including multiple
+  different tokens at once.
 - The recipient address is fixed.
 - Creating the contract locks the funds.
 - A hash of the preimage is fixed.

--- a/docs/atomic-swap-protocol-v1.md
+++ b/docs/atomic-swap-protocol-v1.md
@@ -120,8 +120,9 @@ vice versa.
 - **Non-expired:** In the range `[creation, timeout)`, the swap offer is
   _non-expired_. This is the default state for most offers. However, an offer
   can be created in _expired_ state directly if the above interval is empty.
-- **Expired** In the range `[timeout, ∞)`, the swap offer is _expired_. Common
-  synonym: _abortable_.
+- **Expired** In the range `[timeout, ∞)`, the swap offer is _expired_.
+
+Common synonym: _abortable = expired_.
 
 #### Note on process and expiry state
 

--- a/docs/atomic-swap-protocol-v1.md
+++ b/docs/atomic-swap-protocol-v1.md
@@ -95,6 +95,10 @@ Actions are mutations of the on-chain state triggered by transactions.
 - **Abort:** Withdraws the tokens from the contract to the creator. Requires
   timeout to be reached.
 
+Every account must have permission to perform the _claim_ and _abort_ action to
+allow claiming and aborting when the swap recipient cannot access their keys
+temporarily or has insufficient funds to pay transaction fees.
+
 Common synonyms: _release = claim_, _execute = claim_.
 
 ### Swap offer process state

--- a/docs/atomic-swap-protocol-v1.md
+++ b/docs/atomic-swap-protocol-v1.md
@@ -138,19 +138,19 @@ Others need to be mitigated by the user's choice of parameters.
 
 ### Pre-image attacks
 
-The short position copies the hash without knowing the preimage. This means the
-long position could use a very long preimage that is either expensive or
-impossible to process on one chain but works easily on the other chain. This can
-make it unprofitable or impossible for short to claim their tokens, leading to
-free tokens for long.
+The actor in short position copies the hash without knowing the preimage. This
+means the actor in long position could use a very long preimage that is either
+expensive or impossible to process on one chain but works easily on the other
+chain. This can make it unprofitable or impossible for the actor in short to
+claim their tokens, leading to free tokens for the actor in long.
 
 This risk is avoided in this protocol by having a fixed preimage length.
 
 ### No counter offer created
 
-The short position can pretend to have the intention to create a counter offer
-but not do it. In this case long loses access to the locked tokens until the
-timeout is reached.
+The actor in short position can pretend to have the intention to create a
+counter offer but not do it. In this case the actor in long loses access to the
+locked tokens until the timeout is reached.
 
 ### Half executed atomic swaps
 

--- a/docs/atomic-swap-protocol-v1.md
+++ b/docs/atomic-swap-protocol-v1.md
@@ -108,7 +108,7 @@ A swap offer which has been claimed or aborted cannot change to another process
 state, i.e. the only possible transitions are _open → claimed_ and _open →
 aborted_.
 
-Common synonym: _settled = (claimed or aborted)_
+Common synonyms: _settled = (claimed or aborted)_, _closed = claimed_.
 
 ### Swap offer expiry state
 

--- a/docs/atomic-swap-protocol-v1.md
+++ b/docs/atomic-swap-protocol-v1.md
@@ -15,8 +15,8 @@ specification to build compatible components.
 
 ## Overview
 
-Two actors Alice (A) and Bob (B) agreed on a token exchange off-chain. Both have
-one address on each blockchain X and Y.
+Two actors Alice and Bob agreed on a token exchange off-chain. Both have one
+address on each blockchain X and Y.
 
 - Alice creates a secret key locally (called a "preimage") and stores it.
 - Alice creates a swap offer on X, the blockchain where her tokens live. This is

--- a/docs/atomic-swap-protocol-v1.md
+++ b/docs/atomic-swap-protocol-v1.md
@@ -95,14 +95,17 @@ Actions are mutations of the on-chain state triggered by transactions.
 - **Abort:** Withdraws the tokens from the contract to the creator. Requires
   timeout to be reached.
 
-### Swap offer open state
+### Swap offer process state
 
-Each swap offer individually is either _open_, _claimed_ or _aborted_. The open
-state can only be changed by performing an action via a transaction.
+Each swap offer individually is either _open_, _claimed_ or _aborted_. The
+process state can only be changed by performing an action via a transaction.
 
-- **Open:** This is the initial open state.
-- **Claimed:** An _open_ swap becomes _claimed_ by performing the clain action.
+- **Open:** This is the initial process state.
+- **Claimed:** An _open_ swap becomes _claimed_ by performing the claim action.
 - **Aborted:** An _open_ swap becomes _aborted_ by performing the abort action.
+
+A claimed or aborted swap offer process state cannot change again, i.e. the only
+possible transitions are _open → claimed_ and _open → aborted_.
 
 Common synonym: _settled = (claimed or aborted)_
 
@@ -119,7 +122,7 @@ vice versa.
 - **Expired** In the range `[timeout, ∞)`, the swap offer is _expired_. Common
   synonym: _abortable_.
 
-#### Note on open and expiry state
+#### Note on process and expiry state
 
 Both states are independent of each other. A swap offer can be open and expired
 at the same time.

--- a/docs/atomic-swap-protocol-v1.md
+++ b/docs/atomic-swap-protocol-v1.md
@@ -1,8 +1,8 @@
 # IOV atomic swap protocol version 1
 
-| Status | Authors | Created    | Last updated | License   |
-| ------ | ------- | ---------- | ------------ | --------- |
-| Draft  |         | 2019-03-27 | 2019-03-27   | CC-BY-4.0 |
+| Status | Authors                                | Created    | Last updated | License   |
+| ------ | -------------------------------------- | ---------- | ------------ | --------- |
+| Draft  | Simon Warta, Ethan Frey, Isabella Dell | 2019-03-27 | 2019-04-08   | CC-BY-4.0 |
 
 ## Abstract
 

--- a/docs/atomic-swap-protocol-v1.md
+++ b/docs/atomic-swap-protocol-v1.md
@@ -104,8 +104,9 @@ process state can only be changed by performing an action via a transaction.
 - **Claimed:** An _open_ swap becomes _claimed_ by performing the claim action.
 - **Aborted:** An _open_ swap becomes _aborted_ by performing the abort action.
 
-A claimed or aborted swap offer process state cannot change again, i.e. the only
-possible transitions are _open → claimed_ and _open → aborted_.
+A swap offer which has been claimed or aborted cannot change to another process
+state, i.e. the only possible transitions are _open → claimed_ and _open →
+aborted_.
 
 Common synonym: _settled = (claimed or aborted)_
 

--- a/docs/atomic-swap-protocol-v1.md
+++ b/docs/atomic-swap-protocol-v1.md
@@ -2,7 +2,7 @@
 
 | Status | Authors                                | Created    | Last updated | License   |
 | ------ | -------------------------------------- | ---------- | ------------ | --------- |
-| Draft  | Simon Warta, Ethan Frey, Isabella Dell | 2019-03-27 | 2019-04-24   | CC-BY-4.0 |
+| Draft  | Simon Warta, Ethan Frey, Isabella Dell | 2019-03-27 | 2019-04-29   | CC-BY-4.0 |
 
 ## Abstract
 
@@ -82,12 +82,12 @@ data with `hash = sha256(preimage)`.
 ### Timeouts
 
 A timeout is the first point in time, when the HTLC is expired. It is measured
-in one of the two types absolute times or block height.
+in one of the two types: absolute time or block height.
 
-- **Absolute time** is a second resolution
-  [UNIX time](https://en.wikipedia.org/wiki/Unix_time). It is used for
-  blockchains that have a strong guarantee for correct and fair timestamps with
-  reasonable precision.
+- **Absolute time** is a [UNIX time](https://en.wikipedia.org/wiki/Unix_time)
+  with a resolution of one second. It is used for blockchains that have a strong
+  guarantee for correct and fair timestamps with reasonable precision (e.g.
+  Tendermint-based blockchains).
 - **Block height** is an integer counting the number of blocks created. It is
   used when absolute time is not appropriate.
 
@@ -176,15 +176,15 @@ locked tokens until the timeout is reached.
 
 ### Half executed atomic swaps
 
-1. **Timeout difference:** The actor in short position needs to ensure to have a
-   sufficient amount of time to claim the initial offer, even if the preimage
-   was revealed by claiming the counter offer at the very last possible point in
+1. **Timeout difference:** The actor in short position needs to ensure there is
+   a sufficient amount of time to claim the initial offer, even if the preimage
+   is revealed by claiming the counter offer at the very last possible point in
    time. This should cover all risks that can delay the execution of the claim
-   transaction like different time zones, downtimes of the default blockchain
-   nodes, temporary loss of power, internet connection and access to key
-   material.
+   transaction like different time zones, temporary loss of power, internet
+   connection, access to key material as well as downtimes of the default
+   blockchain nodes and blockchain-related issues.
 2. **Block height based timeout calculation:** The above timeout difference is
-   even harder to calculate when timeouts are measured in block height.
+   even harder to calculate when timeouts are measured in terms of block height.
    Especially with non-constant block times one needs to calculate the expected
    block height at the desired timeout time and take into account a safety
    margin.
@@ -193,7 +193,8 @@ locked tokens until the timeout is reached.
    measured in absolute time is reached without the chance to get a claim
    transaction processed. (b) An initial offer's block height based timeout is
    pushed unexpectedly far into the future, such that the timeout difference for
-   the actor in short position to claim is 0 or negative.
+   the actor in short position to claim is 0 or negative (i.e. impossible to
+   claim).
 
 ## License
 


### PR DESCRIPTION
Depends on #856
Closes #850

---

This ads a specification of the IOV atomic swap protocol and adapts the client-side implementation accordingly.

- [x] Set authors
- [x] Do TODOs
- [x] Explicitly require that anyone can claim