### PR TITLE
Use prettier to format .md files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,459 +6,518 @@
 
 ## 0.13.0
 
-* @iov/bcp: Add `AtomicSwapMerger`
-* @iov/bcp: `AtomicSwapHelpers.createPreimage` and `.hashPreimage` are
-  now available to perform BCP specific atomic swap operations
-* @iov/bcp: Add `signedBy` field to `BcpTxQuery`.
-* @iov/bcp: Add `memo` field to `SwapOfferTransaction`.
-* @iov/bcp: Add `Fee` type and `isFee` helper function.
-* @iov/bcp: Add `getFeeQuote` method to `BcpConnection`.
-* @iov/bns: Implement `getFeeQuote` method on `BnsConnection`.
-* @iov/keycontrol: Add `Keyring.getAllIdentities` and `Keyring.getWalletByIdentity`
-* @iov/keycontrol: Add `UserProfile.getAllIdentities`
-* @iov/keycontrol: Add `.previewIdentity` to the `ReadonlyWallet`/`Wallet` interfaces
-* @iov/jsonrpc: Let `isJsonCompatibleDictionary` not accept non-simple objects
-* @iov/lisk: Implement `watchBlockHeaders` method on `LiskConnection`.
-* @iov/lisk: Implement `getFeeQuote` method on `LiskConnection`.
-* @iov/rise: Implement `getFeeQuote` method on `RiseConnection`.
+- @iov/bcp: Add `AtomicSwapMerger`
+- @iov/bcp: `AtomicSwapHelpers.createPreimage` and `.hashPreimage` are now
+  available to perform BCP specific atomic swap operations
+- @iov/bcp: Add `signedBy` field to `BcpTxQuery`.
+- @iov/bcp: Add `memo` field to `SwapOfferTransaction`.
+- @iov/bcp: Add `Fee` type and `isFee` helper function.
+- @iov/bcp: Add `getFeeQuote` method to `BcpConnection`.
+- @iov/bns: Implement `getFeeQuote` method on `BnsConnection`.
+- @iov/keycontrol: Add `Keyring.getAllIdentities` and
+  `Keyring.getWalletByIdentity`
+- @iov/keycontrol: Add `UserProfile.getAllIdentities`
+- @iov/keycontrol: Add `.previewIdentity` to the `ReadonlyWallet`/`Wallet`
+  interfaces
+- @iov/jsonrpc: Let `isJsonCompatibleDictionary` not accept non-simple objects
+- @iov/lisk: Implement `watchBlockHeaders` method on `LiskConnection`.
+- @iov/lisk: Implement `getFeeQuote` method on `LiskConnection`.
+- @iov/rise: Implement `getFeeQuote` method on `RiseConnection`.
 
 Breaking changes
 
-* @iov/bcp-types: Renamed to @iov/bcp
-* @iov/bcp: Pluralize `.amounts` property and change to `Amount` array in
+- @iov/bcp-types: Renamed to @iov/bcp
+- @iov/bcp: Pluralize `.amounts` property and change to `Amount` array in
   `SwapOfferTransaction`, `SwapData`
-* @iov/bcp: Rename `BcpAtomicSwap` to `AtomicSwap`
-* @iov/bcp: Rename atomic swap query types to `AtomicSwapQuery`,
+- @iov/bcp: Rename `BcpAtomicSwap` to `AtomicSwap`
+- @iov/bcp: Rename atomic swap query types to `AtomicSwapQuery`,
   `AtomicSwapRecipientQuery`, `AtomicSwapSenderQuery`, `AtomicSwapIdQuery`,
   `AtomicSwapHashlockQuery`, `isAtomicSwap*Query`.
-* @iov/bcp: Rename `bnsSwapQueryTags` to `bnsSwapQueryTag`
-* @iov/bcp: Let `SwapOfferTransaction` take a `hash` instead of a `preimage`.
-* @iov/bcp: Rename `SwapData.hashlock` to `SwapData.hash`
-* @iov/bcp: Remove `SwapCounterTransaction` in favour of
-  `SwapOfferTransaction` for both offer and counter offer.
-* @iov/bcp: Transaction fee data (including gas data) is now stored under a `fee` key.
-* @iov/bcp: Rename `SwapTimeoutTransaction` to `SwapAbortTransaction` and
+- @iov/bcp: Rename `bnsSwapQueryTags` to `bnsSwapQueryTag`
+- @iov/bcp: Let `SwapOfferTransaction` take a `hash` instead of a `preimage`.
+- @iov/bcp: Rename `SwapData.hashlock` to `SwapData.hash`
+- @iov/bcp: Remove `SwapCounterTransaction` in favour of `SwapOfferTransaction`
+  for both offer and counter offer.
+- @iov/bcp: Transaction fee data (including gas data) is now stored under a
+  `fee` key.
+- @iov/bcp: Rename `SwapTimeoutTransaction` to `SwapAbortTransaction` and
   `isSwapTimeoutTransaction` to `isSwapAbortTransaction`.
-* @iov/bcp: Convert type `Nonce` from Int53 to number to simplify use over
+- @iov/bcp: Convert type `Nonce` from Int53 to number to simplify use over
   JavaScript and JSON interfaces.
-* @iov/bns: Remove `bnsNonceTag` in favour of `BcpTxQuery.signedBy`.
-* @iov/core: Remove wallet ID argument from `MultiChainSigner.signAndPost`
-* @iov/core: Rename `JsonRpcSigningServer` to `JsRpcSigningServer` and convert
+- @iov/bns: Remove `bnsNonceTag` in favour of `BcpTxQuery.signedBy`.
+- @iov/core: Remove wallet ID argument from `MultiChainSigner.signAndPost`
+- @iov/core: Rename `JsonRpcSigningServer` to `JsRpcSigningServer` and convert
   interface from JSON to JavaScript.
-* @iov/encoding: Remove `Uint32.asNumber`. Use `Uint32.toNumber` instead.
-* @iov/ethereum: The `options` parameter of `ethereumConnector` does not allow
+- @iov/encoding: Remove `Uint32.asNumber`. Use `Uint32.toNumber` instead.
+- @iov/ethereum: The `options` parameter of `ethereumConnector` does not allow
   strings anymore. Use `{ wsUrl: myWebsocketUrl }` instead.
-* @iov/jsonrpc: Make request and response types generic in `SimpleMessagingConnection`.
-* @iov/keycontrol: Remove `HdPaths.metamaskHdKeyTree`. Use `HdPaths.ethereum` instead.
-* @iov/keycontrol: `Keyring.getWallet` and `Keyring.getWallets` return the
+- @iov/jsonrpc: Make request and response types generic in
+  `SimpleMessagingConnection`.
+- @iov/keycontrol: Remove `HdPaths.metamaskHdKeyTree`. Use `HdPaths.ethereum`
+  instead.
+- @iov/keycontrol: `Keyring.getWallet` and `Keyring.getWallets` return the
   immutable type ReadonlyWallet now. New functions to mutate wallets are added:
   `Keyring.setWalletLabel`, `.createIdentity`, `.setIdentityLabel` are added.
-* @iov/keycontrol: Let `Keyring.addWallet` return a `WalletInfo` object
-* @iov/keycontrol: `Keyring.addWallet` now stores a copy of the wallet
-* @iov/keycontrol: Identities now must be unique in `Keyring`.
-* @iov/keycontrol: Remove identity argument from `UserProfile.signTransaction`
-* @iov/keycontrol: Remove wallet ID argument from `UserProfile.signTransaction`,
+- @iov/keycontrol: Let `Keyring.addWallet` return a `WalletInfo` object
+- @iov/keycontrol: `Keyring.addWallet` now stores a copy of the wallet
+- @iov/keycontrol: Identities now must be unique in `Keyring`.
+- @iov/keycontrol: Remove identity argument from `UserProfile.signTransaction`
+- @iov/keycontrol: Remove wallet ID argument from `UserProfile.signTransaction`,
   `.appendSignature`, `.setIdentityLabel` and `.getIdentityLabel` as well as
   `Keyring.setIdentityLabel`.
-* @iov/ledger-bns: Package removed from this monorepo and now available at
+- @iov/ledger-bns: Package removed from this monorepo and now available at
   https://github.com/iov-one/iov-ledger-bns
-* @iov/iov-core: Constructor of `SigningServerCore` now takes two arguments for
+- @iov/iov-core: Constructor of `SigningServerCore` now takes two arguments for
   authozization callbacks.
 
 ## 0.12.3
 
-* @iov/ethereum: Add missing dependencies on @iov/socket and @iov/stream
-* @iov/ethereum: Export `toChecksummedAddress`
+- @iov/ethereum: Add missing dependencies on @iov/socket and @iov/stream
+- @iov/ethereum: Export `toChecksummedAddress`
 
 ## 0.12.2
 
-* @iov/crypto: Add `Secp256k1.recoverPubkey` to recover pubkey from signature
+- @iov/crypto: Add `Secp256k1.recoverPubkey` to recover pubkey from signature
   and message
-* @iov/ethereum: Implement pubkey recovery when parsing transaction in search
-  by transaction ID.
-* @iov/ethereum: Transaction parsing now works for pre-EIP155 signatures
-* @iov/ethereum: Let listenTx/liveTx return signer's pubkey
-* @iov/ethereum: Let `.getAccount` return undefined when balance is 0
+- @iov/ethereum: Implement pubkey recovery when parsing transaction in search by
+  transaction ID.
+- @iov/ethereum: Transaction parsing now works for pre-EIP155 signatures
+- @iov/ethereum: Let listenTx/liveTx return signer's pubkey
+- @iov/ethereum: Let `.getAccount` return undefined when balance is 0
 
 ## 0.12.1
 
-* @iov/bns: Encode transaction fees
-* @iov/bns: Export `ChainAddressPair`
-* @iov/ethereum: Allow passing `EthereumConnectionOptions` instead of websocket
+- @iov/bns: Encode transaction fees
+- @iov/bns: Export `ChainAddressPair`
+- @iov/ethereum: Allow passing `EthereumConnectionOptions` instead of websocket
   URL into second `ethereumConnector` parameter.
 
 ## 0.11.3
 
-* @iov/ethereum: Allow passing `EthereumConnectionOptions` instead of websocket
+- @iov/ethereum: Allow passing `EthereumConnectionOptions` instead of websocket
   URL into second `ethereumConnector` parameter.
 
 ## 0.12.0
 
 Breaking changes
 
-* @iov/bcp-types: Remove `Bcp*` prefix from `BcpAccount`, `BcpAccountQuery`,
+- @iov/bcp-types: Remove `Bcp*` prefix from `BcpAccount`, `BcpAccountQuery`,
   `BcpAddressQuery`, `BcpPubkeyQuery`
-* @iov/bcp-types: Remove `Account.name` in favour of BNS' username NFTs.
-* @iov/bcp-types: Remove `BcpConnection.changeBlock` along with its implementations
-  in favour of `BcpConnection.watchBlockHeaders`.
-* @iov/bcp-types: Remove `BcpQueryEnvelope` and `dummyEnvelope`
-* @iov/bcp-types: Change return type of `BcpAtomicSwapConnection.getSwap` to promise
-  of `ReadonlyArray<BcpAtomicSwap>`.
-* @iov/bcp-types: Rename methods to plural: `BcpAtomicSwapConnection.getSwaps`
+- @iov/bcp-types: Remove `Account.name` in favour of BNS' username NFTs.
+- @iov/bcp-types: Remove `BcpConnection.changeBlock` along with its
+  implementations in favour of `BcpConnection.watchBlockHeaders`.
+- @iov/bcp-types: Remove `BcpQueryEnvelope` and `dummyEnvelope`
+- @iov/bcp-types: Change return type of `BcpAtomicSwapConnection.getSwap` to
+  promise of `ReadonlyArray<BcpAtomicSwap>`.
+- @iov/bcp-types: Rename methods to plural: `BcpAtomicSwapConnection.getSwaps`
   and `.watchSwaps`.
-* @iov/bns: Binary compatibility for weave v0.10.x+ (breaks for all earlier versions)
-* @iov/bns: Remove obsolete `SetNameTx`
-* @iov/bns: Remove `BnsConnection.status`
+- @iov/bns: Binary compatibility for weave v0.10.x+ (breaks for all earlier
+  versions)
+- @iov/bns: Remove obsolete `SetNameTx`
+- @iov/bns: Remove `BnsConnection.status`
 
 ## 0.11.2
 
-* @iov/cli: Import Lisk, RISE and Ethereum symbols automatically
-* @iov/ethereum: Expose `pubkeyToAddress`
+- @iov/cli: Import Lisk, RISE and Ethereum symbols automatically
+- @iov/ethereum: Expose `pubkeyToAddress`
 
 ## 0.11.1
 
-* @iov/ethereum: Fix error reporting when signing and sending transactions
-* @iov/keycontrol: Add `HdPaths.ethereum` for Ethereum HD path derivation
-* @iov/keycontrol: Deprecate `HdPaths.metamaskHdKeyTree` in favour of `HdPaths.ethereum`
+- @iov/ethereum: Fix error reporting when signing and sending transactions
+- @iov/keycontrol: Add `HdPaths.ethereum` for Ethereum HD path derivation
+- @iov/keycontrol: Deprecate `HdPaths.metamaskHdKeyTree` in favour of
+  `HdPaths.ethereum`
 
 ## 0.11.0
 
-* @iov/bcp-types: `BcpConnection.getNonce` now returns a `Promise<Nonce>` and
+- @iov/bcp-types: `BcpConnection.getNonce` now returns a `Promise<Nonce>` and
   implementations set a default value on their own.
-* @iov/bcp-types: Expose `publicKeyBundleEquals`
-* @iov/bcp-types: Add `fractionalDigits` to `BcpTicker`
-* @iov/ethereum: Add new package with Ethereum support
-* @iov/jsonrpc: Add new package for type-safe JSON-RPC 2.0 interfaces and
-  response parsers. This is used for out-of-process signing and can be reused
-  in @iov/ethereum and @iov/tendermint-rpc later on.
-* @iov/keycontrol: Add `HdPaths.bip44Like` and `HdPaths.iov`
-* @iov/iov-core: Add `MultiChainSigner.shutdown` to shutdown the signer.
-* @iov/iov-core: Add `MultiChainSigner.isValidAddress` for chain-specific address input validation.
-* @iov/stream: Add an implementation of `concat` that buffers stream events
-* @iov/stream: Add `firstEvent` as a special case of `toListPromise` with one element
-* @iov/tendermint-rpc: Add support for Tendermint 0.27.x
+- @iov/bcp-types: Expose `publicKeyBundleEquals`
+- @iov/bcp-types: Add `fractionalDigits` to `BcpTicker`
+- @iov/ethereum: Add new package with Ethereum support
+- @iov/jsonrpc: Add new package for type-safe JSON-RPC 2.0 interfaces and
+  response parsers. This is used for out-of-process signing and can be reused in
+  @iov/ethereum and @iov/tendermint-rpc later on.
+- @iov/keycontrol: Add `HdPaths.bip44Like` and `HdPaths.iov`
+- @iov/iov-core: Add `MultiChainSigner.shutdown` to shutdown the signer.
+- @iov/iov-core: Add `MultiChainSigner.isValidAddress` for chain-specific
+  address input validation.
+- @iov/stream: Add an implementation of `concat` that buffers stream events
+- @iov/stream: Add `firstEvent` as a special case of `toListPromise` with one
+  element
+- @iov/tendermint-rpc: Add support for Tendermint 0.27.x
 
 Breaking changes
 
-* @iov/tendermint-rpc: Changed some interfaces to remove dependency on
+- @iov/tendermint-rpc: Changed some interfaces to remove dependency on
   base-types. `PostableBytes` -> `TxBytes`, `PublicKeyBundle` ->
   `ValidatorPubkey`, `ChainId` -> `string`.
-* @iov/base-types: Package removed and all its types are now in @iov/bcp-types.
-* @iov/bcp-types: Convert `TxReadCodec.keyToAddress` into
+- @iov/base-types: Package removed and all its types are now in @iov/bcp-types.
+- @iov/bcp-types: Convert `TxReadCodec.keyToAddress` into
   `identityToAddress(identity: PublicIdentity)`
-* @iov/bcp-types: `BcpConnection.watchNonce` and all its implementations were removed
-* @iov/bcp-types: Return type of `BcpConnection.getAccount` was changed to
+- @iov/bcp-types: `BcpConnection.watchNonce` and all its implementations were
+  removed
+- @iov/bcp-types: Return type of `BcpConnection.getAccount` was changed to
   `BcpAccount | undefined` to better represent the one-or-none result.
-* @iov/bcp-types: Remove `BcpValueNameQuery` from `.getAccount` and `.watchAccount`
-  as we're migrating from wallet nicknames to username NFTs.
-* @iov/bcp-types: Convert `BcpQueryEnvelope` to `ReadonlyArray` in return
-  type of `BcpConnection.getAllTickers`.
-* @iov/bcp-types: Convert `BcpQueryEnvelope` to `BcpTicker | undefined` in return
-  type of `BcpConnection.getTicker`.
-* @iov/bcp-types: Migrate `UnsignedTransaction.chainId` and `.signer` into `.creator`
-* @iov/bcp-types: Add `BcpConnection.getNonces`
-* @iov/bcp-types: Add `BcpTxQuery.sentFromOrTo` in favour of package-specific address tags
-* @iov/bcp-types: Removed `Bcp` prefix from `BcpTransactionState`, `BcpBlockInfoPending`,
-  `BcpBlockInfoInBlock`, `BcpBlockInfo`.
-* @iov/bcp-types: Add block info state `BlockInfoFailed`.
-* @iov/bcp-types: Handle failed transactions in `searchTx`/`listenTx`/`liveTx` and `postTx`.
-* @iov/bns: Convert `.owner` in `BnsUsernameNft` and `BnsBlockchainNft` to `Address`
-* @iov/bns: In `BncConnection.watchBlockHeaders`, the block header events
+- @iov/bcp-types: Remove `BcpValueNameQuery` from `.getAccount` and
+  `.watchAccount` as we're migrating from wallet nicknames to username NFTs.
+- @iov/bcp-types: Convert `BcpQueryEnvelope` to `ReadonlyArray` in return type
+  of `BcpConnection.getAllTickers`.
+- @iov/bcp-types: Convert `BcpQueryEnvelope` to `BcpTicker | undefined` in
+  return type of `BcpConnection.getTicker`.
+- @iov/bcp-types: Migrate `UnsignedTransaction.chainId` and `.signer` into
+  `.creator`
+- @iov/bcp-types: Add `BcpConnection.getNonces`
+- @iov/bcp-types: Add `BcpTxQuery.sentFromOrTo` in favour of package-specific
+  address tags
+- @iov/bcp-types: Removed `Bcp` prefix from `BcpTransactionState`,
+  `BcpBlockInfoPending`, `BcpBlockInfoInBlock`, `BcpBlockInfo`.
+- @iov/bcp-types: Add block info state `BlockInfoFailed`.
+- @iov/bcp-types: Handle failed transactions in `searchTx`/`listenTx`/`liveTx`
+  and `postTx`.
+- @iov/bns: Convert `.owner` in `BnsUsernameNft` and `BnsBlockchainNft` to
+  `Address`
+- @iov/bns: In `BncConnection.watchBlockHeaders`, the block header events
   temporarily contain a dummy `id` string until ID calculation is implemented
-* @iov/core: Remove `MultiChainSigner.getNonce`. If you really need this, use
+- @iov/core: Remove `MultiChainSigner.getNonce`. If you really need this, use
   `signer.connection(chainId).getNonce({ address: addr })` instead.
-* @iov/core: Removed BNS re-exports `bnsConnector`, `bnsFromOrToTag`,
+- @iov/core: Removed BNS re-exports `bnsConnector`, `bnsFromOrToTag`,
   `bnsNonceTag`, `bnsSwapQueryTags`. Import them from @iov/bns.
-* @iov/core: Convert `MultiChainSigner.keyToAddress` into
+- @iov/core: Convert `MultiChainSigner.keyToAddress` into
   `identityToAddress(identity: PublicIdentity)`
-* @iov/keycontrol: Move `PublicIdentity` into @iov/bcp-types; add `chainId`
-* @iov/keycontrol: Add chain ID argument to `UserProfile.createIdentity` and
+- @iov/keycontrol: Move `PublicIdentity` into @iov/bcp-types; add `chainId`
+- @iov/keycontrol: Add chain ID argument to `UserProfile.createIdentity` and
   `Wallet.createIdentity`
-* @iov/keycontrol: Remove redundant chainId parameter from
+- @iov/keycontrol: Remove redundant chainId parameter from
   `Wallet.createTransactionSignature`
-* @iov/keycontrol: Remove `LocalIdentity`/`LocalIdentityId` and create
+- @iov/keycontrol: Remove `LocalIdentity`/`LocalIdentityId` and create
   `UserProdile.getIdentityLabel` to provide labels
-* @iov/tendermint-rpc: Remove support for Tendermint 0.20 and 0.21
-* @iov/tendermint-rpc: Rename `TxResponse.txResult` -> `.result`
-* @iov/crypto: Remove support for ripemd160
+- @iov/tendermint-rpc: Remove support for Tendermint 0.20 and 0.21
+- @iov/tendermint-rpc: Rename `TxResponse.txResult` -> `.result`
+- @iov/crypto: Remove support for ripemd160
 
 ## 0.10.4
 
-* @iov/lisk: Implement `LiskConnection.watchAccount`
-* @iov/lisk: Support search by address tag in `LiskConnection.searchTx`
-* @iov/lisk: Support search by minHeight/maxHeight in `LiskConnection.searchTx`
-* @iov/lisk: Implement `LiskConnection.liveTx`
-* @iov/rise: Implement `RiseConnection.watchAccount`
-* @iov/rise: Support search by address tag in `RiseConnection.searchTx`
-* @iov/keycontrol: Fix parameter type of `UserProfile.createIdentity` to allow
+- @iov/lisk: Implement `LiskConnection.watchAccount`
+- @iov/lisk: Support search by address tag in `LiskConnection.searchTx`
+- @iov/lisk: Support search by minHeight/maxHeight in `LiskConnection.searchTx`
+- @iov/lisk: Implement `LiskConnection.liveTx`
+- @iov/rise: Implement `RiseConnection.watchAccount`
+- @iov/rise: Support search by address tag in `RiseConnection.searchTx`
+- @iov/keycontrol: Fix parameter type of `UserProfile.createIdentity` to allow
   creating identities using `Ed25519Keypair`.
 
 ## 0.10.3
 
-* @iov/cli: Fix levelup import
+- @iov/cli: Fix levelup import
 
 ## 0.10.2
 
-* @iov/bcp-types: Add `BcpAccount.pubkey` and implement in Lisk, RISE and BNS.
-* @iov/core: `MultiChainSigner.getNonce` was deprecated.
+- @iov/bcp-types: Add `BcpAccount.pubkey` and implement in Lisk, RISE and BNS.
+- @iov/core: `MultiChainSigner.getNonce` was deprecated.
 
 ## 0.10.1
 
-* @iov/tendermint-rpc: convert `const enum`s to `enum`s in public interface to
+- @iov/tendermint-rpc: convert `const enum`s to `enum`s in public interface to
   allow callers to use `--isolatedModules`.
 
 ## 0.10.0
 
-* @iov/bcp-types: `BcpTransactionResponse` now contains a `blockInfo` property
-  that allows you to get block related data associated with the transactions
-  and subscribing to updates. `metadata` was deprecated in favour of `blockInfo`.
-* @iov/bcp-types: the new interfaces `getBlockHeader` and `watchBlockHeaders`
+- @iov/bcp-types: `BcpTransactionResponse` now contains a `blockInfo` property
+  that allows you to get block related data associated with the transactions and
+  subscribing to updates. `metadata` was deprecated in favour of `blockInfo`.
+- @iov/bcp-types: the new interfaces `getBlockHeader` and `watchBlockHeaders`
   provide block header information.
-* @iov/bns: Fix encoding of `BcpTxQuery.hash` in `listenTx` and `liveTx`
-* @iov/socket: New package with wrappers around WebSockets: `SocketWrapper`
-  and `StreamingSocket` used by tendermint-rpc and Ethereum.
-* @iov/stream: Add `toListPromise` that collects stream events and returns a
+- @iov/bns: Fix encoding of `BcpTxQuery.hash` in `listenTx` and `liveTx`
+- @iov/socket: New package with wrappers around WebSockets: `SocketWrapper` and
+  `StreamingSocket` used by tendermint-rpc and Ethereum.
+- @iov/stream: Add `toListPromise` that collects stream events and returns a
   list when done.
-* @iov/stream: `ValueAndUpdates.waitFor` now returns the values that matched
-  the search condition.
-* @iov/stream: `DefaultValueProducerCallsbacks.error` added to produce errors.
-* @iov/tendermint-rpc: Gracefully handle duplicate subscriptions.
+- @iov/stream: `ValueAndUpdates.waitFor` now returns the values that matched the
+  search condition.
+- @iov/stream: `DefaultValueProducerCallsbacks.error` added to produce errors.
+- @iov/tendermint-rpc: Gracefully handle duplicate subscriptions.
 
 Breaking changes
 
-* @iov/base-types: Remove `TxId` in favour of `TxHash` in @iov/tendermint-rpc.
-* @iov/bcp-types: An `Amount` is now a `quantity` expressed as a string, a
+- @iov/base-types: Remove `TxId` in favour of `TxHash` in @iov/tendermint-rpc.
+- @iov/bcp-types: An `Amount` is now a `quantity` expressed as a string, a
   `fractionalDigits` number and a `tokenTicker`. This replaces the `whole`,
-  `fractional` pair. `BcpTicker` does not contain `sigFigs` anymore because
-  it is not needed there. `BcpCoin` is now an `Amount` and a `BcpTicker`.
-* @iov/bcp-types: Wrapper type `BcpNonce` was dropped from all interfaces
-  in favour of just `Nonce`.
-* @iov/bcp-types: `BcpConnection.getNonce`/`.watchNonce` now only accept
+  `fractional` pair. `BcpTicker` does not contain `sigFigs` anymore because it
+  is not needed there. `BcpCoin` is now an `Amount` and a `BcpTicker`.
+- @iov/bcp-types: Wrapper type `BcpNonce` was dropped from all interfaces in
+  favour of just `Nonce`.
+- @iov/bcp-types: `BcpConnection.getNonce`/`.watchNonce` now only accept
   `BcpAddressQuery` or `BcpPubkeyQuery` as argument type.
-* @iov/bcp-types: `BcpConnection.listenTx` now takes an `BcpTxQuery` argument
+- @iov/bcp-types: `BcpConnection.listenTx` now takes an `BcpTxQuery` argument
   analogue to `.searchTx` and `.liveTx`.
-* @iov/bcp-types: `BcpTransactionResponse` was removed in favour of the new
+- @iov/bcp-types: `BcpTransactionResponse` was removed in favour of the new
   `PostTxResponse`.
-* @iov/bcp-types: Change binary `TransactionIdBytes` to printable
+- @iov/bcp-types: Change binary `TransactionIdBytes` to printable
   `TransactionId` and use in `TxCodec.identifier`, `PostTxResponse` and
   `BcpTxQuery`.
-* @iov/bcp-types: `BcpTxQuery.tags` is now optional
-* @iov/bcp-types: Remove type `RecipientId`; use `Address` instead.
-* @iov/bcp-types: Remove unused `BaseTx.ttl` and `TtlBytes`
-* @iov/bcp-types: Allow extension of transaction types: move BNS transactions
+- @iov/bcp-types: `BcpTxQuery.tags` is now optional
+- @iov/bcp-types: Remove type `RecipientId`; use `Address` instead.
+- @iov/bcp-types: Remove unused `BaseTx.ttl` and `TtlBytes`
+- @iov/bcp-types: Allow extension of transaction types: move BNS transactions
   into @iov/bns, rename generic ones to `SendTransaction` and
-  `Swap{Offer,Claim,Counter,Timeout}Transaction`. Property `kind` is now
-  a string in the format "{domain}/{concrete_type}", e.g. "bcp/send" or
+  `Swap{Offer,Claim,Counter,Timeout}Transaction`. Property `kind` is now a
+  string in the format "{domain}/{concrete_type}", e.g. "bcp/send" or
   "bns/set_name".
-* @iov/bns: `BnsConnection.postTx` now resolves before a transaction is in a
+- @iov/bns: `BnsConnection.postTx` now resolves before a transaction is in a
   block. The field `blockInfo` of its response can be used to track the
   transaction state.
-* @iov/bns: `getHeader`/`watchHeaders` were removed in favour of
+- @iov/bns: `getHeader`/`watchHeaders` were removed in favour of
   `getBlockHeader`/`watchBlockHeaders` from BCP.
-* @iov/core: Rename `MultiChainSigner.signAndCommit` -> `.signAndPost`
-* @iov/crpto: the new types `Secp256k1Signature` and `ExtendedSecp256k1Signature` replace DER encoded signatures in `Secp256k1`.
-* @iov/faucets: Remove `BovFaucet`. Use `IovFaucet` instead.
-* @iov/keycontrol: `Secp256k1HdWallet.createTransactionSignature` now uses the custom fixed length encoding instead of DER to allow blockchains utilizing the recovery parameter.
-* @iov/stream: `streamPromise` was renamed to `fromListPromise`.
-* @iov/tendermint-rpc: Rename `txCommitSuccess` to `broadcastTxCommitSuccess` and add `broadcastTxSyncSuccess`
-* @iov/tendermint-rpc: Remove all fields from `BroadcastTxAsyncResponse`
-* @iov/tendermint-rpc: Change type of `BroadcastTxSyncResponse.hash` to `TxId`
-* @iov/tendermint-rpc: Un-export interface `RpcTxEvent`
-* @iov/tendermint-rpc: Change all `Method` enum names to PascalCase
-* @iov/tendermint-rpc: `Client.subscribeTx` now takes a `QueryString` argument
-* @iov/tendermint-rpc: Support for Tendermint version 0.20.0 and 0.21.0 is
+- @iov/core: Rename `MultiChainSigner.signAndCommit` -> `.signAndPost`
+- @iov/crpto: the new types `Secp256k1Signature` and
+  `ExtendedSecp256k1Signature` replace DER encoded signatures in `Secp256k1`.
+- @iov/faucets: Remove `BovFaucet`. Use `IovFaucet` instead.
+- @iov/keycontrol: `Secp256k1HdWallet.createTransactionSignature` now uses the
+  custom fixed length encoding instead of DER to allow blockchains utilizing the
+  recovery parameter.
+- @iov/stream: `streamPromise` was renamed to `fromListPromise`.
+- @iov/tendermint-rpc: Rename `txCommitSuccess` to `broadcastTxCommitSuccess`
+  and add `broadcastTxSyncSuccess`
+- @iov/tendermint-rpc: Remove all fields from `BroadcastTxAsyncResponse`
+- @iov/tendermint-rpc: Change type of `BroadcastTxSyncResponse.hash` to `TxId`
+- @iov/tendermint-rpc: Un-export interface `RpcTxEvent`
+- @iov/tendermint-rpc: Change all `Method` enum names to PascalCase
+- @iov/tendermint-rpc: `Client.subscribeTx` now takes a `QueryString` argument
+- @iov/tendermint-rpc: Support for Tendermint version 0.20.0 and 0.21.0 is
   deprecated and will be removed in the next version of IOV-Core. If you need
   support for Tendermint < 0.25.0, please open an issue on Github and we'll
   maintain it.
 
 ## 0.9.3
 
-* @iov/bns: Add missing error propagation from `searchTx`/`listenTx` into `liveTx` stream.
+- @iov/bns: Add missing error propagation from `searchTx`/`listenTx` into
+  `liveTx` stream.
 
 ## 0.9.2
 
-* @iov/bns: Add `getHeader` and `watchHeaders` methods to access block headers
+- @iov/bns: Add `getHeader` and `watchHeaders` methods to access block headers
 
 ## 0.9.1
 
-* @iov/stream: Generalize `streamPromise` to take a promise of an iterable
-* @iov/bns: Fix order of events in `listenTx`. All history tx events are now emitted before updates.
+- @iov/stream: Generalize `streamPromise` to take a promise of an iterable
+- @iov/bns: Fix order of events in `listenTx`. All history tx events are now
+  emitted before updates.
 
 ## 0.9.0
 
-* @iov/core: Export `Secp256k1HdWallet` and import by default in @iov/cli.
-* @iov/faucets: Postpone removal of `BovFaucet` to 0.10.x
+- @iov/core: Export `Secp256k1HdWallet` and import by default in @iov/cli.
+- @iov/faucets: Postpone removal of `BovFaucet` to 0.10.x
 
 Breaking changes
 
-* @iov/bcp-types: Rename `FungibleToken` to `Amount`
-* @iov/bns: Re-generate BNS codec from weave v0.9.0 and adapt wrapper types.
-* @iov/bns: Add support for blockchain and username NFTs
-* @iov/crypto: Convert pubkey of Secp256k1Keypair into uncompressed format with prefix `04`.
-* @iov/crypto: Secp256k1.createSignature/.verifySignature now comsume a message hash and do no hashing internally.
-* @iov/dpos: Rename `Amount`/`parseAmount` to `Quantity`/`parseQuantity`
-* @iov/keycontrol: Let `Secp256k1HdWallet` work on uncompressed pubkeys. Since `Secp256k1HdWallet`
-  was not used yet, there is no migration for existing `Secp256k1HdWallet`.
-* @iov/tendermint-types: Move types `PrivateKeyBundle`, `PrivateKeyBytes` into @iov/bns;
-  split `Tag` into `BcpQueryTag` in @iov/bcp-types and `QueryTag` in @iov/tendermint-rpc;
-  rename `TxQuery` into `BcpTxQuery` in @iov/bcp-types; make `SignatureBundle` available
-  in @iov/tendermint-rcp only and rename to `VoteSignatureBundle`; move `buildTxQuery` into @iov/bns.
-* @iov/tendermint-types: renamed to @iov/base-types
+- @iov/bcp-types: Rename `FungibleToken` to `Amount`
+- @iov/bns: Re-generate BNS codec from weave v0.9.0 and adapt wrapper types.
+- @iov/bns: Add support for blockchain and username NFTs
+- @iov/crypto: Convert pubkey of Secp256k1Keypair into uncompressed format with
+  prefix `04`.
+- @iov/crypto: Secp256k1.createSignature/.verifySignature now comsume a message
+  hash and do no hashing internally.
+- @iov/dpos: Rename `Amount`/`parseAmount` to `Quantity`/`parseQuantity`
+- @iov/keycontrol: Let `Secp256k1HdWallet` work on uncompressed pubkeys. Since
+  `Secp256k1HdWallet` was not used yet, there is no migration for existing
+  `Secp256k1HdWallet`.
+- @iov/tendermint-types: Move types `PrivateKeyBundle`, `PrivateKeyBytes` into
+  @iov/bns; split `Tag` into `BcpQueryTag` in @iov/bcp-types and `QueryTag` in
+  @iov/tendermint-rpc; rename `TxQuery` into `BcpTxQuery` in @iov/bcp-types;
+  make `SignatureBundle` available in @iov/tendermint-rcp only and rename to
+  `VoteSignatureBundle`; move `buildTxQuery` into @iov/bns.
+- @iov/tendermint-types: renamed to @iov/base-types
 
 ## 0.8.1
 
-* @iov/dpos: Deduplicate `Serialization` from Lisk and RISE
-* @iov/keycontrol: Add `Wallet.printableSecret` and `UserProfile.printableSecret`
-* @iov/keycontrol: Add `HdPaths.bip44` and `HdPaths.metamaskHdKeyTree` HD path builders
-* @iov/tendermint-rpc: Ensure transaction search results are sorted by height
+- @iov/dpos: Deduplicate `Serialization` from Lisk and RISE
+- @iov/keycontrol: Add `Wallet.printableSecret` and
+  `UserProfile.printableSecret`
+- @iov/keycontrol: Add `HdPaths.bip44` and `HdPaths.metamaskHdKeyTree` HD path
+  builders
+- @iov/tendermint-rpc: Ensure transaction search results are sorted by height
 
 ## 0.8.0
 
-* @iov/dpos: Add new package with shared code for Lisk and RISE. Don't use this directly. No code change necessary for users of @iov/lisk and @iov/rise.
-* @iov/faucets: add `IovFaucet` to connect to the new faucet application
-* @iov/keycontrol: add format versioning to `Wallet`, `Keyring`, keyring encryption and `UserProfile`
+- @iov/dpos: Add new package with shared code for Lisk and RISE. Don't use this
+  directly. No code change necessary for users of @iov/lisk and @iov/rise.
+- @iov/faucets: add `IovFaucet` to connect to the new faucet application
+- @iov/keycontrol: add format versioning to `Wallet`, `Keyring`, keyring
+  encryption and `UserProfile`
 
 Deprecations
 
-* @iov/faucets: `BovFaucet` is deprecated and will be removed in 0.9. Migrate to the `IovFaucet`.
+- @iov/faucets: `BovFaucet` is deprecated and will be removed in 0.9. Migrate to
+  the `IovFaucet`.
 
 Breaking changes
 
-* @iov/lisk: LiskConnection.postTx does not wait for block anymore (analogue to RiseConnection.postTx),
-  making it faster and more reliable. Transaction state tracking will improve in the future.
-* Due to updates in all serialization formats, UserProfiles stored with
-  earlier versions of IOV-Core cannot be opened with 0.8.0. To migrate to
-  the new version, extract the secret data using an older version and
-  create a new UserProfile in 0.8.0.
+- @iov/lisk: LiskConnection.postTx does not wait for block anymore (analogue to
+  RiseConnection.postTx), making it faster and more reliable. Transaction state
+  tracking will improve in the future.
+- Due to updates in all serialization formats, UserProfiles stored with earlier
+  versions of IOV-Core cannot be opened with 0.8.0. To migrate to the new
+  version, extract the secret data using an older version and create a new
+  UserProfile in 0.8.0.
 
 ## 0.7.1
 
-* @iov/lisk: Implement `LiskConnection.getTicker` and `.getAllTickers`
-* @iov/rise: Implement `RiseConnection.getTicker` and `.getAllTickers`
+- @iov/lisk: Implement `LiskConnection.getTicker` and `.getAllTickers`
+- @iov/rise: Implement `RiseConnection.getTicker` and `.getAllTickers`
 
 ## 0.7.0
 
-* @iov/bcp-types: optional field `expectedChainId` added to `ChainConnector`
-* @iov/bcp-types: `BcpConnection.getAccount` can now be called with a pubkey input
-* @iov/bcp-types: `TxReadCodec` and all its implementations now contain a `isValidAddress` method
-* @iov/core: `MultiChainSigner.addChain` now returns chain information of the chain added
-* @iov/lisk: new package to connect to the Lisk blockchain
-* @iov/rise: new package to connect to the RISE blockchain
-* @iov/encoding: bech32 encoding support for address bytes
-* @iov/keycontrol: `UserProfile.setEntry()` now returns `WalletInfo` of new wallet added, for ease of use
+- @iov/bcp-types: optional field `expectedChainId` added to `ChainConnector`
+- @iov/bcp-types: `BcpConnection.getAccount` can now be called with a pubkey
+  input
+- @iov/bcp-types: `TxReadCodec` and all its implementations now contain a
+  `isValidAddress` method
+- @iov/core: `MultiChainSigner.addChain` now returns chain information of the
+  chain added
+- @iov/lisk: new package to connect to the Lisk blockchain
+- @iov/rise: new package to connect to the RISE blockchain
+- @iov/encoding: bech32 encoding support for address bytes
+- @iov/keycontrol: `UserProfile.setEntry()` now returns `WalletInfo` of new
+  wallet added, for ease of use
 
 Breaking changes
 
-* @iov/bcp-types: `Address` is now a `string` instead of an `Uint8Array`
-* @iov/bcp-types: `BcpTransactionResponse.metadata.success` was removed since failures are reported as promise rejections
-* @iov/bcp-types: `Nonce` is now implemented by `Int53` from @iov/encoding instead of `Long`
-* @iov/bns: `Client` was renamed to `BnsConnection`. The `connect()` function was renamed to `BnsConnection.establish()`
-* @iov/core: rename `IovWriter` to `MultiChainSigner`
-* @iov/core: rename the getter `reader` to `connection` in `MultiChainSigner`
-* @iov/faucets: `BovFaucet.credit` now expects an address in bech32 format
-* @iov/keycontrol: `Ed25519KeyringEntry` now takes a keypair as an argument in `createIdentity()`
-* @iov/keycontrol: `Ed25519SimpleAddressKeyringEntry` was removed in favour of `Ed25519HdWallet` together with `HdPaths.simpleAddress`
-* @iov/keycontrol: in `UserProfile`, `.entriesCount`, `.entryLabels` and `.entryIds` have been merged into `.wallets`
-* @iov/keycontrol: in `UserProfile`, `.setEntryLabel`, `.createIdentity`, `.setIdentityLabel`, `.getIdentities`, `.signTransaction`, `.appendSignature` now only accept string IDs for the entry/wallet argument
-* @iov/keycontrol: `DefaultValueProducer` and `ValueAndUpdates` moved into @iov/stream
-* @iov/keycontrol: `KeyringEntry.createIdentity` now takes a required options argument of type `Ed25519KeyringEntry | ReadonlyArray<Slip10RawIndex> | number`
-* @iov/keycontrol: rename symbols to `Wallet`, `WalletId`, `WalletImplementationIdString`, `WalletSerializationString`
-* @iov/keycontrol: rename `Ed25519KeyringEntry` to `Ed25519WalletId`
-* @iov/keycontrol: in `Keyring`, rename `.getEntries/.getEntryById` to `.getWallets/.getWallet`
-* @iov/keycontrol: in `Keyring`, remove obsolete `.getEntryByIndex`
-* @iov/keycontrol: in `UserProfile`, rename `.addEntry/.setEntryLabel` to `.addWallet/.setWalletLabel`
-* @iov/ledger-bns: in `LedgerSimpleAddressKeyringEntry`, `.createIdentity` takes an index argument
-* @iov/ledger-bns: rename `LedgerSimpleAddressKeyringEntry` to `LedgerSimpleAddressWallet`
-* Due to updates in the Keyring serialization, UserProfiles stored with
-  earlier versions of IOV-Core cannot be opened with 0.7.0. To migrate to
-  the new version, extract the secret data using an older version and
-  create a new UserProfile in 0.7.0.
+- @iov/bcp-types: `Address` is now a `string` instead of an `Uint8Array`
+- @iov/bcp-types: `BcpTransactionResponse.metadata.success` was removed since
+  failures are reported as promise rejections
+- @iov/bcp-types: `Nonce` is now implemented by `Int53` from @iov/encoding
+  instead of `Long`
+- @iov/bns: `Client` was renamed to `BnsConnection`. The `connect()` function
+  was renamed to `BnsConnection.establish()`
+- @iov/core: rename `IovWriter` to `MultiChainSigner`
+- @iov/core: rename the getter `reader` to `connection` in `MultiChainSigner`
+- @iov/faucets: `BovFaucet.credit` now expects an address in bech32 format
+- @iov/keycontrol: `Ed25519KeyringEntry` now takes a keypair as an argument in
+  `createIdentity()`
+- @iov/keycontrol: `Ed25519SimpleAddressKeyringEntry` was removed in favour of
+  `Ed25519HdWallet` together with `HdPaths.simpleAddress`
+- @iov/keycontrol: in `UserProfile`, `.entriesCount`, `.entryLabels` and
+  `.entryIds` have been merged into `.wallets`
+- @iov/keycontrol: in `UserProfile`, `.setEntryLabel`, `.createIdentity`,
+  `.setIdentityLabel`, `.getIdentities`, `.signTransaction`, `.appendSignature`
+  now only accept string IDs for the entry/wallet argument
+- @iov/keycontrol: `DefaultValueProducer` and `ValueAndUpdates` moved into
+  @iov/stream
+- @iov/keycontrol: `KeyringEntry.createIdentity` now takes a required options
+  argument of type
+  `Ed25519KeyringEntry | ReadonlyArray<Slip10RawIndex> | number`
+- @iov/keycontrol: rename symbols to `Wallet`, `WalletId`,
+  `WalletImplementationIdString`, `WalletSerializationString`
+- @iov/keycontrol: rename `Ed25519KeyringEntry` to `Ed25519WalletId`
+- @iov/keycontrol: in `Keyring`, rename `.getEntries/.getEntryById` to
+  `.getWallets/.getWallet`
+- @iov/keycontrol: in `Keyring`, remove obsolete `.getEntryByIndex`
+- @iov/keycontrol: in `UserProfile`, rename `.addEntry/.setEntryLabel` to
+  `.addWallet/.setWalletLabel`
+- @iov/ledger-bns: in `LedgerSimpleAddressKeyringEntry`, `.createIdentity` takes
+  an index argument
+- @iov/ledger-bns: rename `LedgerSimpleAddressKeyringEntry` to
+  `LedgerSimpleAddressWallet`
+- Due to updates in the Keyring serialization, UserProfiles stored with earlier
+  versions of IOV-Core cannot be opened with 0.7.0. To migrate to the new
+  version, extract the secret data using an older version and create a new
+  UserProfile in 0.7.0.
 
 ## 0.6.1
 
-* @iov/keycontrol: add Ed25519HdWallet and Secp256k1HdWallet that work like Ed25519SimpleAddressKeyringEntry but allow derivation of arbirtary SLIP-0010 paths
-* @iov/core: move ChainConnector into @iov/bcp-types to avoid new chains to depend on @iov/core
-* @iov/bcp-types: various refactorings to improve multi chain support
+- @iov/keycontrol: add Ed25519HdWallet and Secp256k1HdWallet that work like
+  Ed25519SimpleAddressKeyringEntry but allow derivation of arbirtary SLIP-0010
+  paths
+- @iov/core: move ChainConnector into @iov/bcp-types to avoid new chains to
+  depend on @iov/core
+- @iov/bcp-types: various refactorings to improve multi chain support
 
 Other notes
 
-* The new name for keyring entries is "wallet". A keyring contains multiple wallets. This transition was started
-  with the intoduction of Ed25519HdWallet and Secp256k1HdWallet and other incompatible API changes will follow in 0.7.
-* We welcome our first external code contributor @SpasZahariev! If you want to get familiar woth the codebase,
-  check the issues labeled with "good first issue".
+- The new name for keyring entries is "wallet". A keyring contains multiple
+  wallets. This transition was started with the intoduction of Ed25519HdWallet
+  and Secp256k1HdWallet and other incompatible API changes will follow in 0.7.
+- We welcome our first external code contributor @SpasZahariev! If you want to
+  get familiar woth the codebase, check the issues labeled with "good first
+  issue".
 
 ## 0.6.0
 
-* @iov/core: expose Ed25519KeyringEntry
-* @iov/keycontrol: refactor entry ID generation
-* @iov/bcp-types: rename interface IovReader -> BcpConnection
-* @iov/bcp-types: make BcpConnection.chainId() synchronous for easier use by clients
-* @iov/bns: expose transaction result
-* @iov/bns: expose atomic swap queries on the bns client
-* @iov/bns: transaction search can handle unlimited number of results
+- @iov/core: expose Ed25519KeyringEntry
+- @iov/keycontrol: refactor entry ID generation
+- @iov/bcp-types: rename interface IovReader -> BcpConnection
+- @iov/bcp-types: make BcpConnection.chainId() synchronous for easier use by
+  clients
+- @iov/bns: expose transaction result
+- @iov/bns: expose atomic swap queries on the bns client
+- @iov/bns: transaction search can handle unlimited number of results
 
 Breaking changes
 
-* Due to updates in the Keyring serialization, UserProfiles stored with
-  earlier versions of IOV-Core cannot be opened with 0.6.0. To migrate to
-  the new version, extract the secret data using an older version and
-  create a new UserProfile in 0.6.0.
+- Due to updates in the Keyring serialization, UserProfiles stored with earlier
+  versions of IOV-Core cannot be opened with 0.6.0. To migrate to the new
+  version, extract the secret data using an older version and create a new
+  UserProfile in 0.6.0.
 
 ## 0.5.4
 
-* @iov/cli: fix global installation support
+- @iov/cli: fix global installation support
 
 ## 0.5.3
 
-* @iov/core and @iov/keycontrol: use strict types for keyring entry IDs
+- @iov/core and @iov/keycontrol: use strict types for keyring entry IDs
 
 ## 0.5.2
 
-* @iov/bns: increase transaction search results to 100 items
-* @iov/core and @iov/keycontrol: add keyring entry IDs
-* @iov/keycontrol: ensure Ed25519SimpleAddressKeyringEntry.fromEntropyWithCurve/ and .fromMnemonicWithCurve return the correct type
+- @iov/bns: increase transaction search results to 100 items
+- @iov/core and @iov/keycontrol: add keyring entry IDs
+- @iov/keycontrol: ensure Ed25519SimpleAddressKeyringEntry.fromEntropyWithCurve/
+  and .fromMnemonicWithCurve return the correct type
 
-**Note: this version was published with an outdated build
-and should not be used**
+**Note: this version was published with an outdated build and should not be
+used**
 
 ## 0.5.1
 
-* @iov/bns: expose transaction IDs
+- @iov/bns: expose transaction IDs
 
 ## 0.5.0
 
-* @iov/bns: Add support of listening to change events, watching accounts, txs
-* @iov/core: Simplify construction of IovWriter
-* @iov/crypto: Rename all `Slip0010*` symbols to `Slip10*`
-* @iov/crypto: Fix keypair representation of Secp256k1.makeKeypair
-* @iov/tendermint: Add support for subscribing to events
+- @iov/bns: Add support of listening to change events, watching accounts, txs
+- @iov/core: Simplify construction of IovWriter
+- @iov/crypto: Rename all `Slip0010*` symbols to `Slip10*`
+- @iov/crypto: Fix keypair representation of Secp256k1.makeKeypair
+- @iov/tendermint: Add support for subscribing to events
 
 Breaking changes
 
-* Due to multi curve support in keyring entries, UserProfiles stored with
-  earlier versions of IOV-Core cannot be opened with 0.5.0. To migrate to
-  the new version, extract the secret data using 0.4.1 and create a new
-  UserProfile in 0.5.0.
-* The IovWriter construction is changed. You can probably save a line there.
+- Due to multi curve support in keyring entries, UserProfiles stored with
+  earlier versions of IOV-Core cannot be opened with 0.5.0. To migrate to the
+  new version, extract the secret data using 0.4.1 and create a new UserProfile
+  in 0.5.0.
+- The IovWriter construction is changed. You can probably save a line there.
   Please look at @iov/core README to see how to build it.
 
 ## 0.4.1
 
-* @iov/faucets: package added to provide easy access to a BovFaucet
+- @iov/faucets: package added to provide easy access to a BovFaucet
 
 ## 0.4.0
 
-* @iov/core: Add disconnect method to IovReader
-* @iov/tendermint-rpc: Add disconnect method to WebsocketClient
-* @iov/ledger-bns: Improved USB connectivity due to hw-transport-node-hid upgrade
+- @iov/core: Add disconnect method to IovReader
+- @iov/tendermint-rpc: Add disconnect method to WebsocketClient
+- @iov/ledger-bns: Improved USB connectivity due to hw-transport-node-hid
+  upgrade
 
 Breaking changes
 
-* @iov/cli: wait() helper function removed
-* @iov/ledger-bns: LedgerSimpleAddressKeyringEntry.startDeviceTracking() must be called
-  before getting device state or calling createIdentity()/createTransactionSignature()
-* The name field from the `getAccount` result data does not contain
-  the chain ID anymore. Before
+- @iov/cli: wait() helper function removed
+- @iov/ledger-bns: LedgerSimpleAddressKeyringEntry.startDeviceTracking() must be
+  called before getting device state or calling
+  createIdentity()/createTransactionSignature()
+- The name field from the `getAccount` result data does not contain the chain ID
+  anymore. Before
 
       [ { name: 'admin*test-chain-HexTMJ',
       address:
@@ -476,23 +535,22 @@ Breaking changes
 
 ## 0.3.1
 
-* @iov/core: Export SetNameTx
-* Improve Windows compatibility of build system and add Edge tests
+- @iov/core: Export SetNameTx
+- Improve Windows compatibility of build system and add Edge tests
 
 ## 0.3.0
 
-* @iov/ledger-bns: Implement LedgerSimpleAddressKeyringEntry.canSign
-* @iov/ledger-bns: Add LedgerSimpleAddressKeyringEntry.deviceState
-* @iov/keycontrol: Encrypt UserProfile using XChaCha20-Poly1305
-* @iov/crypto: Add support for unhardened Secp256k1 HD derivation
-* @iov/cli: Add support for top level await
+- @iov/ledger-bns: Implement LedgerSimpleAddressKeyringEntry.canSign
+- @iov/ledger-bns: Add LedgerSimpleAddressKeyringEntry.deviceState
+- @iov/keycontrol: Encrypt UserProfile using XChaCha20-Poly1305
+- @iov/crypto: Add support for unhardened Secp256k1 HD derivation
+- @iov/cli: Add support for top level await
 
 Breaking changes
 
-* Due to an enhanced encryption mechanism, UserProfiles stored with
-  IOV-Core 0.2.0 cannot be opened with 0.3.0. To migrate to the new
-  version, extract the secret data using 0.2.0 and create a new
-  UserProfile in 0.3.0.
+- Due to an enhanced encryption mechanism, UserProfiles stored with IOV-Core
+  0.2.0 cannot be opened with 0.3.0. To migrate to the new version, extract the
+  secret data using 0.2.0 and create a new UserProfile in 0.3.0.
 
 ## 0.2.0
 

--- a/README.md
+++ b/README.md
@@ -2,28 +2,35 @@
 
 [![Build Status](https://travis-ci.com/iov-one/iov-core.svg?token=evC2AgcwxuvHjXeBP3jq&branch=master)](https://travis-ci.com/iov-one/iov-core)
 
-This repo is provides core functionality to all clients in a cross-platform typescript library.
-This can be used to build cli/gui clients, automated scripts, or help build bcp-proxy apps.
+This repo is provides core functionality to all clients in a cross-platform
+typescript library. This can be used to build cli/gui clients, automated
+scripts, or help build bcp-proxy apps.
 
 Main functionality provided:
 
-- Solid crypto library with HD support for ed25519 (following SLIP-0010, ledger compatible)
-- Secure private key management, including encrypted local storage for both browser and node
-- Generic, type-safe adaptor to read/write on tendermint rpc server (with http/s and ws/s support)
+- Solid crypto library with HD support for ed25519 (following SLIP-0010, ledger
+  compatible)
+- Secure private key management, including encrypted local storage for both
+  browser and node
+- Generic, type-safe adaptor to read/write on tendermint rpc server (with http/s
+  and ws/s support)
 - Adaptor to query / create transactions for IOV's testnet of the BNS blockchain
 - Adaptor for key management using IOV's BNS ledger app
-- High level controller for managing multiple user profiles and various key material
-- High level controller for managing read/write connections to multiple blockchains (CoreWriter)
+- High level controller for managing multiple user profiles and various key
+  material
+- High level controller for managing read/write connections to multiple
+  blockchains (CoreWriter)
 - Integration with REPL environment for quick prototyping for developers
 
-This is still in pre-alpha state and will evolve quickly as we add support for multiple blockchains,
-more transactions types, and better extensibility. However, all attempts have been made that the
-foundational code is quite solid. A security audit and stable release will occur along with the
-timeline of IOV's mainnet launch, but developers looking for client-side libraries can do initial
+This is still in pre-alpha state and will evolve quickly as we add support for
+multiple blockchains, more transactions types, and better extensibility.
+However, all attempts have been made that the foundational code is quite solid.
+A security audit and stable release will occur along with the timeline of IOV's
+mainnet launch, but developers looking for client-side libraries can do initial
 prototypes with the current state.
 
-We are actively building out multiple clients on top of this library and shaking out usability
-issues in the API.
+We are actively building out multiple clients on top of this library and shaking
+out usability issues in the API.
 
 ## Users
 
@@ -37,12 +44,13 @@ The following projects use IOV-Core (add yourself via a PR):
 
 ## Compatibility
 
-The compiled code from this package, which is published on npm, should work on any modern (2018)
-browser, and node 8+. The development environment has been tested on node 8.7.0 LTS and node 10.x.
+The compiled code from this package, which is published on npm, should work on
+any modern (2018) browser, and node 8+. The development environment has been
+tested on node 8.7.0 LTS and node 10.x.
 
-**Yarn not Npm** Please `npm install -g yarn` and use `yarn install`, `yarn build`, etc.
-Developers who installed with `npm i` have reported problems in compiling, so wipe out `node_modules`
-and enjoy `yarn`.
+**Yarn not Npm** Please `npm install -g yarn` and use `yarn install`,
+`yarn build`, etc. Developers who installed with `npm i` have reported problems
+in compiling, so wipe out `node_modules` and enjoy `yarn`.
 
 CI Tests:
 
@@ -54,19 +62,22 @@ CI Tests:
 
 ## Getting Started
 
-The best way to learn about code is to use it.
-You can read some [examples in @iov/core](./packages/iov-core/README.md).
-And you can use a REPL to [interactively try the code](./packages/iov-cli/README.md).
+The best way to learn about code is to use it. You can read some
+[examples in @iov/core](./packages/iov-core/README.md). And you can use a REPL
+to [interactively try the code](./packages/iov-cli/README.md).
 
-Once you understand the basics, you can dig in deeper with the API documentation.
+Once you understand the basics, you can dig in deeper with the API
+documentation.
 
 ## API Docs
 
-Documentation is published at [https://iov-one.github.io/iov-core-docs/](https://iov-one.github.io/iov-core-docs/).
+Documentation is published at
+[https://iov-one.github.io/iov-core-docs/](https://iov-one.github.io/iov-core-docs/).
 
-To build the documentation locally, run `yarn install && yarn build && yarn docs`
-in this repository. This will generate a `./docs` directory in each package that you
-can browse locally to see API docs on the various packages.
+To build the documentation locally, run
+`yarn install && yarn build && yarn docs` in this repository. This will generate
+a `./docs` directory in each package that you can browse locally to see API docs
+on the various packages.
 
 ## Contributing
 
@@ -79,9 +90,10 @@ that provide a nice way to get started with the IOV-Core repo.
 
 ### Development Environment
 
-If you go into a subpackage and try to `yarn build` or `yarn test`, chances are it will fail.
-The reason is that we only check in `*.ts` files, while we need the compiled `*.js` files
-to import other packages. We push these to npm but do not check them into git to avoid commit noise.
+If you go into a subpackage and try to `yarn build` or `yarn test`, chances are
+it will fail. The reason is that we only check in `*.ts` files, while we need
+the compiled `*.js` files to import other packages. We push these to npm but do
+not check them into git to avoid commit noise.
 
 To get started, please go to the root directory and run:
 
@@ -91,14 +103,14 @@ yarn build
 yarn test
 ```
 
-Once that passes, you have the code built and can go into any subdirectory, edit code
-and verify the changes with `yarn test` on that one package.
+Once that passes, you have the code built and can go into any subdirectory, edit
+code and verify the changes with `yarn test` on that one package.
 
 ### Integration Tests
 
 There are a number of integration tests involving communication with tendermint
-(in `@iov/tendermint-rpc`) and the BNS blockchain (in `@iov/bns`) that require
-a test server to run and are skipped by default. If you are working on those
+(in `@iov/tendermint-rpc`) and the BNS blockchain (in `@iov/bns`) that require a
+test server to run and are skipped by default. If you are working on those
 packages, please run those tests. (They require docker to be installed and
 executable by the current user)
 
@@ -118,8 +130,10 @@ unset TENDERMINT_ENABLED
 
 #### BNS
 
-If you are working on `@iov/bns`, you can run the tests against a local
-BNS devnet. See [scripts/bnsd/README.md](https://github.com/iov-one/iov-core/tree/master/scripts/bnsd/README.md#start) for instructions on how to start the BNS devnet. Then run the tests as follows:
+If you are working on `@iov/bns`, you can run the tests against a local BNS
+devnet. See
+[scripts/bnsd/README.md](https://github.com/iov-one/iov-core/tree/master/scripts/bnsd/README.md#start)
+for instructions on how to start the BNS devnet. Then run the tests as follows:
 
 ```
 cd packages/iov-bns
@@ -128,8 +142,10 @@ yarn test
 
 #### Lisk
 
-If you are working on `@iov/lisk`, you can run the tests against a local
-Lisk devnet. See [scripts/lisk/README.md](https://github.com/iov-one/iov-core/tree/master/scripts/lisk#start) for instructions on how to start the Lisk devnet. Then run the tests as follows:
+If you are working on `@iov/lisk`, you can run the tests against a local Lisk
+devnet. See
+[scripts/lisk/README.md](https://github.com/iov-one/iov-core/tree/master/scripts/lisk#start)
+for instructions on how to start the Lisk devnet. Then run the tests as follows:
 
 ```
 cd packages/iov-lisk
@@ -140,9 +156,9 @@ yarn test
 
 The CI runs all code not only under node, but also in various browsers.
 
-These work almost all of the time, but if you CI test fails in the browser,
-or if you are just curious to see this work, you can run the browser tests
-locally with any of the following, in any package you are working on:
+These work almost all of the time, but if you CI test fails in the browser, or
+if you are just curious to see this work, you can run the browser tests locally
+with any of the following, in any package you are working on:
 
 ```
 yarn test-chrome
@@ -153,19 +169,22 @@ yarn test-edge    # windows only
 
 ### Developing under Windows 10
 
-Most of the developers working on this project in windows are also using Windows Subsystem for Linux
-(WSL), which should have maximum compatibility, as CI is linux and osx. However, we do attempt to ensure
-that this code also compiles on the normal windows shell, if you have set up git, node, yarn etc. correctly.
-(Note this has only be verified under windows 10, no guarantees for older versions).
+Most of the developers working on this project in windows are also using Windows
+Subsystem for Linux (WSL), which should have maximum compatibility, as CI is
+linux and osx. However, we do attempt to ensure that this code also compiles on
+the normal windows shell, if you have set up git, node, yarn etc. correctly.
+(Note this has only be verified under windows 10, no guarantees for older
+versions).
 
 ### Line endings (CRLF vs LF)
 
-All the code in the repo should use LF not the windows-specific CRLF as a line ending.
-`tsc` is currently set up to output properly. However, you should also make sure your editor
-saves with `LF` line endings rather than `CRLF`.
+All the code in the repo should use LF not the windows-specific CRLF as a line
+ending. `tsc` is currently set up to output properly. However, you should also
+make sure your editor saves with `LF` line endings rather than `CRLF`.
 
-A bigger issue is `git` changing the endings upon commit. Here is a short workaround,
-adapted from a [stackoverflow discussion](https://stackoverflow.com/questions/2517190/how-do-i-force-git-to-use-lf-instead-of-crlf-under-windows):
+A bigger issue is `git` changing the endings upon commit. Here is a short
+workaround, adapted from a
+[stackoverflow discussion](https://stackoverflow.com/questions/2517190/how-do-i-force-git-to-use-lf-instead-of-crlf-under-windows):
 
 ```
 git config --global core.autocrlf false
@@ -176,16 +195,18 @@ git config --global core.eol lf
 
 ### Libusb fails to build, why?
 
-If you are running on linux, you may not have the proper dependencies installed. For Ubuntu, try the
-following: `sudo apt-get install libudev-dev libusb-1.0-0 libusb-1.0-0-dev`.
-These are needed to compile the usb driver.
+If you are running on linux, you may not have the proper dependencies installed.
+For Ubuntu, try the following:
+`sudo apt-get install libudev-dev libusb-1.0-0 libusb-1.0-0-dev`. These are
+needed to compile the usb driver.
 
-Sometimes compiling native code with `node-pre-gyp` causes issues in very
-recent versions of Node.js. At the moment, Node.js 8, 10 and 11 should work.
+Sometimes compiling native code with `node-pre-gyp` causes issues in very recent
+versions of Node.js. At the moment, Node.js 8, 10 and 11 should work.
 
 ### Docker fails to run a test server
 
-If you're using OSX and Docker Desktop for Mac and you get an error like the following, you'll need to add your `$TMPDIR` path to the list of shared paths:
+If you're using OSX and Docker Desktop for Mac and you get an error like the
+following, you'll need to add your `$TMPDIR` path to the list of shared paths:
 
 ```
 docker: Error response from daemon: Mounts denied:
@@ -200,14 +221,16 @@ In a terminal, run this command to find out your `$TMPDIR`:
 echo $TMPDIR
 ```
 
-Then add it to the list of shared paths in Docker -> Preferences ... -> File Sharing. Apply and restart, and try to start the test server again.
+Then add it to the list of shared paths in Docker -> Preferences ... -> File
+Sharing. Apply and restart, and try to start the test server again.
 
 ### My PR works but the CI rejects it
 
-Make sure you at least ran `yarn test` in all the directories where you modified code.
-The CI will reject any PR if type definitions change after compiling the code to ensure
-it was build and committed prior to pushing.
+Make sure you at least ran `yarn test` in all the directories where you modified
+code. The CI will reject any PR if type definitions change after compiling the
+code to ensure it was build and committed prior to pushing.
 
 ## License
 
-This repository is licensed under the Apache License 2.0 (see NOTICE and LICENSE).
+This repository is licensed under the Apache License 2.0 (see NOTICE and
+LICENSE).

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,46 +1,40 @@
 # Architecture
 
-This is a fundamental question of how we want to organize the apps
-that needs to be clarified to proceed on the design of the key management.
+This is a fundamental question of how we want to organize the apps that needs to
+be clarified to proceed on the design of the key management.
 
 ## Stream State Changes to UI (listener)
 
-Simplest is a bunch of functions that do stuff (add accounts, save
-accounts, unlock accounts, sign transactions). As many may involve
-I/O (reading from disk, talking with ledger), they must all be async
-functions (return Promises).
+Simplest is a bunch of functions that do stuff (add accounts, save accounts,
+unlock accounts, sign transactions). As many may involve I/O (reading from disk,
+talking with ledger), they must all be async functions (return Promises).
 
-Now many of these functions can update state somehow, and those
-changes must be represented properly in a UI (which probably uses
-some sort of redux store). All kinds of Promises resolving to
-various state changes seems like a recipe for errors, so
-we think to just emit events on state change. The UI can then
-take the stream of change events emitted from `watchState`
-and feed that into a dispatcher, same way UI actions feed into the
-dispatcher.
+Now many of these functions can update state somehow, and those changes must be
+represented properly in a UI (which probably uses some sort of redux store). All
+kinds of Promises resolving to various state changes seems like a recipe for
+errors, so we think to just emit events on state change. The UI can then take
+the stream of change events emitted from `watchState` and feed that into a
+dispatcher, same way UI actions feed into the dispatcher.
 
 ## Handling Errors
 
-So, we just call a method and go on, content that the UI will update
-once the new accounts are created, or other action happens.
-However, what happens if there is an error? How do we communicate this?
+So, we just call a method and go on, content that the UI will update once the
+new accounts are created, or other action happens. However, what happens if
+there is an error? How do we communicate this?
 
-Maybe we don't just fire and forget, but rather get a promise back
-from calling the method. We can `.catch()` any errors that are
-returned and in this case dispatch another (UI) event to report the
-failure.
+Maybe we don't just fire and forget, but rather get a promise back from calling
+the method. We can `.catch()` any errors that are returned and in this case
+dispatch another (UI) event to report the failure.
 
-But if we only return a Promise here in order to emit a failure event,
-why can't the KeyController just emit those failure events directly.
-We are guaranteed to eventually get an event describing the
-desired state change or a failure event.
+But if we only return a Promise here in order to emit a failure event, why can't
+the KeyController just emit those failure events directly. We are guaranteed to
+eventually get an event describing the desired state change or a failure event.
 
 ## Unifying actions
 
-At this point, all methods that modify state should have the
-form `(a: A, b: B, ...) => void`. Hmm... we could combine
-those arguments into `(action: Action) => void`, which looks
-very much like a redux dispatcher.
+At this point, all methods that modify state should have the form
+`(a: A, b: B, ...) => void`. Hmm... we could combine those arguments into
+`(action: Action) => void`, which looks very much like a redux dispatcher.
 
 Then we could conceive of just unifying the API to look like:
 
@@ -57,204 +51,196 @@ interface KeyController {
 }
 ```
 
-Huh, now we conceive of multiple parts that each accept a stream
-of inputs into their own dispatch method, and export a stream
-of outputs to any listener, and we can connect two pieces
-to close the loop. We have multiple state stores, but they are
-all coupled with reactive streams so changes propogate everywhere.
+Huh, now we conceive of multiple parts that each accept a stream of inputs into
+their own dispatch method, and export a stream of outputs to any listener, and
+we can connect two pieces to close the loop. We have multiple state stores, but
+they are all coupled with reactive streams so changes propogate everywhere.
 
 Awesome, so much symmetry!
 
 ## Performing Calculations
 
-Not so fast.... sometime we actually do care about the results
-and want to use them in a workflow, not just send them to any
-listener. What about signing a transaction?
+Not so fast.... sometime we actually do care about the results and want to use
+them in a workflow, not just send them to any listener. What about signing a
+transaction?
 
 When I sign a transaction, I may want to do something like:
 
 ```typescript
 const nonce = await node.getNonce(account);
 const signableBytes = codec.signableBytes(tx, nonce, chainID);
-const sig = await keyControl.signTransaction(user, account, signableBytes)
-const signedTx = {...tx, sigs: [...tx.sigs, sig]}
+const sig = await keyControl.signTransaction(user, account, signableBytes);
+const signedTx = { ...tx, sigs: [...tx.sigs, sig] };
 const postable = codec.postableBytes(signedTx);
 const result = await node.sendTx(postable);
 return txSuccessEvent(result.txId);
 ```
 
-I want to use the KeyController to perform a calculation
-and then feed the results into the next step of a longer
-workflow. How do I represent this?
+I want to use the KeyController to perform a calculation and then feed the
+results into the next step of a longer workflow. How do I represent this?
 
 ## Two types of flow
 
-**Proposal**
-(after discussion and reflection, I like this, but please give feedback)
+**Proposal** (after discussion and reflection, I like this, but please give
+feedback)
 
-**Async Actions** Just like when we call a website to perform an action
-in redux. We get a promise back, which we can resolve to some state.
-This is the case that should be used when we want to perform a
-state-changing action on a remote system. This allows us to handle
-success and failure modes at least, or possible use the result for
-other actions. Here we can use standard promise chaining
-(or async/await) to perform sequential computation.
+**Async Actions** Just like when we call a website to perform an action in
+redux. We get a promise back, which we can resolve to some state. This is the
+case that should be used when we want to perform a state-changing action on a
+remote system. This allows us to handle success and failure modes at least, or
+possible use the result for other actions. Here we can use standard promise
+chaining (or async/await) to perform sequential computation.
 
-**Reactive State Mirror** If we want to display the current
-state of the system (list of accounts, current balance, etc),
-the client can choose to mirror a subset of the state of the server.
-We can add `GetState` and `SubscribeToStateChanges` functionality.
-Such that on initial connect the client copies that substate
-locally. It then subscribes to an event stream of all changes. Those
-changes can be applied to the local state mirror via redux-like dispatcher
-keeping the two in sync. Or course it could also be used in a fully
-(functional) reactive programming style like
-[cycle.js](https://cycle.js.org/).
+**Reactive State Mirror** If we want to display the current state of the system
+(list of accounts, current balance, etc), the client can choose to mirror a
+subset of the state of the server. We can add `GetState` and
+`SubscribeToStateChanges` functionality. Such that on initial connect the client
+copies that substate locally. It then subscribes to an event stream of all
+changes. Those changes can be applied to the local state mirror via redux-like
+dispatcher keeping the two in sync. Or course it could also be used in a fully
+(functional) reactive programming style like [cycle.js](https://cycle.js.org/).
 
-An API should exist of multiple asynchronous actions for every
-state transition that can be triggered from outside, and a
-standardized subscription API to reactively mirror state.
-The first part is pretty standard, the second one will be visited
-in more detail in th next section.
+An API should exist of multiple asynchronous actions for every state transition
+that can be triggered from outside, and a standardized subscription API to
+reactively mirror state. The first part is pretty standard, the second one will
+be visited in more detail in th next section.
 
 ## Reactively Mirroring State
 
-We have some system state and we want to display it on a client.
-Basically we need a local mirror of the state. This can be
-acheived by:
+We have some system state and we want to display it on a client. Basically we
+need a local mirror of the state. This can be acheived by:
 
-* Querying on refresh (typical web pages, always show old state)
-* Polling to auto-refresh (get responsiveness but kill the server)
-* Subscribing to changes (websockets, etc.)
+- Querying on refresh (typical web pages, always show old state)
+- Polling to auto-refresh (get responsiveness but kill the server)
+- Subscribing to changes (websockets, etc.)
 
 ### Types of Subscriptions
 
-A subscription will often look something like "Give me state +
-Subscribe to all change events on that state". Assuming
-"give me state" can be done efficiently and there is a
-consistent connection between client and server, this can work well.
-The client has no memory and just mirrors the server.
-One of the most advanced examples of such an architecture
-is [Rethink DB Change Feed API](https://rethinkdb.com/docs/changefeeds/javascript/)
-You can optionally [include the initial value](https://rethinkdb.com/docs/changefeeds/javascript/#including-initial-values)
+A subscription will often look something like "Give me state + Subscribe to all
+change events on that state". Assuming "give me state" can be done efficiently
+and there is a consistent connection between client and server, this can work
+well. The client has no memory and just mirrors the server. One of the most
+advanced examples of such an architecture is
+[Rethink DB Change Feed API](https://rethinkdb.com/docs/changefeeds/javascript/)
+You can optionally
+[include the initial value](https://rethinkdb.com/docs/changefeeds/javascript/#including-initial-values)
 and get a callback on every change.
 
-With modern javascript, we could replace the callback with
-a streams and Observables, like
-[RxJs](https://rxjs-dev.firebaseapp.com/) or
-[xstream](http://staltz.github.io/xstream/). But the logic would
-remain the same.
+With modern javascript, we could replace the callback with a streams and
+Observables, like [RxJs](https://rxjs-dev.firebaseapp.com/) or
+[xstream](http://staltz.github.io/xstream/). But the logic would remain the
+same.
 
-PostgreSQL has a concept of [streaming replication](https://www.postgresql.org/docs/10/static/protocol-replication.html)
-and is designed for the case where we cannot copy the entire state
-when a connection breaks. This may inform a design where the client
-has a memory of information (eg. all transactions on many accounts,
-the votes in an election) and after a short disconnect wants to update
-the information reactively again. Rather than being forced to query
-the entire state, or just streaming changes from the time of
-reconnection (possibly losing some changes while disconnected),
-we want to be able to query for "all changes since the last one I saw",
-which we can pass to the server.
+PostgreSQL has a concept of
+[streaming replication](https://www.postgresql.org/docs/10/static/protocol-replication.html)
+and is designed for the case where we cannot copy the entire state when a
+connection breaks. This may inform a design where the client has a memory of
+information (eg. all transactions on many accounts, the votes in an election)
+and after a short disconnect wants to update the information reactively again.
+Rather than being forced to query the entire state, or just streaming changes
+from the time of reconnection (possibly losing some changes while disconnected),
+we want to be able to query for "all changes since the last one I saw", which we
+can pass to the server.
 
 In the case of PostgreSQL, you first
 [CREATE_REPLICATION_SLOT](https://www.postgresql.org/docs/10/static/protocol-replication.html#PROTOCOL-REPLICATION-CREATE-SLOT)
-to create a queue, and start appending all change events from that
-point on. When you want to start (or restart) replication,
-you [START_REPLICATION](https://www.postgresql.org/docs/10/static/protocol-replication.html#id-1.10.5.9.4.1.5.1.8), which
-`Instructs server to start streaming WAL,  starting at WAL location XXX/XXX.`
-Note the use of two (long) integers to denote the location in a stream
-of events.
-`The receiving process can send replies back to the sender at any time`,
+to create a queue, and start appending all change events from that point on.
+When you want to start (or restart) replication, you
+[START_REPLICATION](https://www.postgresql.org/docs/10/static/protocol-replication.html#id-1.10.5.9.4.1.5.1.8),
+which
+`Instructs server to start streaming WAL, starting at WAL location XXX/XXX.`
+Note the use of two (long) integers to denote the location in a stream of
+events. `The receiving process can send replies back to the sender at any time`,
 including
 `The location of the last WAL byte + 1 received and written to disk in the standby.`
-Once the receiving process has acknowledged receipt up to a given point,
-the sending process is free to clean up this replication slot.
-Otherwise it maintains history until memory limits and garbage
-collection force a cleanup.
+Once the receiving process has acknowledged receipt up to a given point, the
+sending process is free to clean up this replication slot. Otherwise it
+maintains history until memory limits and garbage collection force a cleanup.
 
-From the above, we can see how we can design a client with persistence
-to maintain an offline-usable view as well as quickly reestablish
-a live view of the state over flaky connections. This may sound a bit
-theoretical, but if we aim for a mobile wallet, we should build
-in such a mechanism for the client-server connections. If we want a
-live view from another module in the same process, or another
-process guaranteed to be on the same machine, the simpler
-"change feed" is sufficient to maintain a smooth user experience.
+From the above, we can see how we can design a client with persistence to
+maintain an offline-usable view as well as quickly reestablish a live view of
+the state over flaky connections. This may sound a bit theoretical, but if we
+aim for a mobile wallet, we should build in such a mechanism for the
+client-server connections. If we want a live view from another module in the
+same process, or another process guaranteed to be on the same machine, the
+simpler "change feed" is sufficient to maintain a smooth user experience.
 
 ### Filtering state
 
-When the state we query is the unlocked public identities in a local
-key store, it is simple enough to mirror the entire state in the UI and
-decide what to display in the UI itself. However, if we wish to monitor
-the balance of 3 accounts, we hardly have to stream the entire state
-of a blockchain to do so. For this case we will we need some filter
-on the connection, so only a targetted subset of the data is transmitted.
+When the state we query is the unlocked public identities in a local key store,
+it is simple enough to mirror the entire state in the UI and decide what to
+display in the UI itself. However, if we wish to monitor the balance of 3
+accounts, we hardly have to stream the entire state of a blockchain to do so.
+For this case we will we need some filter on the connection, so only a targetted
+subset of the data is transmitted.
 
 **TODO** Specify this out clearly...
 
-^^^ This is the last open question of efficiently reactively streaming blockchain state ^^^
+^^^ This is the last open question of efficiently reactively streaming
+blockchain state ^^^
 
 ## A semi-concrete use case
 
-Let's make a harder example, where maybe the actor model or
-reactive streams start to make sense.
+Let's make a harder example, where maybe the actor model or reactive streams
+start to make sense.
 
-We connect to 3 different blockchains, I have a wallet UI (in chrome
-extension), and a webapp connected. I have two accounts currently
-unlocked. One is a software key to use for atomic swaps, and the
-other is a ledger that manages long-term storage.
+We connect to 3 different blockchains, I have a wallet UI (in chrome extension),
+and a webapp connected. I have two accounts currently unlocked. One is a
+software key to use for atomic swaps, and the other is a ledger that manages
+long-term storage.
 
-Wallet UI unlocks both account and queries balances.
-See a good deal in the webapp, and initiate an atomic swap.
-This goes to be signed by the software key and a confirmation
-is presented in the wallet UI. After confirm, the offer signed
-and posted to the blockchain, and my desired trade rate is stored
-in my swap-bot (in the wallet UI).
+Wallet UI unlocks both account and queries balances. See a good deal in the
+webapp, and initiate an atomic swap. This goes to be signed by the software key
+and a confirmation is presented in the wallet UI. After confirm, the offer
+signed and posted to the blockchain, and my desired trade rate is stored in my
+swap-bot (in the wallet UI).
 
-While I am waiting for the counter-party to respond, I deside to move
-1000 IOV off the ledger to my day-trader account. I initiate a transaction
-to send this from the wallet UI and a transaction is sent to the ledger.
-In the meantime, CoreReader receives a notification from the second chain in
-the swap that an escrow is proposed. The counter is compared to the original
-agreement, and as it matches, the trusted swap-bot creates a claim tx
-and initiates it for signing (this may happen automatically or pop
-up something on the UI). I click "okay" on the ledger app to finalize the
-send transaction. Both transactions head to the chain, swaps and sends
-are being resolved, and all account balances get updated.
+While I am waiting for the counter-party to respond, I deside to move 1000 IOV
+off the ledger to my day-trader account. I initiate a transaction to send this
+from the wallet UI and a transaction is sent to the ledger. In the meantime,
+CoreReader receives a notification from the second chain in the swap that an
+escrow is proposed. The counter is compared to the original agreement, and as it
+matches, the trusted swap-bot creates a claim tx and initiates it for signing
+(this may happen automatically or pop up something on the UI). I click "okay" on
+the ledger app to finalize the send transaction. Both transactions head to the
+chain, swaps and sends are being resolved, and all account balances get updated.
 
-This is a lot of data moving around at once. How do we model such a case
-without going crazy?
+This is a lot of data moving around at once. How do we model such a case without
+going crazy?
 
-This may seem a bit far-fetched, but once we provide the iov core API, and
-some nice tools, we can allow all kinds of actions, like receiving state
-channel payments and auto-claiming part every eg. 50 IOV tokens. Or
-passing along multi-sig transactions to the next signatory on the message
-after signing.
+This may seem a bit far-fetched, but once we provide the iov core API, and some
+nice tools, we can allow all kinds of actions, like receiving state channel
+payments and auto-claiming part every eg. 50 IOV tokens. Or passing along
+multi-sig transactions to the next signatory on the message after signing.
 
 We should be able to handle information streams and automate many of the
 responses by simple bots (IFTTT style). Hopefully this gives a bit of
-inspiration of where to head with the architecture. I'm still not
-sure what the proper architecture is to fulfill these use cases, but
-I think simple promise chains won't work so well.
+inspiration of where to head with the architecture. I'm still not sure what the
+proper architecture is to fulfill these use cases, but I think simple promise
+chains won't work so well.
 
 ## Protecting internal class state against external manipulation
 
-A class contains data and methods that operate on that data. Classes should distrust the outside world and make sure to all
-state manipulation happens through a method that can verify the requested change
-or update secondary data accoringly (e.g. flush a cache or recalculate a sum).
+A class contains data and methods that operate on that data. Classes should
+distrust the outside world and make sure to all state manipulation happens
+through a method that can verify the requested change or update secondary data
+accoringly (e.g. flush a cache or recalculate a sum).
 
 ### Stategies to protect internal state
 
 The following list shows ideas how to protect internal state against external
-manipulation. In order to find the right case, you need to know if a type is immutable
-or not.
+manipulation. In order to find the right case, you need to know if a type is
+immutable or not.
 
-* **immutable types:** primitives (string, number, boolean, null, undefined, symbol), ReadonlyArray of immutable type, ReadonlyDate
-* **mutable types:** TypedArrays, Arrays, Date, other objects, classes, ReadonlyArray of mutable type,
+- **immutable types:** primitives (string, number, boolean, null, undefined,
+  symbol), ReadonlyArray of immutable type, ReadonlyDate
+- **mutable types:** TypedArrays, Arrays, Date, other objects, classes,
+  ReadonlyArray of mutable type,
 
 #### Re-assignable members (no readonly keyword)
 
-This can usually be avoided and is excpluded via the `readonly-keyword` tslint rule.
+This can usually be avoided and is excpluded via the `readonly-keyword` tslint
+rule.
 
 #### Private readonly immutable members
 
@@ -290,8 +276,8 @@ class Foo {
 }
 ```
 
-If those members should be exposed, use a defensive copy getter method,
-since there is no general way to make mutable objects immutable.
+If those members should be exposed, use a defensive copy getter method, since
+there is no general way to make mutable objects immutable.
 
 ```ts
 class Foo {
@@ -346,8 +332,8 @@ foo.privkey[3] = 0xff;
 console.log(foo.privkey); // Uint8Array [ 170, 34, 187, 255 ]
 ```
 
-Since there is no general way to make mutable objects immutable,
-defensive copies should be used in a getter method.
+Since there is no general way to make mutable objects immutable, defensive
+copies should be used in a getter method.
 
 ```ts
 class Foo {
@@ -368,5 +354,9 @@ console.log(foo.getPrivkey()); // Uint8Array [ 170, 34, 187, 51 ]
 
 ### Edge cases to consider
 
-* Some mutable objects cannot be copied, so a different strategy than defensive copy must be applied.
-* Some immutable objects can do damage anyway. E.g. a rxjs [Subject](http://reactivex.io/rxjs/manual/overview.html#subject) can be abused by a caller to spam messages to other listeners using the `next` method, so it must be converted into an Observable.
+- Some mutable objects cannot be copied, so a different strategy than defensive
+  copy must be applied.
+- Some immutable objects can do damage anyway. E.g. a rxjs
+  [Subject](http://reactivex.io/rxjs/manual/overview.html#subject) can be abused
+  by a caller to spam messages to other listeners using the `next` method, so it
+  must be converted into an Observable.

--- a/docs/KeyBase.md
+++ b/docs/KeyBase.md
@@ -6,12 +6,19 @@ they contain.
 
 ## Key Terms:
 
-- `UserProfile`: A collection of User materials. Includes multiple `keyringEntries` associated with a `UserProfile`.
+- `UserProfile`: A collection of User materials. Includes multiple
+  `keyringEntries` associated with a `UserProfile`.
 - `Keyring`: An object containing `keyringEntry`'s.
-- `KeyringEntry`: An object which houses ONE `SeedIdentity` and N `PublicIdentities`.
-- `SeedIdentity`: Single Private material entry in a `KeyringEntry`, used for deriving a `secret` to sign  transactions and generate `PublicIdentities`.
-- `PublicIdentities`: Public materials collection. Contains the an array of objects related to a `SeedIdentity`.
-- `PublicIdentity`: A collection of information derived from a `secret`. It includes an address, publicKey, and HD path data which is always defined via the HD specifications. Used for end user queries for balances and transaction histories.
+- `KeyringEntry`: An object which houses ONE `SeedIdentity` and N
+  `PublicIdentities`.
+- `SeedIdentity`: Single Private material entry in a `KeyringEntry`, used for
+  deriving a `secret` to sign transactions and generate `PublicIdentities`.
+- `PublicIdentities`: Public materials collection. Contains the an array of
+  objects related to a `SeedIdentity`.
+- `PublicIdentity`: A collection of information derived from a `secret`. It
+  includes an address, publicKey, and HD path data which is always defined via
+  the HD specifications. Used for end user queries for balances and transaction
+  histories.
 
 ## Feature Set:
 
@@ -21,8 +28,8 @@ a Hardware Wallet, and various cryptographic algorithms.
 
 ### Generation of HD Seeds
 
-The iov-core Keybase will require the ability to generate new seeds from entropy for
-a user, when needed. This can occur when a UserProfile is made, or later on
+The iov-core Keybase will require the ability to generate new seeds from entropy
+for a user, when needed. This can occur when a UserProfile is made, or later on
 demand by the User.
 
 ### Import/Export of HD Seeds
@@ -51,13 +58,15 @@ practical to use. Ledger will be the first device type supported by the Keybase.
 ### Transaction/Message operations
 
 The Keybase will have the following features:
+
 - Sign and Verify Transactions
 - Sign and Verify Messages
 
 ### Profile and HD Seed encryption
 
 All data entered into a profile is encrypted before it is stored on disk.
-Additionally, individual KeyringEntries can be encrypted by a separate passphrase.
+Additionally, individual KeyringEntries can be encrypted by a separate
+passphrase.
 
 ## Standards Used:
 
@@ -65,35 +74,47 @@ The Keybase will implement a variety of standards regarding address derivation
 and timestamp generation. These have been listed here for review.
 
 ### Hierarchical Deterministic Wallets
-HD wallets will be created through this standard to yield a master publickey:privatekey pair.
+
+HD wallets will be created through this standard to yield a master
+publickey:privatekey pair.
 
 - BIP32: https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki
 
 ### Multi-Account Hierarchy for Deterministic Wallets
-HD Wallets for chain specific support will be created through the following standards for each algorithm.
+
+HD Wallets for chain specific support will be created through the following
+standards for each algorithm.
 
 #### secp256k1
+
 - BIP43: https://github.com/bitcoin/bips/blob/master/bip-0043.mediawiki
 - BIP44: https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki
 
 #### ed25519
+
 - SLIP-0010: https://github.com/satoshilabs/slips/blob/master/slip-0010.md
 
 #### Both
+
 - SLIP-0044: https://github.com/satoshilabs/slips/blob/master/slip-0044.md
 
 ### HD Seed Generation:
+
 Seed generation will be performed through the BIP39 specification for HD seeds
 
 - BIP39: https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki
 
 ### Timestamp Generation
-Timestamps are generated using a widely known standard to enable deterministic parsing.
+
+Timestamps are generated using a widely known standard to enable deterministic
+parsing.
 
 - RFC 3339: https://tools.ietf.org/html/rfc3339
 
 # Code Architecture
-The code for keyring management is broken down into logical units, each performing a specific task. The design can be visualized as follows:
+
+The code for keyring management is broken down into logical units, each
+performing a specific task. The design can be visualized as follows:
 
 ```
 UserProfileController (1 UserProfileController)
@@ -114,19 +135,23 @@ UserProfileController (1 UserProfileController)
                   | > PublicIdentities (1 SecretIdentity : N PublicIdentities)
 ```
 
-
 ## UserProfileController
 
-The primary purpose of the `UserProfileController` is to manage multiple `UserProfile`s. It provides the logic to manipulate  `UserProfile`s.
+The primary purpose of the `UserProfileController` is to manage multiple
+`UserProfile`s. It provides the logic to manipulate `UserProfile`s.
 
-The following functions are called by the `User`, through the `UserProfileController`
+The following functions are called by the `User`, through the
+`UserProfileController`
 
 ### Functions:
 
 - CreateUserProfile: Creates a new user in the `UserProfileController`
-- LoginUserProfile: Passes `username:password` pair to the `UserProfileController`
-- DeleteUserProfile: Requests deletion of a `UserProfile` to the `UserProfileController`
-- ExportUserProfile: Requests the plaintext export of `UserProfile` details, requires a correct `login`
+- LoginUserProfile: Passes `username:password` pair to the
+  `UserProfileController`
+- DeleteUserProfile: Requests deletion of a `UserProfile` to the
+  `UserProfileController`
+- ExportUserProfile: Requests the plaintext export of `UserProfile` details,
+  requires a correct `login`
 
 ### Object Definition:
 
@@ -138,11 +163,12 @@ The following functions are called by the `User`, through the `UserProfileContro
 
 ## UserProfile
 
- A `UserProfile` contains an object called `keyring`, an object called
+A `UserProfile` contains an object called `keyring`, an object called
 `addressBook`, and an object called `securityModel`. This is a `1:N` relation,
 where `N` is each `UserProfile` created by the `UserProfileController`.
 
 ### Object Definition:
+
 ```
 "UserProfile": {
   "username": "isabella",
@@ -162,16 +188,20 @@ where `N` is each `UserProfile` created by the `UserProfileController`.
 
 ## AddressBook
 
-Contains a list of addresses a user has interacted with, or added for frequent use.
+Contains a list of addresses a user has interacted with, or added for frequent
+use.
 
 ### Functions:
+
 - AddContact: Adds a contact to a `AddressBook` with the specified information.
 - DeleteContact: Deletes a contact from a `AddressBook`
 - GetContact: Returns the `chain:address:humanName` for use in the application.
-- ExportContact: Returns a `contact` in plain text for import in another iov-core system.
+- ExportContact: Returns a `contact` in plain text for import in another
+  iov-core system.
 - ImportContact: Adds a `contact` from a predefined plain text entry.
 
 ### Object Definition:
+
 ```
 "addressBook": {
   "addressBookEntries": [
@@ -196,10 +226,12 @@ when a profile will lock down through inactivity. This is a `1:1` relation
 inside of a `UserProfile`.
 
 ### Functions:
+
 - GetSecurityDetails: Returns a security information for the `UserProfile`.
 - ModifySecurityDetails: Changes security information for the `UserProfile`.
 
 ### Object Definition:
+
 ```
 "securityModel": {
   "timeout": 3600
@@ -213,13 +245,19 @@ of the `UserProfile`'s `KeyringEntry`s. This is a `1:1` relation inside of a
 `UserProfile`.
 
 ### Functions:
-- GetKeyringEntry: Returns a requested `KeyringEntry`'s details, such as `PublicIdentities`.
-- AddKeyringEntry: Adds a new `KeyringEntry`, with an autogenerated or imported `SecretIdentity` to the `Keyring`.
+
+- GetKeyringEntry: Returns a requested `KeyringEntry`'s details, such as
+  `PublicIdentities`.
+- AddKeyringEntry: Adds a new `KeyringEntry`, with an autogenerated or imported
+  `SecretIdentity` to the `Keyring`.
 - DeleteKeyringEntry: Removes an existing `KeyringEntry` from the `Keyring`.
-- ExportKeyringEntry: Exports a `KeyringEntry` in plain text, for use in another `Keyring`.
-- ImportKeyringEntry: Imports a whole `KeyringEntry`, complete with a `SecretIdentity` and the list `PublicIdentities`.
+- ExportKeyringEntry: Exports a `KeyringEntry` in plain text, for use in another
+  `Keyring`.
+- ImportKeyringEntry: Imports a whole `KeyringEntry`, complete with a
+  `SecretIdentity` and the list `PublicIdentities`.
 
 ### Object Definition:
+
 ```
 "keyring": {
   "keyringEntries": []
@@ -228,21 +266,24 @@ of the `UserProfile`'s `KeyringEntry`s. This is a `1:1` relation inside of a
 
 ## KeyringEntry
 
-A `KeyringEntry` contains all of the related `SeedIdentity`,
-`PublicIdentities` and personality information for an associated `SeedIdentity`.
+A `KeyringEntry` contains all of the related `SeedIdentity`, `PublicIdentities`
+and personality information for an associated `SeedIdentity`.
 
-A `SeedIdentity` is only an HD Seed value (`Mnemonic Passphrase`) or a
-hardware device identifier for a `Ledger`.
+A `SeedIdentity` is only an HD Seed value (`Mnemonic Passphrase`) or a hardware
+device identifier for a `Ledger`.
 
 This is a `1:1` relation, where each `KeyringEntry` has one `SeedIdentity`.
 
 ### Functions:
+
 - CreateSeedIdentity: Creates a `SeedIdentity`, if the `KeyRingEntry` has none.
 - RenameSeedIdentity: Changes the label of the `keyringEntry`.
 - DeleteSeedIdentity: Removes the `SeedIdentity` from the `keyringEntry`.
-- ExportSeedIdentity: Exports the `SeedIdentity` in plain text. Only the type of `HD` can be exported.
+- ExportSeedIdentity: Exports the `SeedIdentity` in plain text. Only the type of
+  `HD` can be exported.
 
 ### Object Definition:
+
 ```
 "KeyringEntry": {
   "label": "My Account",
@@ -265,12 +306,14 @@ This is a `1:N` relation, where 1 is the `SeedIdentity` for which the
 `PublicIdentity` is related and N are the generated `PublicIdentities`.
 
 ### Functions:
+
 - GetPublicIdentity: Returns `PublicIdentity` details for a specific algorithm.
 - CreatePublicIdentity: Creates a `PublicIdentity` from the `SeedIdentity`.
 - DeletePublicIdentity: Removes a `PublicIdentity` from `PublicIdentities`.
-- ExportPublicIdentity: Exports  a `PublicIdentity` in plain text.
+- ExportPublicIdentity: Exports a `PublicIdentity` in plain text.
 
 ### Object Definition:
+
 ```
 "PublicIdentities": [
   "PublicIdentity": {
@@ -298,7 +341,9 @@ This is a `1:N` relation, where 1 is the `SeedIdentity` for which the
 
 ## Complete Object Definition
 
-The following is what a fully initialized profile will look like. This includes one relation of each type.
+The following is what a fully initialized profile will look like. This includes
+one relation of each type.
+
 ```
 "UserProfile": {
   "username": "isabella",
@@ -356,45 +401,53 @@ The following is what a fully initialized profile will look like. This includes 
 
 # Address Architecture
 
-There are two main types of addresses implemented into the Keybase.
-These are `Simple Addresses` and `Extended Addresses`.
-The simple address will implement the base set of features offered by BIP43.
-The extended addresses will implement the full suite of BIP44 features.
+There are two main types of addresses implemented into the Keybase. These are
+`Simple Addresses` and `Extended Addresses`. The simple address will implement
+the base set of features offered by BIP43. The extended addresses will implement
+the full suite of BIP44 features.
 
 ## Simple Addresses:
 
-The BCP and BNS will both support the standard cryptography algorithms found in the majority of blockchain ecosystems. This includes `ed25519` and `secp256k1`. While these algorithms are different, we can use some key features of Bitcoin that have propogated and become standard throughout many implementations.
+The BCP and BNS will both support the standard cryptography algorithms found in
+the majority of blockchain ecosystems. This includes `ed25519` and `secp256k1`.
+While these algorithms are different, we can use some key features of Bitcoin
+that have propogated and become standard throughout many implementations.
 
 Simple addresses are BIP43 compatible HD addresses using the IOV purpose.
 
 ### IOV purpose (purpose = 4804438)
 
-BIP43 describes the standard HD path specification. It allows the use of custom `purpose`s for
-for custom address schemes. Simple addresses use `purpose = 4804438`.
-The choosen purpose value is the integer created by the ascii encoding of the letters "IOV".
-We hope it remains unique within the industry.
+BIP43 describes the standard HD path specification. It allows the use of custom
+`purpose`s for for custom address schemes. Simple addresses use
+`purpose = 4804438`. The choosen purpose value is the integer created by the
+ascii encoding of the letters "IOV". We hope it remains unique within the
+industry.
 
 ### Simple Address Derivation
 
-Using `purpose = 4804438`, we create BIP43 compatible HD addresses using the derivation path
-`m / 4804438' / i'` where `i` is an index starting at 0.
+Using `purpose = 4804438`, we create BIP43 compatible HD addresses using the
+derivation path `m / 4804438' / i'` where `i` is an index starting at 0.
 
 This creates a simple, linear address space.
 
 ## Extended Addresses:
 
-In many circumstances, users will want a chain specific key that can be portable if needed. We can provide them access to these keys using the full BIP43/44 specifications.
+In many circumstances, users will want a chain specific key that can be portable
+if needed. We can provide them access to these keys using the full BIP43/44
+specifications.
 
 > m / purpose' / coin_type' / account' / change / address_index
 
-Purpose MUST follow the BIP44 specification and as such, be set to be `44`. `coin_type` MUST be supported according to the SLIP list. This will provide the greatest compatibility, especially if a user needs to exit the system.
+Purpose MUST follow the BIP44 specification and as such, be set to be `44`.
+`coin_type` MUST be supported according to the SLIP list. This will provide the
+greatest compatibility, especially if a user needs to exit the system.
 
 Users MAY use these individual chain specific addresses.
 
 This feature set provides compatibility with other wallets (eg. metamask),
-allowing the user  to use the same seed in other wallets for any features or
-integrations that are not present in iov-core at launch (although we will work over
-time to provide most of these features).
+allowing the user to use the same seed in other wallets for any features or
+integrations that are not present in iov-core at launch (although we will work
+over time to provide most of these features).
 
 This is support is also critical for users who are importing HD seeds from other
 software, so that we can locate existing tokens for that user. During the import
@@ -404,7 +457,8 @@ used. In the case of many addresses, the user can use a `load more` button.
 
 # Security Concerns
 
-There are a few minor security concerns around Seed management and private key usage, these are addressed here.
+There are a few minor security concerns around Seed management and private key
+usage, these are addressed here.
 
 ## Persisting Seeds on Disk
 

--- a/docs/Keybase-UserStories.md
+++ b/docs/Keybase-UserStories.md
@@ -1,7 +1,8 @@
 # User Stories
 
 Below is a list of User Stories that can guide a developer on an End Users work
-flow when using the Keybase. It is broken down into stories around the following topics:
+flow when using the Keybase. It is broken down into stories around the following
+topics:
 
 - User Management
 - Identity Management
@@ -34,7 +35,8 @@ This removes the `UserProfile` from the store and logs the `User` out.
 
 #### I am a User who is away from my computer for X time.
 
-The profile should lock according to the timeout set in the `User`'s `securityModel`.
+The profile should lock according to the timeout set in the `User`'s
+`securityModel`.
 
 #### I want to logout of my `UserProfile`
 
@@ -62,8 +64,8 @@ populate the `SeedIdentity`.
 #### I want to create an Universal Address Pair
 
 Add two `publicIdentity`s, one for `ed25519` and one for `secp256k1`, to
-`publicIdentities` using the `SeedIdentity`. These identities use only the
-BIP32 standard.
+`publicIdentities` using the `SeedIdentity`. These identities use only the BIP32
+standard.
 
 #### I want to create an Extended Address
 
@@ -74,20 +76,19 @@ identity uses the full BIP44 and BIP32 standards.
 
 The following entries discuss the routes a User will take to use their profile.
 
-####  I want to add a `contact` to my `AddressBook`
+#### I want to add a `contact` to my `AddressBook`
 
 Add a `contact` to the `addressBook` in the `UserProfile`
 
 #### I have a populated `KeyringEntry` and want to sign a something
 
-Create a signature from `bytes`, a `SeedIdentity` and `PublicIdentity`
-pair. Return a `signature`.
+Create a signature from `bytes`, a `SeedIdentity` and `PublicIdentity` pair.
+Return a `signature`.
 
-####  I have a populated `KeyringEntry` and want to get a balance
+#### I have a populated `KeyringEntry` and want to get a balance
 
 Return an `address` and a `chain` from a `PublicIdentity`. These will be used
 query the associated chain.
-
 
 # Export / Backup
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,66 +1,112 @@
 # IOV Core Overview
 
-Below is a general image of interactivity between components of the BCP/Iov-Core system proposed by IOV.
+Below is a general image of interactivity between components of the BCP/Iov-Core
+system proposed by IOV.
 
 ![IOV Core Overview](./iov-read-write.svg)
 
-This document deals specifically with the IOV Core components. However, in the interest of explaining the diagram completely, there are some non IOV Core components described.
+This document deals specifically with the IOV Core components. However, in the
+interest of explaining the diagram completely, there are some non IOV Core
+components described.
 
 # IOV Core Components
 
-The above diagram provides the connectivity flow which a IOV Core based application will follow to enable users to access the system. There are two main avenues for accessing blockchains that are connected via the BCP. These include:
+The above diagram provides the connectivity flow which a IOV Core based
+application will follow to enable users to access the system. There are two main
+avenues for accessing blockchains that are connected via the BCP. These include:
 
 - iov-reader: Queries BCP proxies for data for informational purposes
-- iov-writer: Queries BCP Proxies or the BNS for data that must be verified before being used for write activity
+- iov-writer: Queries BCP Proxies or the BNS for data that must be verified
+  before being used for write activity
 
-The various feature set of BCP (`BCP-Minimal`, `BCP-Basic`, ...) are covered in more detail in the 
+The various feature set of BCP (`BCP-Minimal`, `BCP-Basic`, ...) are covered in
+more detail in the
 [BCP Specification](https://github.com/iov-one/bcp-spec/blob/master/library/iov-core/rpc/README.md#bcp-basic)
 
 ## iov-reader
 
-The `iov-reader` library provides the entire feature set of `BCP-Minimal` and support for `BCP-Basic` as well. `BCP-Minimal`, as evidenced in the diagram, provides the ability to query the proxy for nonce and balance. This does not include the write specific functionality of `sendTx` or `checkTx`, as those operations can only occur in a trusted environment offered by the `keybase`.
+The `iov-reader` library provides the entire feature set of `BCP-Minimal` and
+support for `BCP-Basic` as well. `BCP-Minimal`, as evidenced in the diagram,
+provides the ability to query the proxy for nonce and balance. This does not
+include the write specific functionality of `sendTx` or `checkTx`, as those
+operations can only occur in a trusted environment offered by the `keybase`.
 
-`BCP-Basic` offers extended support for the full feature set of the BCP. This includes querying for:
+`BCP-Basic` offers extended support for the full feature set of the BCP. This
+includes querying for:
 
 - `Transaction History`
 - `Atomic Swaps/Escrow Transactions`
 - `Non Fungible Token States`
 
-This suite of features indicates total compatibility with the BCP specification and its core features.
+This suite of features indicates total compatibility with the BCP specification
+and its core features.
 
-The basic feature set can be extended by both the `BCP-Proxy` and `iov-reader` and is aptly named `BCP-Plus`. This means it includes all of the features of `BCP-Basic` and any new feature that are native to an implementation. This could include new endpoints, or extended functionality to existing endpoints. `BCP-Plus` serves as a blanket definition for any enhanced functionality that is not native to the core `BCP` specification.
+The basic feature set can be extended by both the `BCP-Proxy` and `iov-reader`
+and is aptly named `BCP-Plus`. This means it includes all of the features of
+`BCP-Basic` and any new feature that are native to an implementation. This could
+include new endpoints, or extended functionality to existing endpoints.
+`BCP-Plus` serves as a blanket definition for any enhanced functionality that is
+not native to the core `BCP` specification.
 
 ## iov-writer
 
-In order to ensure users are not being fooled by the web application layer, `iov-writer` is given the ability to query a subset of the `BCP` specification. This subset is named `BCP-Minimal`, as it includes the very base set of features needed to safely perform write operations against a blockchain system. This feature set enables the `keybase` to discover the proper `nonce` for a wallet address, and current balance. Additionally, this mechanism is how transactions are sent and subsequently verified by the `keybase`.
+In order to ensure users are not being fooled by the web application layer,
+`iov-writer` is given the ability to query a subset of the `BCP` specification.
+This subset is named `BCP-Minimal`, as it includes the very base set of features
+needed to safely perform write operations against a blockchain system. This
+feature set enables the `keybase` to discover the proper `nonce` for a wallet
+address, and current balance. Additionally, this mechanism is how transactions
+are sent and subsequently verified by the `keybase`.
 
-`iov-writer` also includes the ability to query the `BNS` directly, as these operations explicitly require verifiable proofs to ensure users are not lied to. The `BNS` feature set includes the `BCP-Minimal` feature set, and the ability to query registered `names` and `blockchain definitions`. Both of these queries include the proofs needed to make operations safe.
+`iov-writer` also includes the ability to query the `BNS` directly, as these
+operations explicitly require verifiable proofs to ensure users are not lied to.
+The `BNS` feature set includes the `BCP-Minimal` feature set, and the ability to
+query registered `names` and `blockchain definitions`. Both of these queries
+include the proofs needed to make operations safe.
 
 ## Web Apps
 
-The web app is a general concept in the system, this can be a web page, an electron app or some other application with the ability to implement both `iov-reader` and communicate with the `keybase` application. It will use `iov-reader` to perform queries against a proxy system and provide state to users. It will communicate with the `keybase` to perform blockchain specific write operations.
+The web app is a general concept in the system, this can be a web page, an
+electron app or some other application with the ability to implement both
+`iov-reader` and communicate with the `keybase` application. It will use
+`iov-reader` to perform queries against a proxy system and provide state to
+users. It will communicate with the `keybase` to perform blockchain specific
+write operations.
 
 #### Query
 
-Web apps will query through `iov-reader` and provide information back to the application.
+Web apps will query through `iov-reader` and provide information back to the
+application.
 
 #### Sign/Verify
 
-Web apps will pass all signing and verification requests to the `keybase`, which will either perform a specific set of queries to create transactions, or verify transactions against an existing blockchain.
+Web apps will pass all signing and verification requests to the `keybase`, which
+will either perform a specific set of queries to create transactions, or verify
+transactions against an existing blockchain.
 
 ## BCP-Proxy
 
-The `BCP-Proxy` serves an abstraction layer that is independent of `IOV Core`. It offers the ability to subscribe to an account state on for a given blockchain. At a minimum, for a blockchain to be supported, it needs to have a proxy node that supports the `BCP-Minimal` feature set.
+The `BCP-Proxy` serves an abstraction layer that is independent of `IOV Core`.
+It offers the ability to subscribe to an account state on for a given
+blockchain. At a minimum, for a blockchain to be supported, it needs to have a
+proxy node that supports the `BCP-Minimal` feature set.
 
 ## Blockchain
 
-The blockchain is a generic concept, it lives behind the proxy and provides its data either through subscriptions from the proxy, or through polling from the proxy when requested.
+The blockchain is a generic concept, it lives behind the proxy and provides its
+data either through subscriptions from the proxy, or through polling from the
+proxy when requested.
 
 ## Blockchain - BNS
 
-The BNS is a first class citizen in the ecosystem of `IOV Core`. It provides the critical functions of locating supported blockchains, and registered name <> accounts. This functionality is critical for `IOV Core` operations and must have the highest level of trust. This means that `iov-writer` must be able to query it directly to ensure there is no falsification of the data itself, or the proofs provided with the data.
-
+The BNS is a first class citizen in the ecosystem of `IOV Core`. It provides the
+critical functions of locating supported blockchains, and registered name <>
+accounts. This functionality is critical for `IOV Core` operations and must have
+the highest level of trust. This means that `iov-writer` must be able to query
+it directly to ensure there is no falsification of the data itself, or the
+proofs provided with the data.
 
 # Roadmap
 
-The [roadmap](ROADMAP.md) covers the route needed to achieve the vision of the above system.
+The [roadmap](ROADMAP.md) covers the route needed to achieve the vision of the
+above system.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -6,7 +6,7 @@ milestones
 The Roadmap is a work-in-progress, so please add comments to help clarify and
 point out missing items
 
------------------- (Mostly) finished, may need polish ------------------------
+---------------- (Mostly) finished, may need polish ----------------
 
 ## BcpConnection/writer MVP
 
@@ -83,7 +83,7 @@ transactions and send tokens on the network.
       bcp-proxy maybe?)
 - [x] Expose API for integration in web wallet (using observables as above)
 
------------------- Next steps ------------------------
+---------------- Next steps ----------------
 
 ## Core-Writer Extension MVP (chrome and firefox?)
 
@@ -137,8 +137,7 @@ Depends on: BNS implementation on backend completed and deployed
       the app
 - TODO....
 
------------------- Rough ideas not quite ready for backlog
-------------------------
+---------------- Rough ideas not quite ready for backlog ----------------
 
 ## Enhancement: Flexible Core-Writer (maybe rethink this one)
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,27 +1,32 @@
 # Technical Roadmap (Rough)
 
-This is a rough map of major points that need to be done to reach
-some milestones
+This is a rough map of major points that need to be done to reach some
+milestones
 
-The Roadmap is a work-in-progress, so please add comments to help clarify and point out missing items
+The Roadmap is a work-in-progress, so please add comments to help clarify and
+point out missing items
 
 ------------------ (Mostly) finished, may need polish ------------------------
 
 ## BcpConnection/writer MVP
 
-MVP just shows we can generate HD keys, save/load them, and use them to sign transactions and send tokens on the network.
+MVP just shows we can generate HD keys, save/load them, and use them to sign
+transactions and send tokens on the network.
 
 - [x] HD Keyring works (with fixed path)
 - [x] KeyringController handles persistence
 - [x] We can encode the sendtx transaction for bcp-demo (`bns-codec`)
 - [x] Tendermint RPC client
-- [x] Client wrapper to parse data as defined in [bcp-minimal](https://github.com/iov-one/bcp-spec/blob/master/library/iov-core/rpc/README.md#bcp-minimal)
-- [x] Simple cli (using repl) tool that will use `IOV Core` codebase to sign and send transactions. Queries proper nonce from the chain
+- [x] Client wrapper to parse data as defined in
+      [bcp-minimal](https://github.com/iov-one/bcp-spec/blob/master/library/iov-core/rpc/README.md#bcp-minimal)
+- [x] Simple cli (using repl) tool that will use `IOV Core` codebase to sign and
+      send transactions. Queries proper nonce from the chain
 
 ## Wallet integration
 
 - [x] Cleanup, open source, and publish iov-core to npm
-- [x] Produce a [webapp](https://github.com/iov-one/bcp-menu) that can show account balances using above interface
+- [x] Produce a [webapp](https://github.com/iov-one/bcp-menu) that can show
+      account balances using above interface
 - [x] Enhance webapp to show tx history
 
 ## Ledger integration (on hold)
@@ -35,7 +40,8 @@ MVP just shows we can generate HD keys, save/load them, and use them to sign tra
 
 ## Streaming interface
 
-- [x] Clarify interface for blockchain client, including subscriptions (observable)
+- [x] Clarify interface for blockchain client, including subscriptions
+      (observable)
 - [x] Enhance Tendermint RPC wrapper to fulfill interface
 - [/] Enhance Lisk/Ethereum adaptors to fulfil interface
 - [x] Update wallet to use new realtime/reactive interface
@@ -50,50 +56,70 @@ MVP just shows we can generate HD keys, save/load them, and use them to sign tra
 
 ## Ethereum Proxy
 
-- [x] Add secp256k1 HD support to `keybase` (same hd path as ed25519simpleaddress for now)
+- [x] Add secp256k1 HD support to `keybase` (same hd path as
+      ed25519simpleaddress for now)
 - [x] Add `bcp-proxy` support to provide `bcp-basic` queries for account balance
-- [x] Add support for sendtx with ETH (encode simple transaction and submit to blockchain)
-- [/] Enable querying all transactions per account (note: currently using etherscan)
+- [x] Add support for sendtx with ETH (encode simple transaction and submit to
+      blockchain)
+- [/] Enable querying all transactions per account (note: currently using
+  etherscan)
 - [x] Add support for 1 testnet, mainnet, and poanetwork
-- [ ] Extend sendtx and queries to handle erc20 tokens, by hardcoding a lookup of token name to contract address and sigfigs
+- [ ] Extend sendtx and queries to handle erc20 tokens, by hardcoding a lookup
+      of token name to contract address and sigfigs
 - [ ] Transaction history shows ERC20 amounts as well as ETH amounts
 - [ ] Implement atomic swap contract in solidity
-- [ ] Add swap transactions and queries that interact with our uploaded swap contract (using hardcoded contract address)
-- [x] Sign Ethereum tx with same HD path as metamask. Importing mnemonic enables use in iov-core and metamask
-- [/] Verify we can use Ethereum chains just like Lisk or `bcp-demo` chain with same webapp, and switch between chains
+- [ ] Add swap transactions and queries that interact with our uploaded swap
+      contract (using hardcoded contract address)
+- [x] Sign Ethereum tx with same HD path as metamask. Importing mnemonic enables
+      use in iov-core and metamask
+- [/] Verify we can use Ethereum chains just like Lisk or `bcp-demo` chain with
+  same webapp, and switch between chains
 
 ## Value name support
 
-- [/] Add transactions to buy, (TODO: transfer, swap) values names (building on NFTs)
-- [x] Improve queries to show proper names for account lookups (bns surely and bcp-proxy maybe?)
+- [/] Add transactions to buy, (TODO: transfer, swap) values names (building on
+  NFTs)
+- [x] Improve queries to show proper names for account lookups (bns surely and
+      bcp-proxy maybe?)
 - [x] Expose API for integration in web wallet (using observables as above)
 
 ------------------ Next steps ------------------------
 
 ## Core-Writer Extension MVP (chrome and firefox?)
 
-- This is to create the equivalent of the metamask plugin using iov-core library under the hood... one approach to securely handle keys in Blockchain UIs, but not the only
+- This is to create the equivalent of the metamask plugin using iov-core library
+  under the hood... one approach to securely handle keys in Blockchain UIs, but
+  not the only
 - [ ] Define public API to call `MultiChainSigner` from webapp
-- [ ] Design simple chrome extension that displays data from `MultiChainSigner`, creates accounts, requests confirmations on signing transactions
-- [ ] Update webapp to talk to MultiChainSigner to query current account and show that balance
-- [ ] Update webapp to send "sendtx" requests to MultiChainSigner based on user input in webapp
-- [ ] MVP should show balances and allow sending in normal webapp, all keys and transactions confirmation in chrome extension
-- [ ] Support both `bcp-demo` and Lisk (and Ethereum, if implemented already) chains
+- [ ] Design simple chrome extension that displays data from `MultiChainSigner`,
+      creates accounts, requests confirmations on signing transactions
+- [ ] Update webapp to talk to MultiChainSigner to query current account and
+      show that balance
+- [ ] Update webapp to send "sendtx" requests to MultiChainSigner based on user
+      input in webapp
+- [ ] MVP should show balances and allow sending in normal webapp, all keys and
+      transactions confirmation in chrome extension
+- [ ] Support both `bcp-demo` and Lisk (and Ethereum, if implemented already)
+      chains
 
 ## Enhancement: BNS Integration
+
 Depends on: BNS implementation on backend completed and deployed
 
 - [x] Add `BCP-Plus` query integration for full BNS feature set
 - [ ] Complete full `tx-codec` support for all BNS transactions
 - [ ] Add support for name lookup via chrome extension
 - [ ] Add management of value name (registration/transfer) to Chrome extension
-- [ ] Add lookup of chains via chrome extension and webapp (extend "chain selector")
+- [ ] Add lookup of chains via chrome extension and webapp (extend "chain
+      selector")
 - [ ] Add queries and browsing of names/chains via webapp (not extension)
 
 ## Enhancement: Cosmos-Sdk support
 
-- [ ] Find/build and test reliable codec for amino encoding in Typescript (look at irisnet work to repurpose protobuf.js)
-- [ ] Find/build and test reliable codec for "canonical json" encoding for building sign bytes
+- [ ] Find/build and test reliable codec for amino encoding in Typescript (look
+      at irisnet work to repurpose protobuf.js)
+- [ ] Find/build and test reliable codec for "canonical json" encoding for
+      building sign bytes
 - [ ] Create valid secp256k1 signatures that match golang code expectations
 - [ ] Query and parse account balances from cosmos-sdk binary
 - [ ] Create a sendtx accepted by cosmos-sdk binary
@@ -107,19 +133,25 @@ Depends on: BNS implementation on backend completed and deployed
 - [ ] Add merkle proofs to all weave/bcp-demo/bns query responses
 - [ ] Write typescript light-client implementation to verify headers and proofs
 - [ ] Integrate this with tendermint rpc to produce secure query
-- [ ] Use Secure Queries to query BNS chain, provide a "root of trust" header in the app
+- [ ] Use Secure Queries to query BNS chain, provide a "root of trust" header in
+      the app
 - TODO....
 
------------------- Rough ideas not quite ready for backlog ------------------------
+------------------ Rough ideas not quite ready for backlog
+------------------------
 
 ## Enhancement: Flexible Core-Writer (maybe rethink this one)
 
 - [x] Design extensible transaction interfaces
-- [ ] Design `meta-codec` format that can generate chain-specific tx-codec for a "blockchain family" given a definition file...
-  - all weave-based systems could share a meta-codec that allows adding individual tx,
-  - all Ethereum chains could customize the swap contract in their definition, etc.
+- [ ] Design `meta-codec` format that can generate chain-specific tx-codec for a
+      "blockchain family" given a definition file...
+  - all weave-based systems could share a meta-codec that allows adding
+    individual tx,
+  - all Ethereum chains could customize the swap contract in their definition,
+    etc.
 - [ ] Add definitions for `bcp-demo` and `bcp-plus` example to the package
-- [ ] Auto-generate chain codecs from `meta-codec` + definition in "txBuilder" lookup
+- [ ] Auto-generate chain codecs from `meta-codec` + definition in "txBuilder"
+      lookup
 - [ ] Sign `bcp-plus` transactions using only definitions
 - TODO....
 
@@ -141,25 +173,33 @@ Depends on: BNS implementation on backend completed and deployed
 
 ## Enhancement: Electron App
 
-- [ ] Package webapp containing `BcpConnection` and `MultiChainSigner` into an  electron binary
-- [ ] Provide streamlined integration of confirmation steps, as the binary should trust itself
+- [ ] Package webapp containing `BcpConnection` and `MultiChainSigner` into an
+      electron binary
+- [ ] Provide streamlined integration of confirmation steps, as the binary
+      should trust itself
 - [ ] Provide packaged version of electron app for download
-- [ ] Experiment with deterministic builds, allowing multiple people to compile and sign the same binary
+- [ ] Experiment with deterministic builds, allowing multiple people to compile
+      and sign the same binary
 - TODO....
 
 ## Enhancement: React-Native App
 
-- [ ] Package webapp containing `BcpConnection` and `MultiChainSigner` into a react-native binary
+- [ ] Package webapp containing `BcpConnection` and `MultiChainSigner` into a
+      react-native binary
 - [ ] Provide simple tx sending workflow (as per electron app)
 - [ ] Provide downloadable version of Android (and iOS?) app for download
-- [ ] Experiment with deterministic builds, allowing multiple people to compile and sign the same binary
+- [ ] Experiment with deterministic builds, allowing multiple people to compile
+      and sign the same binary
 - TODO....
 
 ## Earlier work
 
-* `iov-keybase` was a start to sketch out a public api that could be used when used out of process
-  as a browser extension.
-  It's available on the git tag `iov-keybase`: https://github.com/iov-one/iov-core/tree/iov-keybase/packages/iov-keybase
-* The `KeyController` interface was an approach to design the key controller from top to bottom,
-  which has been superceeded by a bottom-to-top approach that resulted in the now active UserProfile.
-  It's available on the git tag `keycontroller-interface`: https://github.com/iov-one/iov-core/blob/keycontroller-interface/packages/iov-keycontrol/src/keycontroller.d.ts
+- `iov-keybase` was a start to sketch out a public api that could be used when
+  used out of process as a browser extension. It's available on the git tag
+  `iov-keybase`:
+  https://github.com/iov-one/iov-core/tree/iov-keybase/packages/iov-keybase
+- The `KeyController` interface was an approach to design the key controller
+  from top to bottom, which has been superceeded by a bottom-to-top approach
+  that resulted in the now active UserProfile. It's available on the git tag
+  `keycontroller-interface`:
+  https://github.com/iov-one/iov-core/blob/keycontroller-interface/packages/iov-keycontrol/src/keycontroller.d.ts

--- a/docs/out-of-process-rpc.md
+++ b/docs/out-of-process-rpc.md
@@ -1,24 +1,25 @@
 # Out of process RPC interface
 
-The following interface is used to communicate between and application (RPC client)
-and an isolated key store (RPC server). The interface description is technology-agnostic
-and can be implemented for example in JavaScript messages or deep-link URLs.
+The following interface is used to communicate between and application (RPC
+client) and an isolated key store (RPC server). The interface description is
+technology-agnostic and can be implemented for example in JavaScript messages or
+deep-link URLs.
 
 ## Types
 
-| Name                | Definition                        |
-|---------------------|-----------------------------------|
-| `null`              | A representation of _no value_    |
-| List{T}             | A list of elements of type T      |
-| String              | A list of unicode codepoints      |
+| Name                | Definition                                                                |
+| ------------------- | ------------------------------------------------------------------------- |
+| `null`              | A representation of _no value_                                            |
+| List{T}             | A list of elements of type T                                              |
+| String              | A list of unicode codepoints                                              |
 | Identity            | An identity on a blockchain, defined as a pair of chain ID and public key |
-| UnsignedTransaction | A transaction to be signed        |
+| UnsignedTransaction | A transaction to be signed                                                |
 
 ## Methods
 
-| Name          | Input parameters   | Return type   | Description   |
-|---------------|--------------------|---------------|---------------|
-| getIdentities | `reason`: String<br>`chainIds`: List{String} | `identities`: List{Identity} | Request available identities for the specified chains. The user can choose which of the matching identities they want to reveal to the client. |
+| Name          | Input parameters                                       | Return type                       | Description                                                                                                                                                                                                                                                                                                                          |
+| ------------- | ------------------------------------------------------ | --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| getIdentities | `reason`: String<br>`chainIds`: List{String}           | `identities`: List{Identity}      | Request available identities for the specified chains. The user can choose which of the matching identities they want to reveal to the client.                                                                                                                                                                                       |
 | signAndPost   | `reason`: String<br>`transaction`: UnsignedTransaction | `transactionId`: String or `null` | Request signing and posting a transaction prepared by the client. User is asked to confirm the signing after reviewing the transaction content. In case of successful post to the blockchain, the transaction ID is returned to the client to allow tracking the confirmation status. When the request is denied, `null` is retruned |
 
 ## TODO

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "scripts": {
     "bootstrap": "lerna bootstrap",
     "format": "lerna run format",
+    "format-text": "prettier --write --prose-wrap always --print-width 80 \"./*.md\" \"./docs/**/*.md\" && lerna run format-text",
     "lint": "lerna run lint",
     "test": "lerna run test",
     "build": "lerna run build",

--- a/scripts/travis/mode_tests-default.sh
+++ b/scripts/travis/mode_tests-default.sh
@@ -98,6 +98,11 @@ else
   # Sanity
   #
 
+  fold_start "format-text"
+  # This in combination with check-dirty (below) ensures text formatting is up-to-date
+  yarn format-text
+  fold_end
+
   fold_start "update-npmipgnore"
   # This in combination with check-dirty (below) ensures .npmignore files are up-to-date
   ./scripts/update_npmignore.sh


### PR DESCRIPTION
First step for #829

The idea is to format code and text separatly
- since different width is desired,
- to avoid unnecessary build times during development.