### PR TITLE
Implement `getFeeQuote` method on `EthereumConnection`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.13.1
 
 - @iov/ethereum: Allow querying of ERC20 token balances
+- @iov/ethereum: Implement `getFeeQuote` method on `EthereumConnection`.
 
 ## 0.13.0
 

--- a/packages/iov-ethereum/src/ethereumconnection.ts
+++ b/packages/iov-ethereum/src/ethereumconnection.ts
@@ -605,8 +605,27 @@ export class EthereumConnection implements BcpConnection {
     }
   }
 
-  public async getFeeQuote(_: UnsignedTransaction): Promise<Fee> {
-    throw new Error("Not implemented");
+  public async getFeeQuote(transaction: UnsignedTransaction): Promise<Fee> {
+    switch (transaction.kind) {
+      case "bcp/send":
+        return {
+          gasPrice: {
+            // TODO: calculate dynamically from previous blocks or external API
+            quantity: "20000000000", // 20 gwei
+            fractionalDigits: constants.primaryTokenFractionalDigits,
+            tokenTicker: constants.primaryTokenTicker,
+          },
+          gasLimit: {
+            quantity: "2100000",
+            // Those fields are pointless and will be removed in 0.14
+            // https://github.com/iov-one/iov-core/issues/858
+            fractionalDigits: constants.primaryTokenFractionalDigits,
+            tokenTicker: constants.primaryTokenTicker,
+          },
+        };
+      default:
+        throw new Error("Received transaction of unsupported kind.");
+    }
   }
 
   private async socketSend(request: JsonRpcRequest, ignoreNetworkError: boolean = false): Promise<void> {

--- a/packages/iov-ethereum/types/ethereumconnection.d.ts
+++ b/packages/iov-ethereum/types/ethereumconnection.d.ts
@@ -31,7 +31,7 @@ export declare class EthereumConnection implements BcpConnection {
     searchTx(query: BcpTxQuery): Promise<ReadonlyArray<ConfirmedTransaction>>;
     listenTx(query: BcpTxQuery): Stream<ConfirmedTransaction | FailedTransaction>;
     liveTx(query: BcpTxQuery): Stream<ConfirmedTransaction | FailedTransaction>;
-    getFeeQuote(_: UnsignedTransaction): Promise<Fee>;
+    getFeeQuote(transaction: UnsignedTransaction): Promise<Fee>;
     private socketSend;
     private searchTransactionsById;
     private searchSendTransactionsByAddress;


### PR DESCRIPTION
Closes #828

---

Note: I am aware this implementation is not great but a step forward compared to the current hardcoded values in the wallet (https://github.com/iov-one/wallet-demo/blob/v0.11.1/src/logic/account.ts#L123-L132). With this merged, we can change the wallet to use BcpConnection.getFeeQuote independent of the chain.