### PR TITLE
Support sending ERC20 tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.13.1
 
 - @iov/ethereum: Allow querying of ERC20 token balances
+- @iov/ethereum: Allow sending of ERC20 tokens
 - @iov/ethereum: Implement `getFeeQuote` method on `EthereumConnection`.
 - @iov/ethereum: Fix transaction fee parsing for transactions from RPC/scraper.
 - @iov/dpos: Let `Serialization.serializeTransaction` accept transactions with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## 0.13.1
 
-- @iov/bcp: Add optional `SendTransaction.contractAddress` to support smart
-  contract based tokens
 - @iov/ethereum: Allow querying of ERC20 token balances
 - @iov/ethereum: Implement `getFeeQuote` method on `EthereumConnection`.
 - @iov/ethereum: Fix transaction fee parsing for transactions from RPC/scraper.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   contract based tokens
 - @iov/ethereum: Allow querying of ERC20 token balances
 - @iov/ethereum: Implement `getFeeQuote` method on `EthereumConnection`.
+- @iov/ethereum: Fix transaction fee parsing for transactions from RPC/scraper.
 - @iov/dpos: Let `Serialization.serializeTransaction` accept transactions with
   fee set.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.13.1
 
+- @iov/bcp: Add optional `SendTransaction.contractAddress` to support smart
+  contract based tokens
 - @iov/ethereum: Allow querying of ERC20 token balances
 - @iov/ethereum: Implement `getFeeQuote` method on `EthereumConnection`.
 - @iov/dpos: Let `Serialization.serializeTransaction` accept transactions with

--- a/packages/iov-bcp/src/transactions.ts
+++ b/packages/iov-bcp/src/transactions.ts
@@ -217,6 +217,11 @@ export interface SendTransaction extends UnsignedTransaction {
   readonly amount: Amount;
   readonly recipient: Address;
   readonly memo?: string;
+  /**
+   * For smart-contract based token transfers, this is the address of the token contract.
+   * For native token transfers, this is undefined.
+   */
+  readonly contractAddress?: Address;
 }
 
 /** A swap offer or a counter offer */

--- a/packages/iov-bcp/src/transactions.ts
+++ b/packages/iov-bcp/src/transactions.ts
@@ -217,11 +217,6 @@ export interface SendTransaction extends UnsignedTransaction {
   readonly amount: Amount;
   readonly recipient: Address;
   readonly memo?: string;
-  /**
-   * For smart-contract based token transfers, this is the address of the token contract.
-   * For native token transfers, this is undefined.
-   */
-  readonly contractAddress?: Address;
 }
 
 /** A swap offer or a counter offer */

--- a/packages/iov-bcp/types/transactions.d.ts
+++ b/packages/iov-bcp/types/transactions.d.ts
@@ -136,11 +136,6 @@ export interface SendTransaction extends UnsignedTransaction {
     readonly amount: Amount;
     readonly recipient: Address;
     readonly memo?: string;
-    /**
-     * For smart-contract based token transfers, this is the address of the token contract.
-     * For native token transfers, this is undefined.
-     */
-    readonly contractAddress?: Address;
 }
 /** A swap offer or a counter offer */
 export interface SwapOfferTransaction extends UnsignedTransaction {

--- a/packages/iov-bcp/types/transactions.d.ts
+++ b/packages/iov-bcp/types/transactions.d.ts
@@ -136,6 +136,11 @@ export interface SendTransaction extends UnsignedTransaction {
     readonly amount: Amount;
     readonly recipient: Address;
     readonly memo?: string;
+    /**
+     * For smart-contract based token transfers, this is the address of the token contract.
+     * For native token transfers, this is undefined.
+     */
+    readonly contractAddress?: Address;
 }
 /** A swap offer or a counter offer */
 export interface SwapOfferTransaction extends UnsignedTransaction {

--- a/packages/iov-ethereum/src/abi.spec.ts
+++ b/packages/iov-ethereum/src/abi.spec.ts
@@ -54,6 +54,31 @@ describe("Abi", () => {
     });
   });
 
+  describe("encodeUint256", () => {
+    it("works", () => {
+      expect(Abi.encodeUint256("0")).toEqual(
+        fromHex("0000000000000000000000000000000000000000000000000000000000000000"),
+      );
+      expect(Abi.encodeUint256("1")).toEqual(
+        fromHex("0000000000000000000000000000000000000000000000000000000000000001"),
+      );
+      expect(Abi.encodeUint256("2")).toEqual(
+        fromHex("0000000000000000000000000000000000000000000000000000000000000002"),
+      );
+      expect(Abi.encodeUint256("123456789")).toEqual(
+        fromHex("00000000000000000000000000000000000000000000000000000000075bcd15"),
+      );
+    });
+
+    it("throws for invalid input", () => {
+      expect(() => Abi.encodeUint256("")).toThrow();
+      expect(() => Abi.encodeUint256(" 1")).toThrow();
+      expect(() => Abi.encodeUint256("-1")).toThrow();
+      expect(() => Abi.encodeUint256("0x1")).toThrow();
+      expect(() => Abi.encodeUint256("a")).toThrow();
+    });
+  });
+
   describe("decodeHeadTail", () => {
     it("works for single string", () => {
       const data = fromHex(

--- a/packages/iov-ethereum/src/abi.spec.ts
+++ b/packages/iov-ethereum/src/abi.spec.ts
@@ -68,6 +68,14 @@ describe("Abi", () => {
       expect(Abi.encodeUint256("123456789")).toEqual(
         fromHex("00000000000000000000000000000000000000000000000000000000075bcd15"),
       );
+      // 2^255
+      expect(
+        Abi.encodeUint256("57896044618658097711785492504343953926634992332820282019728792003956564819968"),
+      ).toEqual(fromHex("8000000000000000000000000000000000000000000000000000000000000000"));
+      // 2^256-1
+      expect(
+        Abi.encodeUint256("115792089237316195423570985008687907853269984665640564039457584007913129639935"),
+      ).toEqual(fromHex("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"));
     });
 
     it("throws for invalid input", () => {
@@ -76,6 +84,11 @@ describe("Abi", () => {
       expect(() => Abi.encodeUint256("-1")).toThrow();
       expect(() => Abi.encodeUint256("0x1")).toThrow();
       expect(() => Abi.encodeUint256("a")).toThrow();
+
+      // too large (2^256)
+      expect(() =>
+        Abi.encodeUint256("115792089237316195423570985008687907853269984665640564039457584007913129639936"),
+      ).toThrow();
     });
   });
 

--- a/packages/iov-ethereum/src/abi.spec.ts
+++ b/packages/iov-ethereum/src/abi.spec.ts
@@ -79,6 +79,59 @@ describe("Abi", () => {
     });
   });
 
+  describe("decodeAddress", () => {
+    it("works", () => {
+      expect(
+        Abi.decodeAddress(fromHex("0000000000000000000000000000000000000000000000000000000000000000")),
+      ).toEqual("0x0000000000000000000000000000000000000000");
+      expect(
+        Abi.decodeAddress(fromHex("0000000000000000000000000000000000000000000000000000000000000001")),
+      ).toEqual("0x0000000000000000000000000000000000000001");
+      expect(
+        Abi.decodeAddress(fromHex("0000000000000000000000000000000000000000000000000000000000000002")),
+      ).toEqual("0x0000000000000000000000000000000000000002");
+      expect(
+        Abi.decodeAddress(fromHex("00000000000000000000000000000000000000000000000000000000075bcd15")),
+      ).toEqual("0x00000000000000000000000000000000075bcd15");
+      expect(
+        Abi.decodeAddress(fromHex("0000000000000000000000003b8a67ad64160e0b977b6dd877e0fb98878ab902")),
+      ).toEqual("0x3b8a67ad64160e0b977b6dd877e0fb98878ab902");
+    });
+
+    it("throws for invalid input", () => {
+      const tooShort = fromHex("00000000000000000000000000000000000000000000000000000000000000");
+      expect(() => Abi.decodeAddress(tooShort)).toThrow();
+
+      const tooLong = fromHex("000000000000000000000000000000000000000000000000000000000000000000");
+      expect(() => Abi.decodeAddress(tooLong)).toThrow();
+    });
+  });
+
+  describe("decodeUint256", () => {
+    it("works", () => {
+      expect(
+        Abi.decodeUint256(fromHex("0000000000000000000000000000000000000000000000000000000000000000")),
+      ).toEqual("0");
+      expect(
+        Abi.decodeUint256(fromHex("0000000000000000000000000000000000000000000000000000000000000001")),
+      ).toEqual("1");
+      expect(
+        Abi.decodeUint256(fromHex("0000000000000000000000000000000000000000000000000000000000000002")),
+      ).toEqual("2");
+      expect(
+        Abi.decodeUint256(fromHex("00000000000000000000000000000000000000000000000000000000075bcd15")),
+      ).toEqual("123456789");
+    });
+
+    it("throws for invalid input", () => {
+      const tooShort = fromHex("00000000000000000000000000000000000000000000000000000000000000");
+      expect(() => Abi.decodeUint256(tooShort)).toThrow();
+
+      const tooLong = fromHex("000000000000000000000000000000000000000000000000000000000000000000");
+      expect(() => Abi.decodeUint256(tooLong)).toThrow();
+    });
+  });
+
   describe("decodeHeadTail", () => {
     it("works for single string", () => {
       const data = fromHex(

--- a/packages/iov-ethereum/src/abi.ts
+++ b/packages/iov-ethereum/src/abi.ts
@@ -28,6 +28,14 @@ export class Abi {
     return Abi.padTo32(addressBytes);
   }
 
+  public static encodeUint256(value: string): Uint8Array {
+    if (!value.match(/^[0-9]+$/)) {
+      throw new Error("Invalid string format");
+    }
+    const numericValue = new BN(value, 10);
+    return numericValue.toArrayLike(Uint8Array, "be", 32);
+  }
+
   /**
    * Decode head-tail encoded data as described in
    * https://medium.com/@hayeah/how-to-decipher-a-smart-contract-method-call-8ee980311603

--- a/packages/iov-ethereum/src/abi.ts
+++ b/packages/iov-ethereum/src/abi.ts
@@ -36,6 +36,21 @@ export class Abi {
     return numericValue.toArrayLike(Uint8Array, "be", 32);
   }
 
+  public static decodeAddress(binary: Uint8Array): Address {
+    if (binary.length !== 32) {
+      throw new Error("Input data not 256 bit long");
+    }
+    const lowBytes = binary.slice(12);
+    return `0x${Encoding.toHex(lowBytes)}` as Address;
+  }
+
+  public static decodeUint256(binary: Uint8Array): string {
+    if (binary.length !== 32) {
+      throw new Error("Input data not 256 bit long");
+    }
+    return new BN(binary).toString();
+  }
+
   /**
    * Decode head-tail encoded data as described in
    * https://medium.com/@hayeah/how-to-decipher-a-smart-contract-method-call-8ee980311603

--- a/packages/iov-ethereum/src/erc20.spec.ts
+++ b/packages/iov-ethereum/src/erc20.spec.ts
@@ -53,7 +53,7 @@ describe("Erc20", () => {
     contractAddress: "0xCb642A87923580b6F7D07D1471F93361196f2650" as Address,
   };
   const trashToken: Erc20Options = {
-    contractAddress: "0x9768ae2339B48643d710B11dDbDb8A7eDBEa15BC" as Address,
+    contractAddress: "0xF01231195AE56d38fa03F5F2933863A2606A6052" as Address,
     decimals: 9,
     symbol: "TRASH",
     name: "Trash Token",

--- a/packages/iov-ethereum/src/erc20.spec.ts
+++ b/packages/iov-ethereum/src/erc20.spec.ts
@@ -51,6 +51,8 @@ function makeClient(baseUrl: string): EthereumRpcClient {
 describe("Erc20", () => {
   const ashToken: Erc20Options = {
     contractAddress: "0xCb642A87923580b6F7D07D1471F93361196f2650" as Address,
+    decimals: 12,
+    symbol: "ASH",
   };
   const trashToken: Erc20Options = {
     contractAddress: "0xF01231195AE56d38fa03F5F2933863A2606A6052" as Address,

--- a/packages/iov-ethereum/src/erc20.ts
+++ b/packages/iov-ethereum/src/erc20.ts
@@ -11,12 +11,12 @@ export interface EthereumRpcClient {
 
 export interface Erc20Options {
   readonly contractAddress: Address;
-  /** Override on-chain symbol. Use this of contract does not define value on-chain */
-  readonly symbol?: string;
-  /** Override on-chain name. Use this of contract does not define value on-chain */
+  /** The token ticker. Overrides the on-chain value. */
+  readonly symbol: string;
+  /** The number of fractional digits. Overrides the on-chain value. */
+  readonly decimals: number;
+  /** Override on-chain name. Use this if contract does not define value on-chain. */
   readonly name?: string;
-  /** Override on-chain decimals. Use this of contract does not define value on-chain */
-  readonly decimals?: number;
 }
 
 export class Erc20 {

--- a/packages/iov-ethereum/src/ethereumcodec.spec.ts
+++ b/packages/iov-ethereum/src/ethereumcodec.spec.ts
@@ -11,14 +11,15 @@ import {
 import { ExtendedSecp256k1Signature } from "@iov/crypto";
 import { Encoding } from "@iov/encoding";
 
-import { ethereumCodec } from "./ethereumcodec";
+import { ethereumCodec, EthereumRpcTransactionResult } from "./ethereumcodec";
 
 const { fromHex } = Encoding;
 
 describe("ethereumCodec", () => {
   describe("parseBytes", () => {
     it("works", () => {
-      const rawGetTransactionByHashResult = {
+      // curl -sS -X POST --data '{"jsonrpc":"2.0","method":"eth_getTransactionByHash","params":["0x3b87faa3410f33284124a6898fac1001673f0f7c3682d18f55bdff0031cce9ce"],"id":1}' https://rinkeby.infura.io | jq
+      const rawGetTransactionByHashResult: EthereumRpcTransactionResult = {
         blockHash: "0x05ebd1bd99956537f49cfa1104682b3b3f9ff9249fa41a09931ce93368606c21",
         blockNumber: "0x37ef3e",
         from: "0x0a65766695a712af41b5cfecaad217b1a11cb22a",

--- a/packages/iov-ethereum/src/ethereumcodec.spec.ts
+++ b/packages/iov-ethereum/src/ethereumcodec.spec.ts
@@ -19,7 +19,7 @@ const { fromHex } = Encoding;
 describe("ethereumCodec", () => {
   describe("parseBytes", () => {
     it("works", () => {
-      // curl -sS -X POST --data '{"jsonrpc":"2.0","method":"eth_getTransactionByHash","params":["0x3b87faa3410f33284124a6898fac1001673f0f7c3682d18f55bdff0031cce9ce"],"id":1}' https://rinkeby.infura.io | jq
+      // curl -sS -X POST --data '{"jsonrpc":"2.0","method":"eth_getTransactionByHash","params":["0x3b87faa3410f33284124a6898fac1001673f0f7c3682d18f55bdff0031cce9ce"],"id":1}' https://rinkeby.infura.io | jq .result
       const rawGetTransactionByHashResult: EthereumRpcTransactionResult = {
         blockHash: "0x05ebd1bd99956537f49cfa1104682b3b3f9ff9249fa41a09931ce93368606c21",
         blockNumber: "0x37ef3e",

--- a/packages/iov-ethereum/src/ethereumcodec.spec.ts
+++ b/packages/iov-ethereum/src/ethereumcodec.spec.ts
@@ -111,18 +111,18 @@ describe("ethereumCodec", () => {
       ) as PublicKeyBytes;
 
       const postableBytes = Encoding.toUtf8(JSON.stringify(rawGetTransactionByHashResult)) as PostableBytes;
-      const codec = new EthereumCodec({
-        erc20Tokens: new Map<TokenTicker, Erc20Options>([
-          [
-            "WETH" as TokenTicker,
-            {
-              contractAddress: "0xc778417e063141139fce010982780140aa0cd5ab" as Address,
-              decimals: 18,
-              symbol: "WETH" as TokenTicker,
-            },
-          ],
-        ]),
-      });
+
+      const erc20Tokens = new Map<TokenTicker, Erc20Options>([
+        [
+          "WETH" as TokenTicker,
+          {
+            contractAddress: "0xc778417e063141139fce010982780140aa0cd5ab" as Address,
+            decimals: 18,
+            symbol: "WETH" as TokenTicker,
+          },
+        ],
+      ]);
+      const codec = new EthereumCodec({ erc20Tokens: erc20Tokens });
       expect(codec.parseBytes(postableBytes, "ethereum-eip155-4" as ChainId)).toEqual({
         transaction: {
           kind: "bcp/send",
@@ -152,7 +152,6 @@ describe("ethereumCodec", () => {
           },
           recipient: "0x9ea4094Ed5D7E089ac846C7D66fc518bd24753ab" as Address,
           memo: undefined,
-          contractAddress: "0xc778417E063141139Fce010982780140Aa0cD5Ab" as Address,
         },
         primarySignature: {
           nonce: 1 as Nonce,

--- a/packages/iov-ethereum/src/ethereumcodec.spec.ts
+++ b/packages/iov-ethereum/src/ethereumcodec.spec.ts
@@ -85,5 +85,76 @@ describe("ethereumCodec", () => {
         otherSignatures: [],
       });
     });
+
+    it("works for ERC20 transfer", () => {
+      // curl -sS -X POST --data '{"jsonrpc":"2.0","method":"eth_getTransactionByHash","params":["0x80295fc8cdf6ac5fce39f34037f07d5be3abe82baa8468196faf1f00ced239e3"],"id":1}' https://rinkeby.infura.io | jq .result
+      const rawGetTransactionByHashResult: EthereumRpcTransactionResult = {
+        blockHash: "0x135592131306762eef45d8f12c3d27c5d709c84d124f0df062d0bb3806a32701",
+        blockNumber: "0x3f20f6",
+        from: "0x9bd26664827550982960b9e76bcd88c0b6791bb4",
+        gas: "0x226c8",
+        gasPrice: "0x3b9aca00",
+        hash: "0x80295fc8cdf6ac5fce39f34037f07d5be3abe82baa8468196faf1f00ced239e3",
+        input:
+          "0xa9059cbb0000000000000000000000009ea4094ed5d7e089ac846c7d66fc518bd24753ab0000000000000000000000000000000000000000000000000000000000000002",
+        nonce: "0x1",
+        r: "0xcbe96b38321e6ef536da5e74b558cf87acdda825be35be40627b2b3d8633b8f4",
+        s: "0x7fc31ca5bb3dbd02e5e8fc5093082f3f2ab3e0042d4e5b25fe09e5f7485d83b7",
+        to: "0xc778417e063141139fce010982780140aa0cd5ab",
+        transactionIndex: "0x7",
+        v: "0x2b",
+        value: "0x0",
+      };
+      const expectedPubkey = fromHex(
+        "040b8b6f82e7226d21991dd6b1a7de357cebfc42ccb95678404d8e2b54cc3be187b17a50ef833884df318aa7def070585c92a185272b8cb8b61ba916d993435c87",
+      ) as PublicKeyBytes;
+
+      const postableBytes = Encoding.toUtf8(JSON.stringify(rawGetTransactionByHashResult)) as PostableBytes;
+      expect(ethereumCodec.parseBytes(postableBytes, "ethereum-eip155-4" as ChainId)).toEqual({
+        transaction: {
+          kind: "bcp/send",
+          creator: {
+            chainId: "ethereum-eip155-4" as ChainId,
+            pubkey: {
+              algo: Algorithm.Secp256k1,
+              data: expectedPubkey,
+            },
+          },
+          fee: {
+            gasLimit: {
+              quantity: "141000",
+              fractionalDigits: 18,
+              tokenTicker: "ETH" as TokenTicker,
+            },
+            gasPrice: {
+              quantity: "1000000000",
+              fractionalDigits: 18,
+              tokenTicker: "ETH" as TokenTicker,
+            },
+          },
+          amount: {
+            quantity: "2",
+            fractionalDigits: 18,
+            tokenTicker: "TKN" as TokenTicker,
+          },
+          recipient: "0x9ea4094Ed5D7E089ac846C7D66fc518bd24753ab" as Address,
+          memo: undefined,
+          contractAddress: "0xc778417E063141139Fce010982780140Aa0cD5Ab" as Address,
+        },
+        primarySignature: {
+          nonce: 1 as Nonce,
+          pubkey: {
+            algo: Algorithm.Secp256k1,
+            data: expectedPubkey,
+          },
+          signature: new ExtendedSecp256k1Signature(
+            Encoding.fromHex("cbe96b38321e6ef536da5e74b558cf87acdda825be35be40627b2b3d8633b8f4"),
+            Encoding.fromHex("7fc31ca5bb3dbd02e5e8fc5093082f3f2ab3e0042d4e5b25fe09e5f7485d83b7"),
+            0,
+          ).toFixedLength() as SignatureBytes,
+        },
+        otherSignatures: [],
+      });
+    });
   });
 });

--- a/packages/iov-ethereum/src/ethereumcodec.spec.ts
+++ b/packages/iov-ethereum/src/ethereumcodec.spec.ts
@@ -51,9 +51,13 @@ describe("ethereumCodec", () => {
             },
           },
           fee: {
-            // TODO: Make this make sense
-            tokens: {
+            gasLimit: {
               quantity: "141000",
+              fractionalDigits: 18,
+              tokenTicker: "ETH" as TokenTicker,
+            },
+            gasPrice: {
+              quantity: "1000000000",
               fractionalDigits: 18,
               tokenTicker: "ETH" as TokenTicker,
             },

--- a/packages/iov-ethereum/src/ethereumcodec.spec.ts
+++ b/packages/iov-ethereum/src/ethereumcodec.spec.ts
@@ -11,7 +11,8 @@ import {
 import { ExtendedSecp256k1Signature } from "@iov/crypto";
 import { Encoding } from "@iov/encoding";
 
-import { ethereumCodec, EthereumRpcTransactionResult } from "./ethereumcodec";
+import { Erc20Options } from "./erc20";
+import { EthereumCodec, ethereumCodec, EthereumRpcTransactionResult } from "./ethereumcodec";
 
 const { fromHex } = Encoding;
 
@@ -110,7 +111,19 @@ describe("ethereumCodec", () => {
       ) as PublicKeyBytes;
 
       const postableBytes = Encoding.toUtf8(JSON.stringify(rawGetTransactionByHashResult)) as PostableBytes;
-      expect(ethereumCodec.parseBytes(postableBytes, "ethereum-eip155-4" as ChainId)).toEqual({
+      const codec = new EthereumCodec({
+        erc20Tokens: new Map<TokenTicker, Erc20Options>([
+          [
+            "WETH" as TokenTicker,
+            {
+              contractAddress: "0xc778417e063141139fce010982780140aa0cd5ab" as Address,
+              decimals: 18,
+              symbol: "WETH" as TokenTicker,
+            },
+          ],
+        ]),
+      });
+      expect(codec.parseBytes(postableBytes, "ethereum-eip155-4" as ChainId)).toEqual({
         transaction: {
           kind: "bcp/send",
           creator: {
@@ -135,7 +148,7 @@ describe("ethereumCodec", () => {
           amount: {
             quantity: "2",
             fractionalDigits: 18,
-            tokenTicker: "TKN" as TokenTicker,
+            tokenTicker: "WETH" as TokenTicker,
           },
           recipient: "0x9ea4094Ed5D7E089ac846C7D66fc518bd24753ab" as Address,
           memo: undefined,

--- a/packages/iov-ethereum/src/ethereumcodec.spec.ts
+++ b/packages/iov-ethereum/src/ethereumcodec.spec.ts
@@ -38,9 +38,7 @@ describe("ethereumCodec", () => {
         "041d4c015b00cbd914e280b871d3c6ae2a047ca650d3ecea4b5246bb3036d4d74960b7feb09068164d2b82f1c7df9e95839b29ae38e90d60578b2318a54e108cf8",
       ) as PublicKeyBytes;
 
-      const postableBytes = Encoding.toUtf8(
-        JSON.stringify({ ...rawGetTransactionByHashResult, type: 0 }),
-      ) as PostableBytes;
+      const postableBytes = Encoding.toUtf8(JSON.stringify(rawGetTransactionByHashResult)) as PostableBytes;
       expect(ethereumCodec.parseBytes(postableBytes, "ethereum-eip155-4" as ChainId)).toEqual({
         transaction: {
           kind: "bcp/send",

--- a/packages/iov-ethereum/src/ethereumcodec.ts
+++ b/packages/iov-ethereum/src/ethereumcodec.ts
@@ -71,6 +71,7 @@ export const ethereumCodec: TxCodec = {
   parseBytes: (bytes: PostableBytes, chainId: ChainId): SignedTransaction => {
     const json: EthereumRpcTransactionResult = JSON.parse(Encoding.fromUtf8(bytes));
     const nonce = decodeHexQuantityNonce(json.nonce);
+    const value = decodeHexQuantityString(json.value);
     const input = Encoding.fromHex(normalizeHex(json.input));
     const chain: Eip155ChainId = {
       forkState: BlknumForkState.Forked,
@@ -88,7 +89,7 @@ export const ethereumCodec: TxCodec = {
       json.gasPrice,
       json.gas,
       json.to as Address,
-      json.value,
+      value,
       input,
       encodeQuantity(chain.chainId),
     );

--- a/packages/iov-ethereum/src/ethereumcodec.ts
+++ b/packages/iov-ethereum/src/ethereumcodec.ts
@@ -59,7 +59,7 @@ export const ethereumCodec: TxCodec = {
     const signature = new ExtendedSecp256k1Signature(r, s, recoveryParam);
     const signatureBytes = signature.toFixedLength() as SignatureBytes;
 
-    const message = Serialization.serializeUnsignedEthSendTransaction(
+    const message = Serialization.serializeGenericTransaction(
       nonce,
       json.gasPrice,
       json.gas,

--- a/packages/iov-ethereum/src/ethereumcodec.ts
+++ b/packages/iov-ethereum/src/ethereumcodec.ts
@@ -71,42 +71,34 @@ export const ethereumCodec: TxCodec = {
     const messageHash = new Keccak256(message).digest();
     const signerPubkey = Secp256k1.recoverPubkey(signature, messageHash) as PublicKeyBytes;
 
-    let unsignedTransaction: SendTransaction;
-    switch (json.type) {
-      case 0:
-        const send: SendTransaction = {
-          kind: "bcp/send",
-          creator: {
-            chainId: chainId,
-            pubkey: {
-              algo: Algorithm.Secp256k1,
-              data: signerPubkey,
-            },
-          },
-          fee: {
-            // TODO: Make this make sense
-            tokens: {
-              quantity: decodeHexQuantityString(json.gas),
-              fractionalDigits: constants.primaryTokenFractionalDigits,
-              tokenTicker: constants.primaryTokenTicker,
-            },
-          },
-          amount: {
-            quantity: decodeHexQuantityString(json.value),
-            fractionalDigits: constants.primaryTokenFractionalDigits,
-            tokenTicker: constants.primaryTokenTicker,
-          },
-          recipient: toChecksummedAddress(json.to),
-          memo: Encoding.fromUtf8(Encoding.fromHex(normalizeHex(json.input))),
-        };
-        unsignedTransaction = send;
-        break;
-      default:
-        throw new Error("Unsupported transaction type");
-    }
+    const send: SendTransaction = {
+      kind: "bcp/send",
+      creator: {
+        chainId: chainId,
+        pubkey: {
+          algo: Algorithm.Secp256k1,
+          data: signerPubkey,
+        },
+      },
+      fee: {
+        // TODO: Make this make sense
+        tokens: {
+          quantity: decodeHexQuantityString(json.gas),
+          fractionalDigits: constants.primaryTokenFractionalDigits,
+          tokenTicker: constants.primaryTokenTicker,
+        },
+      },
+      amount: {
+        quantity: decodeHexQuantityString(json.value),
+        fractionalDigits: constants.primaryTokenFractionalDigits,
+        tokenTicker: constants.primaryTokenTicker,
+      },
+      recipient: toChecksummedAddress(json.to),
+      memo: Encoding.fromUtf8(Encoding.fromHex(normalizeHex(json.input))),
+    };
 
     return {
-      transaction: unsignedTransaction,
+      transaction: send,
       primarySignature: {
         nonce: nonce,
         pubkey: {

--- a/packages/iov-ethereum/src/ethereumcodec.ts
+++ b/packages/iov-ethereum/src/ethereumcodec.ts
@@ -41,6 +41,7 @@ export interface EthereumRpcTransactionResult {
   readonly blockHash: string;
   readonly blockNumber: string;
   readonly from: string;
+  /** Gas limit as set by the user */
   readonly gas: string;
   readonly gasPrice: string;
   readonly hash: string;
@@ -104,9 +105,13 @@ export const ethereumCodec: TxCodec = {
         },
       },
       fee: {
-        // TODO: Make this make sense
-        tokens: {
+        gasLimit: {
           quantity: decodeHexQuantityString(json.gas),
+          fractionalDigits: constants.primaryTokenFractionalDigits,
+          tokenTicker: constants.primaryTokenTicker,
+        },
+        gasPrice: {
+          quantity: decodeHexQuantityString(json.gasPrice),
           fractionalDigits: constants.primaryTokenFractionalDigits,
           tokenTicker: constants.primaryTokenTicker,
         },

--- a/packages/iov-ethereum/src/ethereumcodec.ts
+++ b/packages/iov-ethereum/src/ethereumcodec.ts
@@ -61,7 +61,11 @@ export interface EthereumRpcTransactionResult {
 }
 
 export interface EthereumCodecOptions {
-  /** List of supported ERC20 tokens */
+  /**
+   * ERC20 tokens supported by the codec instance.
+   *
+   * The behaviour of encoding/decoding transactions for other tokens is undefined.
+   */
   readonly erc20Tokens?: Map<TokenTicker, Erc20Options>;
 }
 

--- a/packages/iov-ethereum/src/ethereumcodec.ts
+++ b/packages/iov-ethereum/src/ethereumcodec.ts
@@ -74,13 +74,13 @@ export class EthereumCodec implements TxCodec {
 
   public bytesToSign(unsigned: UnsignedTransaction, nonce: Nonce): SigningJob {
     return {
-      bytes: Serialization.serializeUnsignedTransaction(unsigned, nonce) as SignableBytes,
+      bytes: Serialization.serializeUnsignedTransaction(unsigned, nonce, this.erc20Tokens) as SignableBytes,
       prehashType: PrehashType.Keccak256,
     };
   }
 
   public bytesToPost(signed: SignedTransaction): PostableBytes {
-    return Serialization.serializeSignedTransaction(signed) as PostableBytes;
+    return Serialization.serializeSignedTransaction(signed, this.erc20Tokens) as PostableBytes;
   }
 
   public identifier(signed: SignedTransaction): TransactionId {
@@ -155,7 +155,6 @@ export class EthereumCodec implements TxCodec {
         },
         recipient: toChecksummedAddress(Abi.decodeAddress(input.slice(4, 4 + 32))),
         memo: undefined,
-        contractAddress: contractAddress,
       };
     } else {
       send = {

--- a/packages/iov-ethereum/src/ethereumconnection.spec.ts
+++ b/packages/iov-ethereum/src/ethereumconnection.spec.ts
@@ -500,9 +500,8 @@ describe("EthereumConnection", () => {
         expect(result).toBeTruthy();
         expect(result.log).toBeUndefined();
 
-        // TODO: reactivate when parsing works
-        // const blockInfo = await result.blockInfo.waitFor(info => !isBlockInfoPending(info));
-        // expect(blockInfo.state).toEqual(TransactionState.Succeeded);
+        const blockInfo = await result.blockInfo.waitFor(info => !isBlockInfoPending(info));
+        expect(blockInfo.state).toEqual(TransactionState.Succeeded);
 
         const recipientAccount = await connection.getAccount({ address: recipientAddress });
         const erc20Balance = recipientAccount!.balance.find(

--- a/packages/iov-ethereum/src/ethereumconnection.spec.ts
+++ b/packages/iov-ethereum/src/ethereumconnection.spec.ts
@@ -146,7 +146,7 @@ describe("EthereumConnection", () => {
         erc20Tokens: testConfig.erc20Tokens,
       });
       const tokens = await connection.getAllTickers();
-      expect(tokens).toEqual(testConfig.tokens);
+      expect(tokens).toEqual(testConfig.expectedTokens);
       connection.disconnect();
     });
   });

--- a/packages/iov-ethereum/src/ethereumconnection.spec.ts
+++ b/packages/iov-ethereum/src/ethereumconnection.spec.ts
@@ -65,7 +65,6 @@ async function randomAddress(): Promise<Address> {
 }
 
 describe("EthereumConnection", () => {
-  const defaultMnemonic = "oxygen fall sure lava energy veteran enroll frown question detail include maximum";
   const defaultAmount: Amount = {
     quantity: "445500",
     fractionalDigits: 18,
@@ -290,7 +289,7 @@ describe("EthereumConnection", () => {
       pendingWithoutEthereum();
 
       const profile = new UserProfile();
-      const wallet = profile.addWallet(Secp256k1HdWallet.fromMnemonic(defaultMnemonic));
+      const wallet = profile.addWallet(Secp256k1HdWallet.fromMnemonic(testConfig.mnemonic));
       const mainIdentity = await profile.createIdentity(wallet.id, testConfig.chainId, HdPaths.ethereum(0));
 
       const recipientAddress = "0xE137f5264b6B528244E1643a2D570b37660B7F14" as Address;
@@ -325,7 +324,7 @@ describe("EthereumConnection", () => {
       pendingWithoutEthereum();
 
       const profile = new UserProfile();
-      const wallet = profile.addWallet(Secp256k1HdWallet.fromMnemonic(defaultMnemonic));
+      const wallet = profile.addWallet(Secp256k1HdWallet.fromMnemonic(testConfig.mnemonic));
       const mainIdentity = await profile.createIdentity(wallet.id, testConfig.chainId, HdPaths.ethereum(0));
 
       const recipientAddress = "0xE137f5264b6B528244E1643a2D570b37660B7F14" as Address;
@@ -372,7 +371,7 @@ describe("EthereumConnection", () => {
       const connection = await EthereumConnection.establish(testConfig.base);
 
       const profile = new UserProfile();
-      const wallet = profile.addWallet(Secp256k1HdWallet.fromMnemonic(defaultMnemonic));
+      const wallet = profile.addWallet(Secp256k1HdWallet.fromMnemonic(testConfig.mnemonic));
       const mainIdentity = await profile.createIdentity(wallet.id, testConfig.chainId, HdPaths.ethereum(0));
 
       const sendTx: SendTransaction = {
@@ -406,7 +405,7 @@ describe("EthereumConnection", () => {
       const connection = await EthereumConnection.establish(testConfig.base);
 
       const profile = new UserProfile();
-      const wallet = profile.addWallet(Secp256k1HdWallet.fromMnemonic(defaultMnemonic));
+      const wallet = profile.addWallet(Secp256k1HdWallet.fromMnemonic(testConfig.mnemonic));
       const brokeIdentity = await profile.createIdentity(
         wallet.id,
         testConfig.chainId,
@@ -439,7 +438,7 @@ describe("EthereumConnection", () => {
       pendingWithoutEthereum();
 
       const profile = new UserProfile();
-      const wallet = profile.addWallet(Secp256k1HdWallet.fromMnemonic(defaultMnemonic));
+      const wallet = profile.addWallet(Secp256k1HdWallet.fromMnemonic(testConfig.mnemonic));
       const mainIdentity = await profile.createIdentity(wallet.id, testConfig.chainId, HdPaths.ethereum(0));
 
       const sendTx: SendTransaction = {
@@ -473,7 +472,7 @@ describe("EthereumConnection", () => {
       pendingWithoutEthereum();
 
       const profile = new UserProfile();
-      const wallet = profile.addWallet(Secp256k1HdWallet.fromMnemonic(defaultMnemonic));
+      const wallet = profile.addWallet(Secp256k1HdWallet.fromMnemonic(testConfig.mnemonic));
       const mainIdentity = await profile.createIdentity(wallet.id, testConfig.chainId, HdPaths.ethereum(0));
 
       const connection = await EthereumConnection.establish(testConfig.base, {
@@ -554,7 +553,7 @@ describe("EthereumConnection", () => {
 
         // post transactions
         const profile = new UserProfile();
-        const wallet = profile.addWallet(Secp256k1HdWallet.fromMnemonic(defaultMnemonic));
+        const wallet = profile.addWallet(Secp256k1HdWallet.fromMnemonic(testConfig.mnemonic));
         const mainIdentity = await profile.createIdentity(wallet.id, testConfig.chainId, HdPaths.ethereum(0));
         const nonce = await connection.getNonce({ pubkey: mainIdentity.pubkey });
         await postTransaction(profile, mainIdentity, nonce, recipient, connection);
@@ -588,7 +587,7 @@ describe("EthereumConnection", () => {
       pendingWithoutEthereum();
 
       const profile = new UserProfile();
-      const wallet = profile.addWallet(Secp256k1HdWallet.fromMnemonic(defaultMnemonic));
+      const wallet = profile.addWallet(Secp256k1HdWallet.fromMnemonic(testConfig.mnemonic));
       const mainIdentity = await profile.createIdentity(wallet.id, testConfig.chainId, HdPaths.ethereum(0));
 
       const recipientAddress = "0xE137f5264b6B528244E1643a2D570b37660B7F14" as Address;
@@ -665,7 +664,7 @@ describe("EthereumConnection", () => {
       });
 
       const profile = new UserProfile();
-      const wallet = profile.addWallet(Secp256k1HdWallet.fromMnemonic(defaultMnemonic));
+      const wallet = profile.addWallet(Secp256k1HdWallet.fromMnemonic(testConfig.mnemonic));
       const mainIdentity = await profile.createIdentity(wallet.id, testConfig.chainId, HdPaths.ethereum(0));
 
       const recipientAddress = await randomAddress();
@@ -832,7 +831,7 @@ describe("EthereumConnection", () => {
         // send transactions
 
         const profile = new UserProfile();
-        const wallet = profile.addWallet(Secp256k1HdWallet.fromMnemonic(defaultMnemonic));
+        const wallet = profile.addWallet(Secp256k1HdWallet.fromMnemonic(testConfig.mnemonic));
         const sender = await profile.createIdentity(wallet.id, testConfig.chainId, HdPaths.ethereum(1));
 
         const sendA: SendTransaction = {
@@ -911,7 +910,7 @@ describe("EthereumConnection", () => {
         // send transactions
 
         const profile = new UserProfile();
-        const wallet = profile.addWallet(Secp256k1HdWallet.fromMnemonic(defaultMnemonic));
+        const wallet = profile.addWallet(Secp256k1HdWallet.fromMnemonic(testConfig.mnemonic));
         const sender = await profile.createIdentity(wallet.id, testConfig.chainId, HdPaths.ethereum(1));
 
         const sendA: SendTransaction = {
@@ -1014,7 +1013,7 @@ describe("EthereumConnection", () => {
         });
 
         const profile = new UserProfile();
-        const wallet = profile.addWallet(Secp256k1HdWallet.fromMnemonic(defaultMnemonic));
+        const wallet = profile.addWallet(Secp256k1HdWallet.fromMnemonic(testConfig.mnemonic));
         const sender = await profile.createIdentity(wallet.id, testConfig.chainId, HdPaths.ethereum(1));
 
         const recipientAddress = await randomAddress();
@@ -1078,7 +1077,7 @@ describe("EthereumConnection", () => {
         // send transactions
 
         const profile = new UserProfile();
-        const wallet = profile.addWallet(Secp256k1HdWallet.fromMnemonic(defaultMnemonic));
+        const wallet = profile.addWallet(Secp256k1HdWallet.fromMnemonic(testConfig.mnemonic));
         const sender = await profile.createIdentity(wallet.id, testConfig.chainId, HdPaths.ethereum(1));
 
         const send: SendTransaction = {
@@ -1182,7 +1181,7 @@ describe("EthereumConnection", () => {
 
         // post transactions
         const profile = new UserProfile();
-        const wallet = profile.addWallet(Secp256k1HdWallet.fromMnemonic(defaultMnemonic));
+        const wallet = profile.addWallet(Secp256k1HdWallet.fromMnemonic(testConfig.mnemonic));
         const mainIdentity = await profile.createIdentity(wallet.id, testConfig.chainId, HdPaths.ethereum(0));
 
         const [nonceA, nonceB] = await connection.getNonces({ pubkey: mainIdentity.pubkey }, 2);

--- a/packages/iov-ethereum/src/ethereumconnection.spec.ts
+++ b/packages/iov-ethereum/src/ethereumconnection.spec.ts
@@ -26,7 +26,7 @@ import { HdPaths, Secp256k1HdWallet, UserProfile } from "@iov/keycontrol";
 import { toListPromise } from "@iov/stream";
 
 import { pubkeyToAddress } from "./address";
-import { ethereumCodec } from "./ethereumcodec";
+import { ethereumCodec, EthereumCodec } from "./ethereumcodec";
 import { EthereumConnection } from "./ethereumconnection";
 import { testConfig } from "./testconfig.spec";
 
@@ -479,6 +479,10 @@ describe("EthereumConnection", () => {
         erc20Tokens: testConfig.erc20Tokens,
       });
 
+      const codec = new EthereumCodec({
+        erc20Tokens: testConfig.erc20Tokens,
+      });
+
       for (const transferTest of testConfig.erc20TransferTests) {
         const recipientAddress = await randomAddress();
 
@@ -493,8 +497,8 @@ describe("EthereumConnection", () => {
           ...transferTest,
         };
         const nonce = await connection.getNonce({ pubkey: mainIdentity.pubkey });
-        const signed = await profile.signTransaction(sendTx, ethereumCodec, nonce);
-        const bytesToPost = ethereumCodec.bytesToPost(signed);
+        const signed = await profile.signTransaction(sendTx, codec, nonce);
+        const bytesToPost = codec.bytesToPost(signed);
 
         const result = await connection.postTx(bytesToPost);
         expect(result).toBeTruthy();

--- a/packages/iov-ethereum/src/ethereumconnection.ts
+++ b/packages/iov-ethereum/src/ethereumconnection.ts
@@ -36,7 +36,7 @@ import { concat, DefaultValueProducer, ValueAndUpdates } from "@iov/stream";
 import { pubkeyToAddress } from "./address";
 import { constants } from "./constants";
 import { Erc20, Erc20Options } from "./erc20";
-import { ethereumCodec } from "./ethereumcodec";
+import { EthereumCodec } from "./ethereumcodec";
 import { HttpJsonRpcClient } from "./httpjsonrpcclient";
 import { Parse } from "./parse";
 import {
@@ -91,6 +91,7 @@ export class EthereumConnection implements BcpConnection {
   private readonly socket: StreamingSocket | undefined;
   private readonly scraperApiUrl: string | undefined;
   private readonly erc20Tokens = new Map<TokenTicker, Erc20>();
+  private readonly codec: EthereumCodec;
 
   constructor(baseUrl: string, chainId: ChainId, options?: EthereumConnectionOptions) {
     this.rpcClient = new HttpJsonRpcClient(baseUrl);
@@ -129,6 +130,10 @@ export class EthereumConnection implements BcpConnection {
         }
       }
     }
+
+    this.codec = new EthereumCodec({
+      erc20Tokens: options ? options.erc20Tokens : undefined,
+    });
   }
 
   public disconnect(): void {
@@ -662,7 +667,7 @@ export class EthereumConnection implements BcpConnection {
 
     const currentHeight = await this.height();
     const confirmations = currentHeight - transactionHeight + 1;
-    const transaction = ethereumCodec.parseBytes(
+    const transaction = this.codec.parseBytes(
       Encoding.toUtf8(JSON.stringify(transactionsResponse.result)) as PostableBytes,
       this.myChainId,
     );

--- a/packages/iov-ethereum/src/ethereumconnection.ts
+++ b/packages/iov-ethereum/src/ethereumconnection.ts
@@ -662,12 +662,8 @@ export class EthereumConnection implements BcpConnection {
 
     const currentHeight = await this.height();
     const confirmations = currentHeight - transactionHeight + 1;
-    const transactionJson = {
-      ...transactionsResponse.result,
-      type: 0,
-    };
     const transaction = ethereumCodec.parseBytes(
-      Encoding.toUtf8(JSON.stringify(transactionJson)) as PostableBytes,
+      Encoding.toUtf8(JSON.stringify(transactionsResponse.result)) as PostableBytes,
       this.myChainId,
     );
     const transactionId = `0x${normalizeHex(transactionsResponse.result.hash)}` as TransactionId;

--- a/packages/iov-ethereum/src/serialization.spec.ts
+++ b/packages/iov-ethereum/src/serialization.spec.ts
@@ -14,6 +14,7 @@ import {
 import { ExtendedSecp256k1Signature } from "@iov/crypto";
 import { Encoding } from "@iov/encoding";
 
+import { Erc20Options } from "./erc20";
 import { Serialization } from "./serialization";
 
 const { serializeSignedTransaction, serializeUnsignedTransaction } = Serialization;
@@ -236,7 +237,6 @@ describe("Serialization", () => {
           },
         },
         recipient: "0x8fec1c262599f4169401ff48a9d63503ceaaf742" as Address,
-        contractAddress: "0x6c6ee5e31d828de241282b9606c8e98ea48526e2" as Address,
       };
       const nonce = 26 as Nonce;
 
@@ -252,7 +252,17 @@ describe("Serialization", () => {
           // zero length s
           "80",
       );
-      const serializedTx = serializeUnsignedTransaction(tx, nonce);
+      const erc20Tokens = new Map<TokenTicker, Erc20Options>([
+        [
+          "HOT" as TokenTicker,
+          {
+            contractAddress: "0x6c6ee5e31d828de241282b9606c8e98ea48526e2" as Address,
+            symbol: "HOT" as TokenTicker,
+            decimals: 18,
+          },
+        ],
+      ]);
+      const serializedTx = serializeUnsignedTransaction(tx, nonce, erc20Tokens);
       expect(serializedTx).toEqual(expected);
     });
   });
@@ -346,7 +356,6 @@ describe("Serialization", () => {
             },
           },
           recipient: "0x8fec1c262599f4169401ff48a9d63503ceaaf742" as Address,
-          contractAddress: "0x6c6ee5e31d828de241282b9606c8e98ea48526e2" as Address,
         },
         primarySignature: {
           nonce: 26 as Nonce,
@@ -365,7 +374,18 @@ describe("Serialization", () => {
       const expected = fromHex(
         "f8a91a850165a0bc0082cdbd946c6ee5e31d828de241282b9606c8e98ea48526e280b844a9059cbb0000000000000000000000008fec1c262599f4169401ff48a9d63503ceaaf74200000000000000000000000000000000000000000000385c193e12be6d312c0025a06a6bbd9d45779c81a24172a1c90e9790033cce1fd6893a49ac31d972e436ee37a0443fbc313ff9e4399da1b285bd3f9b9c776349b61d0334c83f4eb51ba67a0a7d",
       );
-      const serializedTx = serializeSignedTransaction(signed);
+
+      const erc20Tokens = new Map<TokenTicker, Erc20Options>([
+        [
+          "HOT" as TokenTicker,
+          {
+            contractAddress: "0x6c6ee5e31d828de241282b9606c8e98ea48526e2" as Address,
+            symbol: "HOT" as TokenTicker,
+            decimals: 18,
+          },
+        ],
+      ]);
+      const serializedTx = serializeSignedTransaction(signed, erc20Tokens);
       expect(serializedTx).toEqual(expected);
     });
   });

--- a/packages/iov-ethereum/src/serialization.spec.ts
+++ b/packages/iov-ethereum/src/serialization.spec.ts
@@ -314,5 +314,59 @@ describe("Serialization", () => {
         ),
       );
     });
+
+    it("can serialize ERC20 token transfer", () => {
+      // https://etherscan.io/getRawTx?tx=0x5d08a3cda172df9520f965549b4d7fc4b32baa026e8beff5293ba90c845c93b2
+      // 266151.44240739 HOT from 0xc023d0f30ef630db4f4be6219608d6bcf99684f0 to 0x8fec1c262599f4169401ff48a9d63503ceaaf742
+      const signed: SignedTransaction<SendTransaction> = {
+        transaction: {
+          kind: "bcp/send",
+          creator: {
+            chainId: "ethereum-eip155-1" as ChainId,
+            pubkey: {
+              algo: Algorithm.Secp256k1,
+              data: fromHex("") as PublicKeyBytes,
+            },
+          },
+          amount: {
+            quantity: "266151442407390000000000",
+            fractionalDigits: 18,
+            tokenTicker: "HOT" as TokenTicker,
+          },
+          fee: {
+            gasPrice: {
+              quantity: "6000000000", // 6 Gwei
+              fractionalDigits: 18,
+              tokenTicker: "ETH" as TokenTicker,
+            },
+            gasLimit: {
+              quantity: "52669",
+              fractionalDigits: 18,
+              tokenTicker: "ETH" as TokenTicker,
+            },
+          },
+          recipient: "0x8fec1c262599f4169401ff48a9d63503ceaaf742" as Address,
+          contractAddress: "0x6c6ee5e31d828de241282b9606c8e98ea48526e2" as Address,
+        },
+        primarySignature: {
+          nonce: 26 as Nonce,
+          pubkey: {
+            algo: Algorithm.Secp256k1,
+            data: new Uint8Array([]) as PublicKeyBytes, // unused for serialization
+          },
+          signature: new ExtendedSecp256k1Signature(
+            fromHex("6a6bbd9d45779c81a24172a1c90e9790033cce1fd6893a49ac31d972e436ee37"),
+            fromHex("443fbc313ff9e4399da1b285bd3f9b9c776349b61d0334c83f4eb51ba67a0a7d"),
+            0,
+          ).toFixedLength() as SignatureBytes,
+        },
+        otherSignatures: [],
+      };
+      const expected = fromHex(
+        "f8a91a850165a0bc0082cdbd946c6ee5e31d828de241282b9606c8e98ea48526e280b844a9059cbb0000000000000000000000008fec1c262599f4169401ff48a9d63503ceaaf74200000000000000000000000000000000000000000000385c193e12be6d312c0025a06a6bbd9d45779c81a24172a1c90e9790033cce1fd6893a49ac31d972e436ee37a0443fbc313ff9e4399da1b285bd3f9b9c776349b61d0334c83f4eb51ba67a0a7d",
+      );
+      const serializedTx = serializeSignedTransaction(signed);
+      expect(serializedTx).toEqual(expected);
+    });
   });
 });

--- a/packages/iov-ethereum/src/serialization.spec.ts
+++ b/packages/iov-ethereum/src/serialization.spec.ts
@@ -205,6 +205,56 @@ describe("Serialization", () => {
         /not a unsigned safe integer/i,
       );
     });
+
+    it("can serialize ERC20 token transfer", () => {
+      // https://etherscan.io/getRawTx?tx=0x5d08a3cda172df9520f965549b4d7fc4b32baa026e8beff5293ba90c845c93b2
+      // 266151.44240739 HOT from 0xc023d0f30ef630db4f4be6219608d6bcf99684f0 to 0x8fec1c262599f4169401ff48a9d63503ceaaf742
+      const tx: SendTransaction = {
+        kind: "bcp/send",
+        creator: {
+          chainId: "ethereum-eip155-1" as ChainId,
+          pubkey: {
+            algo: Algorithm.Secp256k1,
+            data: fromHex("") as PublicKeyBytes,
+          },
+        },
+        amount: {
+          quantity: "266151442407390000000000",
+          fractionalDigits: 18,
+          tokenTicker: "HOT" as TokenTicker,
+        },
+        fee: {
+          gasPrice: {
+            quantity: "6000000000", // 6 Gwei
+            fractionalDigits: 18,
+            tokenTicker: "ETH" as TokenTicker,
+          },
+          gasLimit: {
+            quantity: "52669",
+            fractionalDigits: 18,
+            tokenTicker: "ETH" as TokenTicker,
+          },
+        },
+        recipient: "0x8fec1c262599f4169401ff48a9d63503ceaaf742" as Address,
+        contractAddress: "0x6c6ee5e31d828de241282b9606c8e98ea48526e2" as Address,
+      };
+      const nonce = 26 as Nonce;
+
+      const expected = fromHex(
+        // full length of list
+        "f869" +
+          // content from getRawTx with signatures stripped off
+          "1a850165a0bc0082cdbd946c6ee5e31d828de241282b9606c8e98ea48526e280b844a9059cbb0000000000000000000000008fec1c262599f4169401ff48a9d63503ceaaf74200000000000000000000000000000000000000000000385c193e12be6d312c00" +
+          // chain ID = 1
+          "01" +
+          // zero length r
+          "80" +
+          // zero length s
+          "80",
+      );
+      const serializedTx = serializeUnsignedTransaction(tx, nonce);
+      expect(serializedTx).toEqual(expected);
+    });
   });
 
   describe("serializeSignedTransaction", () => {

--- a/packages/iov-ethereum/src/serialization.ts
+++ b/packages/iov-ethereum/src/serialization.ts
@@ -1,4 +1,4 @@
-import { isSendTransaction, Nonce, SignedTransaction, UnsignedTransaction } from "@iov/bcp";
+import { Address, isSendTransaction, Nonce, SignedTransaction, UnsignedTransaction } from "@iov/bcp";
 import { ExtendedSecp256k1Signature } from "@iov/crypto";
 import { Encoding, Int53 } from "@iov/encoding";
 
@@ -14,19 +14,23 @@ export class Serialization {
     nonce: Nonce,
     gasPriceHex: string,
     gasLimitHex: string,
-    recipientHex: string,
+    recipient: Address,
     valueHex: string,
     data: Uint8Array,
     v: string,
     r?: Uint8Array,
     s?: Uint8Array,
   ): Uint8Array {
+    if (!isValidAddress(recipient)) {
+      throw new Error("Invalid recipient address");
+    }
+
     // Last 3 items are v, r and s values. Are present to encode full structure.
     return toRlp([
       Serialization.encodeNonce(nonce),
       fromHex(normalizeHex(gasPriceHex)),
       fromHex(normalizeHex(gasLimitHex)),
-      fromHex(normalizeHex(recipientHex)),
+      fromHex(normalizeHex(recipient)),
       fromHex(normalizeHex(valueHex)),
       data,
       fromHex(normalizeHex(v)),

--- a/packages/iov-ethereum/src/serialization.ts
+++ b/packages/iov-ethereum/src/serialization.ts
@@ -95,22 +95,15 @@ export class Serialization {
     const unsigned = signed.transaction;
 
     if (isSendTransaction(unsigned)) {
-      let gasPriceHex = "0x";
-      let gasLimitHex = "0x";
-
-      const valueHex = encodeQuantityString(unsigned.amount.quantity);
-      if (unsigned.fee && unsigned.fee.gasPrice) {
-        gasPriceHex = encodeQuantityString(unsigned.fee.gasPrice.quantity);
-      }
-      if (unsigned.fee && unsigned.fee.gasLimit) {
-        gasLimitHex = encodeQuantityString(unsigned.fee.gasLimit.quantity);
-      }
-
-      const data = Encoding.toUtf8(unsigned.memo || "");
+      const gasPriceHex =
+        unsigned.fee && unsigned.fee.gasPrice ? encodeQuantityString(unsigned.fee.gasPrice.quantity) : "0x";
+      const gasLimitHex =
+        unsigned.fee && unsigned.fee.gasLimit ? encodeQuantityString(unsigned.fee.gasLimit.quantity) : "0x";
 
       if (!isValidAddress(unsigned.recipient)) {
         throw new Error("Invalid recipient address");
       }
+
       const sig = ExtendedSecp256k1Signature.fromFixedLength(signed.primarySignature.signature);
       const r = sig.r();
       const s = sig.s();
@@ -120,6 +113,9 @@ export class Serialization {
           ? { forkState: BlknumForkState.Forked, chainId: chainId }
           : { forkState: BlknumForkState.Before };
       const v = eip155V(chain, sig.recovery);
+
+      const valueHex = encodeQuantityString(unsigned.amount.quantity);
+      const data = Encoding.toUtf8(unsigned.memo || "");
       return Serialization.serializeGenericTransaction(
         signed.primarySignature.nonce,
         gasPriceHex,

--- a/packages/iov-ethereum/src/serialization.ts
+++ b/packages/iov-ethereum/src/serialization.ts
@@ -16,7 +16,7 @@ export class Serialization {
     gasLimitHex: string,
     recipientHex: string,
     valueHex: string,
-    dataHex: string,
+    data: Uint8Array,
     chainIdHex: string,
   ): Uint8Array {
     // Last 3 items are v, r and s values. Are present to encode full structure.
@@ -26,7 +26,7 @@ export class Serialization {
       fromHex(normalizeHex(gasLimitHex)),
       fromHex(normalizeHex(recipientHex)),
       fromHex(normalizeHex(valueHex)),
-      fromHex(normalizeHex(dataHex)),
+      data,
       fromHex(normalizeHex(chainIdHex)),
       new Uint8Array([]),
       new Uint8Array([]),
@@ -67,21 +67,20 @@ export class Serialization {
           gasPriceHex,
           gasLimitHex,
           unsigned.contractAddress,
-          "0x",
-          "0x" + Encoding.toHex(erc20TransferCall),
+          "0x", // ETH value
+          erc20TransferCall,
           chainIdHex,
         );
       } else {
-        const valueHex = encodeQuantityString(unsigned.amount.quantity);
-        const dataHex = unsigned.memo ? "0x" + Encoding.toHex(Encoding.toUtf8(unsigned.memo)) : "0x";
         // native ETH send
+        const memoData = unsigned.memo ? Encoding.toUtf8(unsigned.memo) : new Uint8Array([]);
         return Serialization.serializeUnsignedEthSendTransaction(
           nonce,
           gasPriceHex,
           gasLimitHex,
           unsigned.recipient,
-          valueHex,
-          dataHex,
+          encodeQuantityString(unsigned.amount.quantity),
+          memoData,
           chainIdHex,
         );
       }

--- a/packages/iov-ethereum/src/serialization.ts
+++ b/packages/iov-ethereum/src/serialization.ts
@@ -10,14 +10,16 @@ import { encodeQuantity, encodeQuantityString, fromBcpChainId, normalizeHex } fr
 const { fromHex } = Encoding;
 
 export class Serialization {
-  public static serializeUnsignedEthSendTransaction(
+  public static serializeGenericTransaction(
     nonce: Nonce,
     gasPriceHex: string,
     gasLimitHex: string,
     recipientHex: string,
     valueHex: string,
     data: Uint8Array,
-    chainIdHex: string,
+    v: string,
+    r?: Uint8Array,
+    s?: Uint8Array,
   ): Uint8Array {
     // Last 3 items are v, r and s values. Are present to encode full structure.
     return toRlp([
@@ -27,9 +29,9 @@ export class Serialization {
       fromHex(normalizeHex(recipientHex)),
       fromHex(normalizeHex(valueHex)),
       data,
-      fromHex(normalizeHex(chainIdHex)),
-      new Uint8Array([]),
-      new Uint8Array([]),
+      fromHex(normalizeHex(v)),
+      r || new Uint8Array([]),
+      s || new Uint8Array([]),
     ]);
   }
 
@@ -62,7 +64,7 @@ export class Serialization {
           ...Abi.encodeUint256(unsigned.amount.quantity),
         ]);
 
-        return Serialization.serializeUnsignedEthSendTransaction(
+        return Serialization.serializeGenericTransaction(
           nonce,
           gasPriceHex,
           gasLimitHex,
@@ -74,7 +76,7 @@ export class Serialization {
       } else {
         // native ETH send
         const memoData = unsigned.memo ? Encoding.toUtf8(unsigned.memo) : new Uint8Array([]);
-        return Serialization.serializeUnsignedEthSendTransaction(
+        return Serialization.serializeGenericTransaction(
           nonce,
           gasPriceHex,
           gasLimitHex,
@@ -95,7 +97,6 @@ export class Serialization {
     if (isSendTransaction(unsigned)) {
       let gasPriceHex = "0x";
       let gasLimitHex = "0x";
-      let dataHex = "0x";
 
       const valueHex = encodeQuantityString(unsigned.amount.quantity);
       if (unsigned.fee && unsigned.fee.gasPrice) {
@@ -104,13 +105,12 @@ export class Serialization {
       if (unsigned.fee && unsigned.fee.gasLimit) {
         gasLimitHex = encodeQuantityString(unsigned.fee.gasLimit.quantity);
       }
-      if (unsigned.memo) {
-        dataHex += Encoding.toHex(Encoding.toUtf8(unsigned.memo));
-      }
+
+      const data = Encoding.toUtf8(unsigned.memo || "");
+
       if (!isValidAddress(unsigned.recipient)) {
         throw new Error("Invalid recipient address");
       }
-      const encodedNonce = Serialization.encodeNonce(signed.primarySignature.nonce);
       const sig = ExtendedSecp256k1Signature.fromFixedLength(signed.primarySignature.signature);
       const r = sig.r();
       const s = sig.s();
@@ -120,18 +120,17 @@ export class Serialization {
           ? { forkState: BlknumForkState.Forked, chainId: chainId }
           : { forkState: BlknumForkState.Before };
       const v = eip155V(chain, sig.recovery);
-      const postableTx = toRlp([
-        encodedNonce,
-        fromHex(normalizeHex(gasPriceHex)),
-        fromHex(normalizeHex(gasLimitHex)),
-        fromHex(normalizeHex(unsigned.recipient)),
-        fromHex(normalizeHex(valueHex)),
-        fromHex(normalizeHex(dataHex)),
-        fromHex(normalizeHex(encodeQuantity(v))),
+      return Serialization.serializeGenericTransaction(
+        signed.primarySignature.nonce,
+        gasPriceHex,
+        gasLimitHex,
+        unsigned.recipient,
+        valueHex,
+        data,
+        encodeQuantity(v),
         r,
         s,
-      ]);
-      return postableTx;
+      );
     } else {
       throw new Error("Unsupported kind of transaction");
     }

--- a/packages/iov-ethereum/src/serialization.ts
+++ b/packages/iov-ethereum/src/serialization.ts
@@ -99,10 +99,14 @@ export class Serialization {
     const unsigned = signed.transaction;
 
     if (isSendTransaction(unsigned)) {
-      const gasPriceHex =
-        unsigned.fee && unsigned.fee.gasPrice ? encodeQuantityString(unsigned.fee.gasPrice.quantity) : "0x";
-      const gasLimitHex =
-        unsigned.fee && unsigned.fee.gasLimit ? encodeQuantityString(unsigned.fee.gasLimit.quantity) : "0x";
+      if (!unsigned.fee || !unsigned.fee.gasPrice) {
+        throw new Error("fee.gasPrice must be set");
+      }
+      const gasPriceHex = encodeQuantityString(unsigned.fee.gasPrice.quantity);
+      if (!unsigned.fee.gasLimit) {
+        throw new Error("fee.gasLimit must be set");
+      }
+      const gasLimitHex = encodeQuantityString(unsigned.fee.gasLimit.quantity);
 
       if (!isValidAddress(unsigned.recipient)) {
         throw new Error("Invalid recipient address");

--- a/packages/iov-ethereum/src/testconfig.spec.ts
+++ b/packages/iov-ethereum/src/testconfig.spec.ts
@@ -60,7 +60,7 @@ export interface EthereumNetworkConfig {
     readonly gasLimitTooLow: RegExp;
   };
   readonly erc20Tokens: Map<TokenTicker, Erc20Options>;
-  readonly tokens: ReadonlyArray<BcpTicker>;
+  readonly expectedTokens: ReadonlyArray<BcpTicker>;
 }
 
 // Set environment variable ETHEREUM_NETWORK to "local" (default), "ropsten", "rinkeby"
@@ -171,7 +171,7 @@ const local: EthereumNetworkConfig = {
       },
     ],
   ]),
-  tokens: [
+  expectedTokens: [
     {
       tokenTicker: "ETH" as TokenTicker,
       tokenName: "Ether",
@@ -259,7 +259,7 @@ const ropsten: EthereumNetworkConfig = {
     gasLimitTooLow: /intrinsic gas too low/i,
   },
   erc20Tokens: new Map([]),
-  tokens: [
+  expectedTokens: [
     {
       tokenTicker: "ETH" as TokenTicker,
       tokenName: "Ether",
@@ -353,7 +353,7 @@ const rinkeby: EthereumNetworkConfig = {
   erc20Tokens: new Map<TokenTicker, Erc20Options>([
     ["WETH" as TokenTicker, { contractAddress: "0xc778417e063141139fce010982780140aa0cd5ab" as Address }],
   ]),
-  tokens: [
+  expectedTokens: [
     {
       tokenTicker: "ETH" as TokenTicker,
       tokenName: "Ether",

--- a/packages/iov-ethereum/src/testconfig.spec.ts
+++ b/packages/iov-ethereum/src/testconfig.spec.ts
@@ -27,6 +27,7 @@ export interface EthereumNetworkConfig {
   readonly wsUrl: string;
   readonly chainId: ChainId;
   readonly minHeight: number;
+  readonly mnemonic: string;
   readonly accountStates: {
     /** An account with ETH and ERC20 balance */
     readonly default: {
@@ -78,6 +79,7 @@ const local: EthereumNetworkConfig = {
   wsUrl: "ws://localhost:8545/ws",
   chainId: "ethereum-eip155-5777" as ChainId,
   minHeight: 0, // ganache does not auto-generate a genesis block
+  mnemonic: "oxygen fall sure lava energy veteran enroll frown question detail include maximum",
   accountStates: {
     default: {
       pubkey: {
@@ -221,6 +223,7 @@ const ropsten: EthereumNetworkConfig = {
   wsUrl: "wss://ropsten.infura.io/ws",
   chainId: "ethereum-eip155-3" as ChainId,
   minHeight: 4284887,
+  mnemonic: "oxygen fall sure lava energy veteran enroll frown question detail include maximum",
   accountStates: {
     default: {
       pubkey: {
@@ -299,6 +302,7 @@ const rinkeby: EthereumNetworkConfig = {
   wsUrl: "wss://rinkeby.infura.io/ws",
   chainId: "ethereum-eip155-4" as ChainId,
   minHeight: 3211058,
+  mnemonic: "retire bench island cushion panther noodle cactus keep danger assault home letter",
   accountStates: {
     default: {
       // Second account (m/44'/60'/0'/0/1) of

--- a/packages/iov-ethereum/src/testconfig.spec.ts
+++ b/packages/iov-ethereum/src/testconfig.spec.ts
@@ -16,6 +16,11 @@ import { Erc20Options } from "./erc20";
 
 const { fromHex } = Encoding;
 
+export interface Erc20TransferTest {
+  readonly contractAddress: Address;
+  readonly amount: Amount;
+}
+
 export interface EthereumNetworkConfig {
   readonly env: string;
   readonly base: string;
@@ -60,6 +65,7 @@ export interface EthereumNetworkConfig {
     readonly gasLimitTooLow: RegExp;
   };
   readonly erc20Tokens: Map<TokenTicker, Erc20Options>;
+  readonly erc20TransferTests: ReadonlyArray<Erc20TransferTest>;
   readonly expectedTokens: ReadonlyArray<BcpTicker>;
 }
 
@@ -171,6 +177,24 @@ const local: EthereumNetworkConfig = {
       },
     ],
   ]),
+  erc20TransferTests: [
+    {
+      contractAddress: "0xCb642A87923580b6F7D07D1471F93361196f2650" as Address,
+      amount: {
+        quantity: "3",
+        tokenTicker: "ASH" as TokenTicker,
+        fractionalDigits: 12,
+      },
+    },
+    {
+      contractAddress: "0x9768ae2339B48643d710B11dDbDb8A7eDBEa15BC" as Address,
+      amount: {
+        quantity: "5678",
+        tokenTicker: "TRASH" as TokenTicker,
+        fractionalDigits: 9,
+      },
+    },
+  ],
   expectedTokens: [
     {
       tokenTicker: "ETH" as TokenTicker,
@@ -259,6 +283,7 @@ const ropsten: EthereumNetworkConfig = {
     gasLimitTooLow: /intrinsic gas too low/i,
   },
   erc20Tokens: new Map([]),
+  erc20TransferTests: [],
   expectedTokens: [
     {
       tokenTicker: "ETH" as TokenTicker,
@@ -353,6 +378,7 @@ const rinkeby: EthereumNetworkConfig = {
   erc20Tokens: new Map<TokenTicker, Erc20Options>([
     ["WETH" as TokenTicker, { contractAddress: "0xc778417e063141139fce010982780140aa0cd5ab" as Address }],
   ]),
+  erc20TransferTests: [],
   expectedTokens: [
     {
       tokenTicker: "ETH" as TokenTicker,

--- a/packages/iov-ethereum/src/testconfig.spec.ts
+++ b/packages/iov-ethereum/src/testconfig.spec.ts
@@ -167,6 +167,8 @@ const local: EthereumNetworkConfig = {
       "ASH" as TokenTicker,
       {
         contractAddress: "0xCb642A87923580b6F7D07D1471F93361196f2650" as Address,
+        decimals: 12,
+        symbol: "ASH",
       },
     ],
     [
@@ -380,7 +382,14 @@ const rinkeby: EthereumNetworkConfig = {
     gasLimitTooLow: /intrinsic gas too low/i,
   },
   erc20Tokens: new Map<TokenTicker, Erc20Options>([
-    ["WETH" as TokenTicker, { contractAddress: "0xc778417e063141139fce010982780140aa0cd5ab" as Address }],
+    [
+      "WETH" as TokenTicker,
+      {
+        contractAddress: "0xc778417e063141139fce010982780140aa0cd5ab" as Address,
+        decimals: 18,
+        symbol: "WETH" as TokenTicker,
+      },
+    ],
   ]),
   erc20TransferTests: [],
   expectedTokens: [

--- a/packages/iov-ethereum/src/testconfig.spec.ts
+++ b/packages/iov-ethereum/src/testconfig.spec.ts
@@ -170,7 +170,7 @@ const local: EthereumNetworkConfig = {
     [
       "TRASH" as TokenTicker,
       {
-        contractAddress: "0x9768ae2339B48643d710B11dDbDb8A7eDBEa15BC" as Address,
+        contractAddress: "0xF01231195AE56d38fa03F5F2933863A2606A6052" as Address,
         decimals: 9,
         symbol: "TRASH",
         name: "Trash Token",
@@ -187,7 +187,7 @@ const local: EthereumNetworkConfig = {
       },
     },
     {
-      contractAddress: "0x9768ae2339B48643d710B11dDbDb8A7eDBEa15BC" as Address,
+      contractAddress: "0xF01231195AE56d38fa03F5F2933863A2606A6052" as Address,
       amount: {
         quantity: "5678",
         tokenTicker: "TRASH" as TokenTicker,

--- a/packages/iov-ethereum/src/utils.ts
+++ b/packages/iov-ethereum/src/utils.ts
@@ -2,6 +2,7 @@ import { ChainId, Nonce } from "@iov/bcp";
 import { Uint53 } from "@iov/encoding";
 
 import BN = require("bn.js");
+import { Abi } from "./abi";
 
 const bcpChainIdPrefix = "ethereum-eip155-";
 
@@ -72,4 +73,26 @@ export function fromBcpChainId(chainId: ChainId): number {
   }
 
   return Uint53.fromString(rest).toNumber();
+}
+
+/**
+ * A function to determine if a transaction is interpreted as ERC20 transfer.
+ * We can not know for sure if it was a ERC20 call without knowledge of the recipient type,
+ * which is not available at the codec level.
+ */
+export function shouldBeInterpretedAsErc20Transfer(input: Uint8Array, ethQuantity: string): boolean {
+  if (ethQuantity !== "0") {
+    return false;
+  }
+
+  if (input.length !== 4 + 32 + 32) {
+    return false;
+  }
+
+  const expectedPrefix = Abi.calculateMethodId("transfer(address,uint256)");
+  if (expectedPrefix.some((byte, index) => input[index] !== byte)) {
+    return false;
+  }
+
+  return true;
 }

--- a/packages/iov-ethereum/src/utils.ts
+++ b/packages/iov-ethereum/src/utils.ts
@@ -1,7 +1,8 @@
+import BN = require("bn.js");
+
 import { ChainId, Nonce } from "@iov/bcp";
 import { Uint53 } from "@iov/encoding";
 
-import BN = require("bn.js");
 import { Abi } from "./abi";
 
 const bcpChainIdPrefix = "ethereum-eip155-";

--- a/packages/iov-ethereum/types/abi.d.ts
+++ b/packages/iov-ethereum/types/abi.d.ts
@@ -9,6 +9,8 @@ export declare class Abi {
     static calculateMethodId(signature: string): Uint8Array;
     static encodeAddress(address: Address): Uint8Array;
     static encodeUint256(value: string): Uint8Array;
+    static decodeAddress(binary: Uint8Array): Address;
+    static decodeUint256(binary: Uint8Array): string;
     /**
      * Decode head-tail encoded data as described in
      * https://medium.com/@hayeah/how-to-decipher-a-smart-contract-method-call-8ee980311603

--- a/packages/iov-ethereum/types/abi.d.ts
+++ b/packages/iov-ethereum/types/abi.d.ts
@@ -8,6 +8,7 @@ export interface HeadTail {
 export declare class Abi {
     static calculateMethodId(signature: string): Uint8Array;
     static encodeAddress(address: Address): Uint8Array;
+    static encodeUint256(value: string): Uint8Array;
     /**
      * Decode head-tail encoded data as described in
      * https://medium.com/@hayeah/how-to-decipher-a-smart-contract-method-call-8ee980311603

--- a/packages/iov-ethereum/types/erc20.d.ts
+++ b/packages/iov-ethereum/types/erc20.d.ts
@@ -5,12 +5,12 @@ export interface EthereumRpcClient {
 }
 export interface Erc20Options {
     readonly contractAddress: Address;
-    /** Override on-chain symbol. Use this of contract does not define value on-chain */
-    readonly symbol?: string;
-    /** Override on-chain name. Use this of contract does not define value on-chain */
+    /** The token ticker. Overrides the on-chain value. */
+    readonly symbol: string;
+    /** The number of fractional digits. Overrides the on-chain value. */
+    readonly decimals: number;
+    /** Override on-chain name. Use this if contract does not define value on-chain. */
     readonly name?: string;
-    /** Override on-chain decimals. Use this of contract does not define value on-chain */
-    readonly decimals?: number;
 }
 export declare class Erc20 {
     private readonly client;

--- a/packages/iov-ethereum/types/ethereumcodec.d.ts
+++ b/packages/iov-ethereum/types/ethereumcodec.d.ts
@@ -23,7 +23,11 @@ export interface EthereumRpcTransactionResult {
     readonly value: string;
 }
 export interface EthereumCodecOptions {
-    /** List of supported ERC20 tokens */
+    /**
+     * ERC20 tokens supported by the codec instance.
+     *
+     * The behaviour of encoding/decoding transactions for other tokens is undefined.
+     */
     readonly erc20Tokens?: Map<TokenTicker, Erc20Options>;
 }
 export declare class EthereumCodec implements TxCodec {

--- a/packages/iov-ethereum/types/ethereumcodec.d.ts
+++ b/packages/iov-ethereum/types/ethereumcodec.d.ts
@@ -27,7 +27,8 @@ export interface EthereumCodecOptions {
     readonly erc20Tokens?: Map<TokenTicker, Erc20Options>;
 }
 export declare class EthereumCodec implements TxCodec {
-    constructor(_1: EthereumCodecOptions);
+    private readonly erc20Tokens;
+    constructor(options: EthereumCodecOptions);
     bytesToSign(unsigned: UnsignedTransaction, nonce: Nonce): SigningJob;
     bytesToPost(signed: SignedTransaction): PostableBytes;
     identifier(signed: SignedTransaction): TransactionId;

--- a/packages/iov-ethereum/types/ethereumcodec.d.ts
+++ b/packages/iov-ethereum/types/ethereumcodec.d.ts
@@ -8,6 +8,7 @@ export interface EthereumRpcTransactionResult {
     readonly blockHash: string;
     readonly blockNumber: string;
     readonly from: string;
+    /** Gas limit as set by the user */
     readonly gas: string;
     readonly gasPrice: string;
     readonly hash: string;

--- a/packages/iov-ethereum/types/ethereumcodec.d.ts
+++ b/packages/iov-ethereum/types/ethereumcodec.d.ts
@@ -1,4 +1,5 @@
-import { TxCodec } from "@iov/bcp";
+import { Address, ChainId, Nonce, PostableBytes, PublicIdentity, SignedTransaction, SigningJob, TokenTicker, TransactionId, TxCodec, UnsignedTransaction } from "@iov/bcp";
+import { Erc20Options } from "./erc20";
 /**
  * See https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_gettransactionbyhash
  *
@@ -21,4 +22,18 @@ export interface EthereumRpcTransactionResult {
     readonly v: string;
     readonly value: string;
 }
-export declare const ethereumCodec: TxCodec;
+export interface EthereumCodecOptions {
+    /** List of supported ERC20 tokens */
+    readonly erc20Tokens?: Map<TokenTicker, Erc20Options>;
+}
+export declare class EthereumCodec implements TxCodec {
+    constructor(_1: EthereumCodecOptions);
+    bytesToSign(unsigned: UnsignedTransaction, nonce: Nonce): SigningJob;
+    bytesToPost(signed: SignedTransaction): PostableBytes;
+    identifier(signed: SignedTransaction): TransactionId;
+    parseBytes(bytes: PostableBytes, chainId: ChainId): SignedTransaction;
+    identityToAddress(identity: PublicIdentity): Address;
+    isValidAddress(address: string): boolean;
+}
+/** An unconfigured EthereumCodec for backwards compatibility */
+export declare const ethereumCodec: EthereumCodec;

--- a/packages/iov-ethereum/types/ethereumcodec.d.ts
+++ b/packages/iov-ethereum/types/ethereumcodec.d.ts
@@ -1,2 +1,23 @@
 import { TxCodec } from "@iov/bcp";
+/**
+ * See https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_gettransactionbyhash
+ *
+ * This interface is package-internal.
+ */
+export interface EthereumRpcTransactionResult {
+    readonly blockHash: string;
+    readonly blockNumber: string;
+    readonly from: string;
+    readonly gas: string;
+    readonly gasPrice: string;
+    readonly hash: string;
+    readonly input: string;
+    readonly nonce: string;
+    readonly r: string;
+    readonly s: string;
+    readonly to: string;
+    readonly transactionIndex: string;
+    readonly v: string;
+    readonly value: string;
+}
 export declare const ethereumCodec: TxCodec;

--- a/packages/iov-ethereum/types/ethereumconnection.d.ts
+++ b/packages/iov-ethereum/types/ethereumconnection.d.ts
@@ -15,6 +15,7 @@ export declare class EthereumConnection implements BcpConnection {
     private readonly socket;
     private readonly scraperApiUrl;
     private readonly erc20Tokens;
+    private readonly codec;
     constructor(baseUrl: string, chainId: ChainId, options?: EthereumConnectionOptions);
     disconnect(): void;
     chainId(): ChainId;

--- a/packages/iov-ethereum/types/serialization.d.ts
+++ b/packages/iov-ethereum/types/serialization.d.ts
@@ -1,6 +1,6 @@
 import { Nonce, SignedTransaction, UnsignedTransaction } from "@iov/bcp";
 export declare class Serialization {
-    static serializeUnsignedEthSendTransaction(nonce: Nonce, gasPriceHex: string, gasLimitHex: string, recipientHex: string, valueHex: string, data: Uint8Array, chainIdHex: string): Uint8Array;
+    static serializeGenericTransaction(nonce: Nonce, gasPriceHex: string, gasLimitHex: string, recipientHex: string, valueHex: string, data: Uint8Array, v: string, r?: Uint8Array, s?: Uint8Array): Uint8Array;
     static serializeUnsignedTransaction(unsigned: UnsignedTransaction, nonce: Nonce): Uint8Array;
     static serializeSignedTransaction(signed: SignedTransaction): Uint8Array;
     /**

--- a/packages/iov-ethereum/types/serialization.d.ts
+++ b/packages/iov-ethereum/types/serialization.d.ts
@@ -1,10 +1,14 @@
 import { Address, Nonce, SignedTransaction, UnsignedTransaction } from "@iov/bcp";
 export declare class Serialization {
-    static serializeGenericTransaction(nonce: Nonce, gasPriceHex: string, gasLimitHex: string, recipient: Address, valueHex: string, data: Uint8Array, v: string, r?: Uint8Array, s?: Uint8Array): Uint8Array;
+    static serializeGenericTransaction(nonce: Nonce, gasPriceHex: string, gasLimitHex: string, recipient: Address, value: string, data: Uint8Array, v: string, r?: Uint8Array, s?: Uint8Array): Uint8Array;
     static serializeUnsignedTransaction(unsigned: UnsignedTransaction, nonce: Nonce): Uint8Array;
     static serializeSignedTransaction(signed: SignedTransaction): Uint8Array;
     /**
      * Nonce 0 must be represented as 0x instead of 0x0 for some strange reason
      */
     private static encodeNonce;
+    /**
+     * Value 0 must be represented as 0x instead of 0x0 for some strange reason
+     */
+    private static encodeValue;
 }

--- a/packages/iov-ethereum/types/serialization.d.ts
+++ b/packages/iov-ethereum/types/serialization.d.ts
@@ -1,8 +1,9 @@
-import { Address, Nonce, SignedTransaction, UnsignedTransaction } from "@iov/bcp";
+import { Address, Nonce, SignedTransaction, TokenTicker, UnsignedTransaction } from "@iov/bcp";
+import { Erc20Options } from "./erc20";
 export declare class Serialization {
     static serializeGenericTransaction(nonce: Nonce, gasPriceHex: string, gasLimitHex: string, recipient: Address, value: string, data: Uint8Array, v: string, r?: Uint8Array, s?: Uint8Array): Uint8Array;
-    static serializeUnsignedTransaction(unsigned: UnsignedTransaction, nonce: Nonce): Uint8Array;
-    static serializeSignedTransaction(signed: SignedTransaction): Uint8Array;
+    static serializeUnsignedTransaction(unsigned: UnsignedTransaction, nonce: Nonce, erc20Tokens?: Map<TokenTicker, Erc20Options>): Uint8Array;
+    static serializeSignedTransaction(signed: SignedTransaction, erc20Tokens?: Map<TokenTicker, Erc20Options>): Uint8Array;
     /**
      * Nonce 0 must be represented as 0x instead of 0x0 for some strange reason
      */

--- a/packages/iov-ethereum/types/serialization.d.ts
+++ b/packages/iov-ethereum/types/serialization.d.ts
@@ -1,6 +1,6 @@
-import { Nonce, SignedTransaction, UnsignedTransaction } from "@iov/bcp";
+import { Address, Nonce, SignedTransaction, UnsignedTransaction } from "@iov/bcp";
 export declare class Serialization {
-    static serializeGenericTransaction(nonce: Nonce, gasPriceHex: string, gasLimitHex: string, recipientHex: string, valueHex: string, data: Uint8Array, v: string, r?: Uint8Array, s?: Uint8Array): Uint8Array;
+    static serializeGenericTransaction(nonce: Nonce, gasPriceHex: string, gasLimitHex: string, recipient: Address, valueHex: string, data: Uint8Array, v: string, r?: Uint8Array, s?: Uint8Array): Uint8Array;
     static serializeUnsignedTransaction(unsigned: UnsignedTransaction, nonce: Nonce): Uint8Array;
     static serializeSignedTransaction(signed: SignedTransaction): Uint8Array;
     /**

--- a/packages/iov-ethereum/types/serialization.d.ts
+++ b/packages/iov-ethereum/types/serialization.d.ts
@@ -1,6 +1,6 @@
 import { Nonce, SignedTransaction, UnsignedTransaction } from "@iov/bcp";
 export declare class Serialization {
-    static serializeUnsignedEthSendTransaction(nonce: Nonce, gasPriceHex: string, gasLimitHex: string, recipientHex: string, valueHex: string, dataHex: string, chainIdHex: string): Uint8Array;
+    static serializeUnsignedEthSendTransaction(nonce: Nonce, gasPriceHex: string, gasLimitHex: string, recipientHex: string, valueHex: string, data: Uint8Array, chainIdHex: string): Uint8Array;
     static serializeUnsignedTransaction(unsigned: UnsignedTransaction, nonce: Nonce): Uint8Array;
     static serializeSignedTransaction(signed: SignedTransaction): Uint8Array;
     /**

--- a/packages/iov-ethereum/types/utils.d.ts
+++ b/packages/iov-ethereum/types/utils.d.ts
@@ -11,3 +11,9 @@ export declare function encodeQuantityString(value: string): string;
 export declare function normalizeHex(input: string): string;
 export declare function toBcpChainId(numericChainId: number): ChainId;
 export declare function fromBcpChainId(chainId: ChainId): number;
+/**
+ * A function to determine if a transaction is interpreted as ERC20 transfer.
+ * We can not know for sure if it was a ERC20 call without knowledge of the recipient type,
+ * which is not available at the codec level.
+ */
+export declare function shouldBeInterpretedAsErc20Transfer(input: Uint8Array, ethQuantity: string): boolean;

--- a/scripts/ethereum/deployment/src/deploy_contracts.ts
+++ b/scripts/ethereum/deployment/src/deploy_contracts.ts
@@ -12,6 +12,7 @@ const ganacheGasPrice = 50000;
 // From README.md
 const mainIdentity = Address.fromString("0x88F3b5659075D0E06bB1004BE7b1a7E66F452284");
 const secondIdentity = Address.fromString("0x0A65766695A712Af41B5cfECAaD217B1a11CB22A");
+const noEthAddress = Address.fromString("0x0000000000111111111122222222223333333333");
 
 function debugAddress(address: Address | undefined): string | undefined {
   return address ? address.toString() : undefined;
@@ -27,6 +28,7 @@ interface DeploymentJob {
 }
 
 interface MintingJob {
+  readonly contract: DeployableContract;
   readonly recipient: Address;
   readonly quantity: string;
 }
@@ -36,6 +38,8 @@ export async function main(args: ReadonlyArray<string>): Promise<void> {
 
   const provider = new WebsocketProvider(ganacheUrl);
   const eth = new Eth(provider);
+
+  const mintingJobs = new Array<MintingJob>();
 
   // Order matters to get reproducible contract addresses
   const deploymentJobs: ReadonlyArray<DeploymentJob> = [
@@ -53,19 +57,20 @@ export async function main(args: ReadonlyArray<string>): Promise<void> {
     console.log(`${name} deployed to`, debugAddress(receipt.contractAddress));
 
     if (typeof contract.methods.mint !== "undefined") {
-      const mintingJobs: ReadonlyArray<MintingJob> = [
-        { recipient: mainIdentity, quantity: "1000000000000000000000000" /* 1 million */ },
-        { recipient: secondIdentity, quantity: "33445566" },
-        { recipient: Address.fromString("0x0000000000111111111122222222223333333333"), quantity: "38" },
-      ];
-
-      for (const { recipient, quantity } of mintingJobs) {
-        console.log(`Minting ${quantity} atomic units for ${recipient} ...`);
-        await contract.methods
-          .mint(recipient, quantity)
-          .send({ from: mainIdentity, gasPrice: ganacheGasPrice })
-          .getReceipt();
-      }
+      mintingJobs.push(
+        { contract: contract, recipient: mainIdentity, quantity: "100000000" /* 100 million atomics */ },
+        { contract: contract, recipient: secondIdentity, quantity: "33445566" },
+        { contract: contract, recipient: noEthAddress, quantity: "38" },
+      );
     }
+  }
+
+  // Perform all minting jobs after all deployments to not change delployment nonces when updating minting
+  for (const { contract, recipient, quantity } of mintingJobs) {
+    console.log(`Minting ${quantity} atomic units for ${recipient} ...`);
+    await contract.methods
+      .mint(recipient, quantity)
+      .send({ from: mainIdentity, gasPrice: ganacheGasPrice })
+      .getReceipt();
   }
 }

--- a/scripts/ethereum/deployment/src/deploy_contracts.ts
+++ b/scripts/ethereum/deployment/src/deploy_contracts.ts
@@ -54,6 +54,7 @@ export async function main(args: ReadonlyArray<string>): Promise<void> {
 
     if (typeof contract.methods.mint !== "undefined") {
       const mintingJobs: ReadonlyArray<MintingJob> = [
+        { recipient: mainIdentity, quantity: "1000000000000000000000000" /* 1 million */ },
         { recipient: secondIdentity, quantity: "33445566" },
         { recipient: Address.fromString("0x0000000000111111111122222222223333333333"), quantity: "38" },
       ];

--- a/scripts/ethereum/deployment/src/deploy_contracts.ts
+++ b/scripts/ethereum/deployment/src/deploy_contracts.ts
@@ -65,7 +65,7 @@ export async function main(args: ReadonlyArray<string>): Promise<void> {
     }
   }
 
-  // Perform all minting jobs after all deployments to not change delployment nonces when updating minting
+  // Perform minting jobs after all deployments so that deployment nonces stay constant
   for (const { contract, recipient, quantity } of mintingJobs) {
     console.log(`Minting ${quantity} atomic units for ${recipient} ...`);
     await contract.methods

--- a/scripts/ethereum/init.sh
+++ b/scripts/ethereum/init.sh
@@ -6,7 +6,7 @@ export GANACHE_PORT="8545"
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-docker pull "alpine"
+# Don't pull before run. We can use whatever version of alpine is available locally.
 DOCKER_HOST_IP=$(docker run --rm alpine ip route | awk 'NR==1 {print $3}')
 
 (


### PR DESCRIPTION
Closes #813 
Closes #814 

----------

Cannot yet be used in higher level API since `EthereumConnection.searchTransactionsById` > `ethereumCodec.parseBytes` do not yet support ERC20 transfer (see #848)