### PR TITLE
Product fee support

### DIFF
--- a/packages/iov-bns/src/bnsconnection.spec.ts
+++ b/packages/iov-bns/src/bnsconnection.spec.ts
@@ -86,6 +86,12 @@ describe("BnsConnection", () => {
     fractionalDigits: 9,
     tokenTicker: cash,
   };
+  // this is enough money in an accout that registers names... twice the cost of one name registration product fee
+  const registerAmount: Amount = {
+    quantity: "10000000000",
+    fractionalDigits: 9,
+    tokenTicker: cash,
+  };
 
   // The first simple address key (m/4804438'/0') generated from this mnemonic produces the address
   // tiov1k898u78hgs36uqw68dg7va5nfkgstu5z0fhz3f (bech32) / b1ca7e78f74423ae01da3b51e676934d9105f282 (hex).
@@ -596,7 +602,7 @@ describe("BnsConnection", () => {
 
       // we need funds to pay the fees
       const address = identityToAddress(identity);
-      await sendTokensFromFaucet(connection, address);
+      await sendTokensFromFaucet(connection, address, registerAmount);
 
       // Create and send registration
       const username = `testuser_${Math.random()}`;
@@ -638,7 +644,7 @@ describe("BnsConnection", () => {
       const identity = await profile.createIdentity(wallet.id, registryChainId, HdPaths.simpleAddress(0));
       // we need funds to pay the fees
       const myAddress = identityToAddress(identity);
-      await sendTokensFromFaucet(connection, myAddress);
+      await sendTokensFromFaucet(connection, myAddress, registerAmount);
 
       // Create and send registration
       const username = `testuser_${Math.random()}`;
@@ -1238,7 +1244,7 @@ describe("BnsConnection", () => {
       const wallet = profile.addWallet(Ed25519HdWallet.fromEntropy(await Random.getBytes(32)));
       const identity = await profile.createIdentity(wallet.id, registryChainId, HdPaths.simpleAddress(0));
       const identityAddress = identityToAddress(identity);
-      await sendTokensFromFaucet(connection, identityAddress);
+      await sendTokensFromFaucet(connection, identityAddress, registerAmount);
 
       // Register username
       const username = `testuser_${Math.random()}`;
@@ -1296,7 +1302,7 @@ describe("BnsConnection", () => {
       const wallet = profile.addWallet(Ed25519HdWallet.fromEntropy(await Random.getBytes(32)));
       const identity = await profile.createIdentity(wallet.id, registryChainId, HdPaths.simpleAddress(0));
       const identityAddress = identityToAddress(identity);
-      await sendTokensFromFaucet(connection, identityAddress);
+      await sendTokensFromFaucet(connection, identityAddress, registerAmount);
 
       // With a  blockchain
       const chainId = `wonderland_${Math.random()}` as ChainId;
@@ -1801,8 +1807,8 @@ describe("BnsConnection", () => {
       };
 
       const result = await connection.getFeeQuote(usernameRegistration);
-      // anti-spam gconf fee from genesis
-      expect(result.tokens!.quantity).toEqual("10000000");
+      // 5 CASH product fee
+      expect(result.tokens!.quantity).toEqual("5000000000");
       expect(result.tokens!.fractionalDigits).toEqual(9);
       expect(result.tokens!.tokenTicker).toEqual("CASH" as TokenTicker);
 

--- a/packages/iov-bns/src/bnsconnection.spec.ts
+++ b/packages/iov-bns/src/bnsconnection.spec.ts
@@ -86,7 +86,7 @@ describe("BnsConnection", () => {
     fractionalDigits: 9,
     tokenTicker: cash,
   };
-  // this is enough money in an accout that registers names... twice the cost of one name registration product fee
+  // this is enough money in an account that registers names... twice the cost of one name registration product fee
   const registerAmount: Amount = {
     quantity: "10000000000",
     fractionalDigits: 9,

--- a/packages/iov-bns/src/bnsconnection.ts
+++ b/packages/iov-bns/src/bnsconnection.ts
@@ -47,7 +47,7 @@ import { broadcastTxSyncSuccess, Client as TendermintClient } from "@iov/tenderm
 
 import { bnsCodec } from "./bnscodec";
 import { ChainData, Context } from "./context";
-import { decodeJsonAmount, decodeNonce, decodeToken, decodeUsernameNft, decodeAmount } from "./decode";
+import { decodeAmount, decodeJsonAmount, decodeNonce, decodeToken, decodeUsernameNft } from "./decode";
 import * as codecImpl from "./generated/codecimpl";
 import { bnsSwapQueryTag } from "./tags";
 import {

--- a/packages/iov-bns/src/bnsconnection.ts
+++ b/packages/iov-bns/src/bnsconnection.ts
@@ -5,6 +5,7 @@ import {
   Account,
   AccountQuery,
   AddressQuery,
+  Amount,
   AtomicSwap,
   AtomicSwapMerger,
   AtomicSwapQuery,
@@ -46,7 +47,7 @@ import { broadcastTxSyncSuccess, Client as TendermintClient } from "@iov/tenderm
 
 import { bnsCodec } from "./bnscodec";
 import { ChainData, Context } from "./context";
-import { decodeJsonAmount, decodeNonce, decodeToken, decodeUsernameNft } from "./decode";
+import { decodeJsonAmount, decodeNonce, decodeToken, decodeUsernameNft, decodeAmount } from "./decode";
 import * as codecImpl from "./generated/codecimpl";
 import { bnsSwapQueryTag } from "./tags";
 import {
@@ -613,15 +614,12 @@ export class BnsConnection implements BcpAtomicSwapConnection {
       throw new Error("Received transaction of unsupported kind.");
     }
     // get gconf fee
-    // TODO: get product fee for this type
+    const min = await this.getMinimumFee();
+    // get product fee for this type
+    const product = await this.getProductFee(transaction.kind);
     // take maximum
-    const res = await this.query("/", Encoding.toAscii("gconf:cash:minimal_fee"));
-    if (res.results.length !== 1) {
-      throw new Error("Received unexpected number of fees");
-    }
-    const data = Encoding.fromAscii(res.results[0].value);
-    const amount = decodeJsonAmount(data);
-    return { tokens: amount };
+    const fee = product || min;
+    return { tokens: fee };
   }
 
   public async withDefaultFee<T extends UnsignedTransaction>(transaction: T): Promise<T> {
@@ -645,6 +643,64 @@ export class BnsConnection implements BcpAtomicSwapConnection {
       tokenTicker: b.tokenTicker,
     }));
     return { ...escrow, data: { ...escrow.data, amounts: amounts } };
+  }
+
+  /**
+   * Queries the blockchain for the enforced minimum anti-spam fee
+   */
+  protected async getMinimumFee(): Promise<Amount> {
+    const res = await this.query("/", Encoding.toAscii("gconf:cash:minimal_fee"));
+    if (res.results.length !== 1) {
+      throw new Error("Received unexpected number of fees");
+    }
+    const data = Encoding.fromAscii(res.results[0].value);
+    const amount = decodeJsonAmount(data);
+    return amount;
+  }
+
+  /**
+   * Queries the blockchain for the enforced product fee for this kind of transaction.
+   * Returns undefined if no product fee is defined
+   */
+  protected async getProductFee(kind: string): Promise<Amount | undefined> {
+    const path = mapKindToBnsPath(kind);
+
+    // TODO: add query handler to msgfee
+    const { results } = await this.query("/", Encoding.toAscii(`msgfee:${path}`));
+    if (results.length > 1) {
+      throw new Error("Received unexpected number of fees");
+    }
+    if (results.length === 0) {
+      return undefined;
+    }
+
+    const parser = createParser(codecImpl.msgfee.MsgFee, "msgfee:");
+    const fees = results
+      .map(parser)
+      .map(msg => msg.fee)
+      .map(x => decodeAmount(x!));
+    return fees.length > 0 ? fees[0] : undefined;
+  }
+}
+
+function mapKindToBnsPath(kind: string): string | undefined {
+  switch (kind) {
+    case "bcp/send":
+      return "cash/send";
+    case "bcp/swap_offer":
+      return "escrow/create";
+    case "bcp/swap_claim":
+      return "escrow/release";
+    case "bcp/swap_abort":
+      return "escrow/return";
+    case "bns/register_username":
+      return "nft/username/issue";
+    case "bns/add_address_to_username":
+      return "nft/username/address/add";
+    case "bns/remove_address_from_username":
+      return "nft/username/address/remove";
+    default:
+      return undefined;
   }
 }
 

--- a/packages/iov-bns/types/bnsconnection.d.ts
+++ b/packages/iov-bns/types/bnsconnection.d.ts
@@ -1,5 +1,5 @@
 import { Stream } from "xstream";
-import { Account, AccountQuery, AddressQuery, AtomicSwap, AtomicSwapQuery, BcpAtomicSwapConnection, BcpTicker, BcpTxQuery, BlockHeader, ChainId, ConfirmedTransaction, FailedTransaction, Fee, Nonce, PostableBytes, PostTxResponse, PubkeyQuery, TokenTicker, UnsignedTransaction } from "@iov/bcp";
+import { Account, AccountQuery, AddressQuery, Amount, AtomicSwap, AtomicSwapQuery, BcpAtomicSwapConnection, BcpTicker, BcpTxQuery, BlockHeader, ChainId, ConfirmedTransaction, FailedTransaction, Fee, Nonce, PostableBytes, PostTxResponse, PubkeyQuery, TokenTicker, UnsignedTransaction } from "@iov/bcp";
 import { BnsUsernameNft, BnsUsernamesQuery, Result } from "./types";
 /**
  * Talks directly to the BNS blockchain and exposes the
@@ -73,6 +73,15 @@ export declare class BnsConnection implements BcpAtomicSwapConnection {
     withDefaultFee<T extends UnsignedTransaction>(transaction: T): Promise<T>;
     protected query(path: string, data: Uint8Array): Promise<QueryResponse>;
     protected updateEscrowBalance<T extends AtomicSwap>(escrow: T): Promise<T>;
+    /**
+     * Queries the blockchain for the enforced minimum anti-spam fee
+     */
+    protected getMinimumFee(): Promise<Amount>;
+    /**
+     * Queries the blockchain for the enforced product fee for this kind of transaction.
+     * Returns undefined if no product fee is defined
+     */
+    protected getProductFee(kind: string): Promise<Amount | undefined>;
 }
 export interface QueryResponse {
     readonly height?: number;

--- a/packages/iov-bns/types/bnsconnection.d.ts
+++ b/packages/iov-bns/types/bnsconnection.d.ts
@@ -74,9 +74,9 @@ export declare class BnsConnection implements BcpAtomicSwapConnection {
     protected query(path: string, data: Uint8Array): Promise<QueryResponse>;
     protected updateEscrowBalance<T extends AtomicSwap>(escrow: T): Promise<T>;
     /**
-     * Queries the blockchain for the enforced minimum anti-spam fee
+     * Queries the blockchain for the enforced anti-spam fee
      */
-    protected getMinimumFee(): Promise<Amount>;
+    protected getDefaultFee(): Promise<Amount>;
     /**
      * Queries the blockchain for the enforced product fee for this kind of transaction.
      * Returns undefined if no product fee is defined

--- a/scripts/bnsd/genesis_app_state.json
+++ b/scripts/bnsd/genesis_app_state.json
@@ -26,5 +26,9 @@
   "gconf": {
     "cash:minimal_fee": "0.01 CASH",
     "cash:collector_address": "0000000000000000000000000000000000000000"
-  }
+  },
+  "msgfee": [{
+    "msg_path": "nft/username/issue",
+    "fee":      "5 CASH"
+  }]
 }


### PR DESCRIPTION
Closes #866 

getFeeQuote() will also query the product fees for the specified transaction kind and use that instead of the minimum anti-spam fee if present.

* Updated the bnsd CI genesis file to add a 5 CASH product fee for registering username
* Added logic to query these values and override other quote if needed
* Updated tests