### PR TITLE
Create JsonRpcSigningServer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## 0.13.4
 
 - @iov/keycontrol: Export `ReadonlyWallet`.
+- @iov/jsonrpc: Add `jsonRpcCode` constant object. Deprecate old `jsonRpcCode*`
+  constants in favour of `jsonRpcCode`.
 
 ## 0.13.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 - @iov/jsonrpc: Add `jsonRpcCode` constant object. Deprecate old `jsonRpcCode*`
   constants in favour of `jsonRpcCode`.
 - @iov/core: Add `JsonRpcSigningServer`.
+- @iov/core: Deprecate `JsRpcSigningServer` and related types in favour of
+  `JsonRpcSigningServer`.
 
 ## 0.13.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - @iov/keycontrol: Export `ReadonlyWallet`.
 - @iov/jsonrpc: Add `jsonRpcCode` constant object. Deprecate old `jsonRpcCode*`
   constants in favour of `jsonRpcCode`.
+- @iov/core: Add `JsonRpcSigningServer`.
 
 ## 0.13.3
 

--- a/packages/iov-core/src/index.ts
+++ b/packages/iov-core/src/index.ts
@@ -25,5 +25,6 @@ export {
   parseJsRpcResponse,
 } from "./jsrpc";
 export { JsRpcSigningServer } from "./jsrpcsigningserver";
+export { JsonRpcSigningServer } from "./jsonrpcsigningserver";
 export { MultiChainSigner } from "./multichainsigner";
 export { GetIdentitiesAuthorization, SignAndPostAuthorization, SigningServerCore } from "./signingservercore";

--- a/packages/iov-core/src/index.ts
+++ b/packages/iov-core/src/index.ts
@@ -28,3 +28,4 @@ export { JsRpcSigningServer } from "./jsrpcsigningserver";
 export { JsonRpcSigningServer } from "./jsonrpcsigningserver";
 export { MultiChainSigner } from "./multichainsigner";
 export { GetIdentitiesAuthorization, SignAndPostAuthorization, SigningServerCore } from "./signingservercore";
+export { TransactionEncoder } from "./transactionencoder";

--- a/packages/iov-core/src/jsonrpcsigningserver.spec.ts
+++ b/packages/iov-core/src/jsonrpcsigningserver.spec.ts
@@ -1,13 +1,85 @@
 import {
   Address,
   Algorithm,
+  Amount,
   ChainId,
+  isConfirmedTransaction,
   isPublicIdentity,
+  PublicIdentity,
   PublicKeyBytes,
   SendTransaction,
   TokenTicker,
+  TransactionId,
 } from "@iov/bcp";
+import { bnsCodec, bnsConnector } from "@iov/bns";
+import { Ed25519, Random } from "@iov/crypto";
 import { Encoding } from "@iov/encoding";
+import { ethereumConnector } from "@iov/ethereum";
+import { isJsonRpcErrorResponse } from "@iov/jsonrpc";
+import { Ed25519HdWallet, HdPaths, Secp256k1HdWallet, UserProfile } from "@iov/keycontrol";
+import { firstEvent } from "@iov/stream";
+
+import { MultiChainSigner } from "./multichainsigner";
+import { GetIdentitiesAuthorization, SignAndPostAuthorization, SigningServerCore } from "./signingservercore";
+
+const { fromHex } = Encoding;
+
+function pendingWithoutBnsd(): void {
+  if (!process.env.BNSD_ENABLED) {
+    pending("Set BNSD_ENABLED to enable bnsd-based tests");
+  }
+}
+
+function pendingWithoutEthereum(): void {
+  if (!process.env.ETHEREUM_ENABLED) {
+    pending("Set ETHEREUM_ENABLED to enable ethereum-based tests");
+  }
+}
+
+async function randomBnsAddress(): Promise<Address> {
+  const rawKeypair = await Ed25519.makeKeypair(await Random.getBytes(32));
+  const randomIdentity: PublicIdentity = {
+    chainId: "some-testnet" as ChainId,
+    pubkey: {
+      algo: Algorithm.Ed25519,
+      data: rawKeypair.pubkey as PublicKeyBytes,
+    },
+  };
+  return bnsCodec.identityToAddress(randomIdentity);
+}
+
+const bnsdUrl = "ws://localhost:23456";
+const bnsdFaucetMnemonic = "degree tackle suggest window test behind mesh extra cover prepare oak script";
+const ethereumUrl = "http://localhost:8545";
+const ethereumChainId = "ethereum-eip155-5777" as ChainId;
+const ganacheMnemonic = "oxygen fall sure lava energy veteran enroll frown question detail include maximum";
+
+const defaultGetIdentitiesCallback: GetIdentitiesAuthorization = async (_, matching) => matching;
+const defaultSignAndPostCallback: SignAndPostAuthorization = async (_1, _2) => true;
+
+async function makeBnsEthereumSigningServer(): Promise<JsonRpcSigningServer> {
+  const profile = new UserProfile();
+  const ed25519Wallet = profile.addWallet(Ed25519HdWallet.fromMnemonic(bnsdFaucetMnemonic));
+  const secp256k1Wallet = profile.addWallet(Secp256k1HdWallet.fromMnemonic(ganacheMnemonic));
+  const signer = new MultiChainSigner(profile);
+
+  // connect to chains
+  const bnsConnection = (await signer.addChain(bnsConnector(bnsdUrl))).connection;
+  const ethereumConnection = (await signer.addChain(ethereumConnector(ethereumUrl, {}))).connection;
+
+  // faucet identity
+  await profile.createIdentity(ed25519Wallet.id, bnsConnection.chainId(), HdPaths.simpleAddress(0));
+  // ganache second identity
+  await profile.createIdentity(secp256k1Wallet.id, ethereumConnection.chainId(), HdPaths.bip44(60, 0, 0, 1));
+
+  const core = new SigningServerCore(
+    profile,
+    signer,
+    defaultGetIdentitiesCallback,
+    defaultSignAndPostCallback,
+  );
+  return new JsonRpcSigningServer(core);
+}
 
 import { JsonRpcSigningServer } from "./jsonrpcsigningserver";
 
@@ -155,5 +227,178 @@ describe("JsonRpcSigningServer", () => {
       expect(restored).toEqual(original);
       expect(isPublicIdentity(restored.creator)).toEqual(true);
     });
+  });
+
+  const ganacheSecondIdentity: PublicIdentity = {
+    chainId: ethereumChainId,
+    pubkey: {
+      algo: Algorithm.Secp256k1,
+      data: Encoding.fromHex(
+        "041d4c015b00cbd914e280b871d3c6ae2a047ca650d3ecea4b5246bb3036d4d74960b7feb09068164d2b82f1c7df9e95839b29ae38e90d60578b2318a54e108cf8",
+      ) as PublicKeyBytes,
+    },
+  };
+
+  const defaultAmount: Amount = {
+    quantity: "1",
+    fractionalDigits: 9,
+    tokenTicker: "CASH" as TokenTicker,
+  };
+
+  it("can get bnsd identities", async () => {
+    pendingWithoutBnsd();
+    pendingWithoutEthereum();
+
+    const bnsConnection = await bnsConnector(bnsdUrl).client();
+
+    const server = await makeBnsEthereumSigningServer();
+
+    const response = await server.handleUnchecked({
+      jsonrpc: "2.0",
+      id: 123,
+      method: "getIdentities",
+      params: {
+        reason: "Who are you?",
+        chainIds: [bnsConnection.chainId()],
+      },
+    });
+    expect(response.id).toEqual(123);
+    if (isJsonRpcErrorResponse(response)) {
+      throw new Error(`Response must not be an error, but got '${response.error.message}'`);
+    }
+    const result = JsonRpcSigningServer.fromJson(response.result);
+    expect(result).toEqual(jasmine.any(Array));
+    expect((result as ReadonlyArray<any>).length).toEqual(1);
+    expect(result[0].chainId).toEqual(bnsConnection.chainId());
+    expect(result[0].pubkey).toEqual({
+      algo: Algorithm.Ed25519,
+      data: fromHex("533e376559fa551130e721735af5e7c9fcd8869ddd54519ee779fce5984d7898"),
+    });
+
+    server.shutdown();
+    bnsConnection.disconnect();
+  });
+
+  it("can get ethereum identities", async () => {
+    pendingWithoutBnsd();
+    pendingWithoutEthereum();
+
+    const server = await makeBnsEthereumSigningServer();
+
+    const response = await server.handleChecked({
+      jsonrpc: "2.0",
+      id: 123,
+      method: "getIdentities",
+      params: {
+        reason: "Who are you?",
+        chainIds: [ethereumChainId],
+      },
+    });
+    expect(response.id).toEqual(123);
+    if (isJsonRpcErrorResponse(response)) {
+      throw new Error(`Response must not be an error, but got '${response.error.message}'`);
+    }
+    const result = JsonRpcSigningServer.fromJson(response.result);
+    expect(result).toEqual(jasmine.any(Array));
+    expect((result as ReadonlyArray<any>).length).toEqual(1);
+    expect(result[0]).toEqual(ganacheSecondIdentity);
+
+    server.shutdown();
+  });
+
+  it("can get BNS or Ethereum identities", async () => {
+    pendingWithoutBnsd();
+    pendingWithoutEthereum();
+
+    const bnsConnection = await bnsConnector(bnsdUrl).client();
+
+    const server = await makeBnsEthereumSigningServer();
+
+    const response = await server.handleChecked({
+      jsonrpc: "2.0",
+      id: 123,
+      method: "getIdentities",
+      params: {
+        reason: "Who are you?",
+        chainIds: [ethereumChainId, bnsConnection.chainId()],
+      },
+    });
+    expect(response.id).toEqual(123);
+    if (isJsonRpcErrorResponse(response)) {
+      throw new Error(`Response must not be an error, but got '${response.error.message}'`);
+    }
+    const result = JsonRpcSigningServer.fromJson(response.result);
+    expect(result).toEqual(jasmine.any(Array));
+    expect((result as ReadonlyArray<any>).length).toEqual(2);
+    expect(result[0].chainId).toEqual(bnsConnection.chainId());
+    expect(result[0].pubkey).toEqual({
+      algo: Algorithm.Ed25519,
+      data: fromHex("533e376559fa551130e721735af5e7c9fcd8869ddd54519ee779fce5984d7898"),
+    });
+    expect(result[1]).toEqual(ganacheSecondIdentity);
+
+    server.shutdown();
+    bnsConnection.disconnect();
+  });
+
+  it("send a signing request to service", async () => {
+    pendingWithoutBnsd();
+    pendingWithoutEthereum();
+
+    const bnsConnection = await bnsConnector(bnsdUrl).client();
+
+    const server = await makeBnsEthereumSigningServer();
+
+    const identitiesResponse = await server.handleChecked({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "getIdentities",
+      params: {
+        reason: "Who are you?",
+        chainIds: [bnsConnection.chainId()],
+      },
+    });
+    if (isJsonRpcErrorResponse(identitiesResponse)) {
+      throw new Error(`Response must not be an error, but got '${identitiesResponse.error.message}'`);
+    }
+    expect(identitiesResponse.result).toEqual(jasmine.any(Array));
+    expect((identitiesResponse.result as ReadonlyArray<any>).length).toEqual(1);
+    const signer = JsonRpcSigningServer.fromJson(identitiesResponse.result[0]);
+    if (!isPublicIdentity(signer)) {
+      throw new Error("Identity element is not valid");
+    }
+
+    const send: SendTransaction = {
+      kind: "bcp/send",
+      creator: signer,
+      memo: `Hello ${Math.random()}`,
+      amount: defaultAmount,
+      recipient: await randomBnsAddress(),
+    };
+
+    const signAndPostResponse = await server.handleChecked({
+      jsonrpc: "2.0",
+      id: 2,
+      method: "signAndPost",
+      params: {
+        reason: "Please sign",
+        transaction: JsonRpcSigningServer.toJson(send),
+      },
+    });
+    if (isJsonRpcErrorResponse(signAndPostResponse)) {
+      throw new Error(`Response must not be an error, but got '${signAndPostResponse.error.message}'`);
+    }
+    const transactionId: TransactionId = JsonRpcSigningServer.fromJson(signAndPostResponse.result);
+    expect(transactionId).toMatch(/^[0-9A-F]+$/);
+
+    const result = await firstEvent(bnsConnection.liveTx({ id: transactionId }));
+    if (!isConfirmedTransaction(result)) {
+      throw new Error("Confirmed transaction extected");
+    }
+    expect(result.transactionId).toEqual(transactionId);
+    expect(result.transaction).toEqual(send);
+
+    server.shutdown();
+    bnsConnection.disconnect();
   });
 });

--- a/packages/iov-core/src/jsonrpcsigningserver.spec.ts
+++ b/packages/iov-core/src/jsonrpcsigningserver.spec.ts
@@ -125,10 +125,12 @@ describe("JsonRpcSigningServer", () => {
     const result = TransactionEncoder.fromJson(response.result);
     expect(result).toEqual(jasmine.any(Array));
     expect((result as ReadonlyArray<any>).length).toEqual(1);
-    expect(result[0].chainId).toEqual(bnsConnection.chainId());
-    expect(result[0].pubkey).toEqual({
-      algo: Algorithm.Ed25519,
-      data: fromHex("533e376559fa551130e721735af5e7c9fcd8869ddd54519ee779fce5984d7898"),
+    expect(result[0]).toEqual({
+      chainId: bnsConnection.chainId(),
+      pubkey: {
+        algo: Algorithm.Ed25519,
+        data: fromHex("533e376559fa551130e721735af5e7c9fcd8869ddd54519ee779fce5984d7898"),
+      },
     });
 
     server.shutdown();
@@ -186,10 +188,12 @@ describe("JsonRpcSigningServer", () => {
     const result = TransactionEncoder.fromJson(response.result);
     expect(result).toEqual(jasmine.any(Array));
     expect((result as ReadonlyArray<any>).length).toEqual(2);
-    expect(result[0].chainId).toEqual(bnsConnection.chainId());
-    expect(result[0].pubkey).toEqual({
-      algo: Algorithm.Ed25519,
-      data: fromHex("533e376559fa551130e721735af5e7c9fcd8869ddd54519ee779fce5984d7898"),
+    expect(result[0]).toEqual({
+      chainId: bnsConnection.chainId(),
+      pubkey: {
+        algo: Algorithm.Ed25519,
+        data: fromHex("533e376559fa551130e721735af5e7c9fcd8869ddd54519ee779fce5984d7898"),
+      },
     });
     expect(result[1]).toEqual(ganacheSecondIdentity);
 
@@ -197,7 +201,7 @@ describe("JsonRpcSigningServer", () => {
     bnsConnection.disconnect();
   });
 
-  it("send a signing request to service", async () => {
+  it("handles signing requests", async () => {
     pendingWithoutBnsd();
     pendingWithoutEthereum();
 
@@ -249,7 +253,7 @@ describe("JsonRpcSigningServer", () => {
 
     const result = await firstEvent(bnsConnection.liveTx({ id: transactionId }));
     if (!isConfirmedTransaction(result)) {
-      throw new Error("Confirmed transaction extected");
+      throw new Error("Expected confirmed transaction");
     }
     expect(result.transactionId).toEqual(transactionId);
     expect(result.transaction).toEqual(send);

--- a/packages/iov-core/src/jsonrpcsigningserver.spec.ts
+++ b/packages/iov-core/src/jsonrpcsigningserver.spec.ts
@@ -1,0 +1,159 @@
+import {
+  Address,
+  Algorithm,
+  ChainId,
+  isPublicIdentity,
+  PublicKeyBytes,
+  SendTransaction,
+  TokenTicker,
+} from "@iov/bcp";
+import { Encoding } from "@iov/encoding";
+
+import { JsonRpcSigningServer } from "./jsonrpcsigningserver";
+
+const { fromJson, toJson } = JsonRpcSigningServer;
+
+describe("JsonRpcSigningServer", () => {
+  describe("toJson", () => {
+    it("works for numbers", () => {
+      expect(toJson(0)).toEqual(0);
+      expect(toJson(1)).toEqual(1);
+      expect(toJson(-1)).toEqual(-1);
+      expect(toJson(Number.POSITIVE_INFINITY)).toEqual(Number.POSITIVE_INFINITY);
+      expect(toJson(Number.NaN)).toEqual(Number.NaN);
+    });
+
+    it("works for booleans", () => {
+      expect(toJson(true)).toEqual(true);
+      expect(toJson(false)).toEqual(false);
+    });
+
+    it("works for null", () => {
+      expect(toJson(null)).toEqual(null);
+    });
+
+    it("works for arrays", () => {
+      expect(toJson([])).toEqual([]);
+      expect(toJson([1, 2, 3])).toEqual([1, 2, 3]);
+      expect(toJson([1, [2, 3]])).toEqual([1, [2, 3]]);
+    });
+
+    it("works for dicts", () => {
+      expect(toJson({})).toEqual({});
+      expect(toJson({ foo: 1 })).toEqual({ foo: 1 });
+      expect(toJson({ foo: 1, bar: 2 })).toEqual({ foo: 1, bar: 2 });
+      expect(toJson({ foo: { bar: 1 } })).toEqual({ foo: { bar: 1 } });
+    });
+
+    it("fails for unsupported objects", () => {
+      expect(() => toJson(() => 0)).toThrowError(/Cannot encode type to JSON/i);
+      expect(() => toJson(/[0-9]+/)).toThrowError(/Cannot encode type to JSON/i);
+      expect(() => toJson(new Uint32Array())).toThrowError(/Cannot encode type to JSON/i);
+      expect(() => toJson(undefined)).toThrowError(/Cannot encode type to JSON/i);
+    });
+
+    it("prefixes strings", () => {
+      expect(toJson("")).toEqual("string:");
+      expect(toJson("abc")).toEqual("string:abc");
+      expect(toJson("\0")).toEqual("string:\0");
+    });
+
+    it("prefixes and hex encodes Uint8Array", () => {
+      expect(toJson(new Uint8Array([]))).toEqual("Uint8Array:");
+      expect(toJson(new Uint8Array([0x12]))).toEqual("Uint8Array:12");
+      expect(toJson(new Uint8Array([0x12, 0xab]))).toEqual("Uint8Array:12ab");
+    });
+
+    // Encoding recursive objects is explicitly undefined behavior. Just use this
+    // test to play around.
+    xit("fails for recursive objects", () => {
+      const a: any = {};
+      const b: any = {};
+      // tslint:disable-next-line: no-object-mutation
+      b.neighbour = a;
+      // tslint:disable-next-line: no-object-mutation
+      a.neighbour = b;
+      expect(() => toJson(a)).toThrowError(/Maximum call stack size exceeded/i);
+    });
+  });
+
+  describe("fromJson", () => {
+    it("works for numbers", () => {
+      expect(fromJson(0)).toEqual(0);
+      expect(fromJson(1)).toEqual(1);
+      expect(fromJson(-1)).toEqual(-1);
+      expect(fromJson(Number.POSITIVE_INFINITY)).toEqual(Number.POSITIVE_INFINITY);
+      expect(fromJson(Number.NaN)).toEqual(Number.NaN);
+    });
+
+    it("works for booleans", () => {
+      expect(fromJson(true)).toEqual(true);
+      expect(fromJson(false)).toEqual(false);
+    });
+
+    it("works for null", () => {
+      expect(fromJson(null)).toEqual(null);
+    });
+
+    it("works for arrays", () => {
+      expect(fromJson([])).toEqual([]);
+      expect(fromJson([1, 2, 3])).toEqual([1, 2, 3]);
+      expect(fromJson([1, [2, 3]])).toEqual([1, [2, 3]]);
+    });
+
+    it("works for dicts", () => {
+      expect(fromJson({})).toEqual({});
+      expect(fromJson({ foo: 1 })).toEqual({ foo: 1 });
+      expect(fromJson({ foo: 1, bar: 2 })).toEqual({ foo: 1, bar: 2 });
+      expect(fromJson({ foo: { bar: 1 } })).toEqual({ foo: { bar: 1 } });
+    });
+
+    it("works for strings", () => {
+      // "string:" prefix
+      expect(fromJson("string:")).toEqual("");
+      expect(fromJson("string:abc")).toEqual("abc");
+      expect(fromJson("string:\0")).toEqual("\0");
+
+      // "Uint8Array:" prefix
+      expect(fromJson("Uint8Array:")).toEqual(new Uint8Array([]));
+      expect(fromJson("Uint8Array:12")).toEqual(new Uint8Array([0x12]));
+      expect(fromJson("Uint8Array:aabb")).toEqual(new Uint8Array([0xaa, 0xbb]));
+
+      // other prefixes
+      expect(() => fromJson("")).toThrowError(/Found string with unknown prefix/i);
+      expect(() => fromJson("abc")).toThrowError(/Found string with unknown prefix/i);
+      expect(() => fromJson("Integer:123")).toThrowError(/Found string with unknown prefix/i);
+    });
+
+    it("decodes a full send transaction", () => {
+      const original: SendTransaction = {
+        kind: "bcp/send",
+        creator: {
+          chainId: "testchain" as ChainId,
+          pubkey: {
+            algo: Algorithm.Ed25519,
+            data: Encoding.fromHex("aabbccdd") as PublicKeyBytes,
+          },
+        },
+        memo: "Hello hello",
+        amount: {
+          quantity: "123",
+          tokenTicker: "CASH" as TokenTicker,
+          fractionalDigits: 2,
+        },
+        recipient: "aabbcc" as Address,
+        fee: {
+          tokens: {
+            quantity: "1",
+            tokenTicker: "ASH" as TokenTicker,
+            fractionalDigits: 2,
+          },
+        },
+      };
+
+      const restored = fromJson(toJson(original));
+      expect(restored).toEqual(original);
+      expect(isPublicIdentity(restored.creator)).toEqual(true);
+    });
+  });
+});

--- a/packages/iov-core/src/jsonrpcsigningserver.spec.ts
+++ b/packages/iov-core/src/jsonrpcsigningserver.spec.ts
@@ -131,9 +131,9 @@ describe("JsonRpcSigningServer", () => {
     });
 
     it("prefixes and hex encodes Uint8Array", () => {
-      expect(toJson(new Uint8Array([]))).toEqual("Uint8Array:");
-      expect(toJson(new Uint8Array([0x12]))).toEqual("Uint8Array:12");
-      expect(toJson(new Uint8Array([0x12, 0xab]))).toEqual("Uint8Array:12ab");
+      expect(toJson(new Uint8Array([]))).toEqual("bytes:");
+      expect(toJson(new Uint8Array([0x12]))).toEqual("bytes:12");
+      expect(toJson(new Uint8Array([0x12, 0xab]))).toEqual("bytes:12ab");
     });
 
     // Encoding recursive objects is explicitly undefined behavior. Just use this
@@ -186,10 +186,10 @@ describe("JsonRpcSigningServer", () => {
       expect(fromJson("string:abc")).toEqual("abc");
       expect(fromJson("string:\0")).toEqual("\0");
 
-      // "Uint8Array:" prefix
-      expect(fromJson("Uint8Array:")).toEqual(new Uint8Array([]));
-      expect(fromJson("Uint8Array:12")).toEqual(new Uint8Array([0x12]));
-      expect(fromJson("Uint8Array:aabb")).toEqual(new Uint8Array([0xaa, 0xbb]));
+      // "bytes:" prefix
+      expect(fromJson("bytes:")).toEqual(new Uint8Array([]));
+      expect(fromJson("bytes:12")).toEqual(new Uint8Array([0x12]));
+      expect(fromJson("bytes:aabb")).toEqual(new Uint8Array([0xaa, 0xbb]));
 
       // other prefixes
       expect(() => fromJson("")).toThrowError(/Found string with unknown prefix/i);

--- a/packages/iov-core/src/jsonrpcsigningserver.spec.ts
+++ b/packages/iov-core/src/jsonrpcsigningserver.spec.ts
@@ -82,153 +82,9 @@ async function makeBnsEthereumSigningServer(): Promise<JsonRpcSigningServer> {
 }
 
 import { JsonRpcSigningServer } from "./jsonrpcsigningserver";
-
-const { fromJson, toJson } = JsonRpcSigningServer;
+import { TransactionEncoder } from "./transactionencoder";
 
 describe("JsonRpcSigningServer", () => {
-  describe("toJson", () => {
-    it("works for numbers", () => {
-      expect(toJson(0)).toEqual(0);
-      expect(toJson(1)).toEqual(1);
-      expect(toJson(-1)).toEqual(-1);
-      expect(toJson(Number.POSITIVE_INFINITY)).toEqual(Number.POSITIVE_INFINITY);
-      expect(toJson(Number.NaN)).toEqual(Number.NaN);
-    });
-
-    it("works for booleans", () => {
-      expect(toJson(true)).toEqual(true);
-      expect(toJson(false)).toEqual(false);
-    });
-
-    it("works for null", () => {
-      expect(toJson(null)).toEqual(null);
-    });
-
-    it("works for arrays", () => {
-      expect(toJson([])).toEqual([]);
-      expect(toJson([1, 2, 3])).toEqual([1, 2, 3]);
-      expect(toJson([1, [2, 3]])).toEqual([1, [2, 3]]);
-    });
-
-    it("works for dicts", () => {
-      expect(toJson({})).toEqual({});
-      expect(toJson({ foo: 1 })).toEqual({ foo: 1 });
-      expect(toJson({ foo: 1, bar: 2 })).toEqual({ foo: 1, bar: 2 });
-      expect(toJson({ foo: { bar: 1 } })).toEqual({ foo: { bar: 1 } });
-    });
-
-    it("fails for unsupported objects", () => {
-      expect(() => toJson(() => 0)).toThrowError(/Cannot encode type to JSON/i);
-      expect(() => toJson(/[0-9]+/)).toThrowError(/Cannot encode type to JSON/i);
-      expect(() => toJson(new Uint32Array())).toThrowError(/Cannot encode type to JSON/i);
-      expect(() => toJson(undefined)).toThrowError(/Cannot encode type to JSON/i);
-    });
-
-    it("prefixes strings", () => {
-      expect(toJson("")).toEqual("string:");
-      expect(toJson("abc")).toEqual("string:abc");
-      expect(toJson("\0")).toEqual("string:\0");
-    });
-
-    it("prefixes and hex encodes Uint8Array", () => {
-      expect(toJson(new Uint8Array([]))).toEqual("bytes:");
-      expect(toJson(new Uint8Array([0x12]))).toEqual("bytes:12");
-      expect(toJson(new Uint8Array([0x12, 0xab]))).toEqual("bytes:12ab");
-    });
-
-    // Encoding recursive objects is explicitly undefined behavior. Just use this
-    // test to play around.
-    xit("fails for recursive objects", () => {
-      const a: any = {};
-      const b: any = {};
-      // tslint:disable-next-line: no-object-mutation
-      b.neighbour = a;
-      // tslint:disable-next-line: no-object-mutation
-      a.neighbour = b;
-      expect(() => toJson(a)).toThrowError(/Maximum call stack size exceeded/i);
-    });
-  });
-
-  describe("fromJson", () => {
-    it("works for numbers", () => {
-      expect(fromJson(0)).toEqual(0);
-      expect(fromJson(1)).toEqual(1);
-      expect(fromJson(-1)).toEqual(-1);
-      expect(fromJson(Number.POSITIVE_INFINITY)).toEqual(Number.POSITIVE_INFINITY);
-      expect(fromJson(Number.NaN)).toEqual(Number.NaN);
-    });
-
-    it("works for booleans", () => {
-      expect(fromJson(true)).toEqual(true);
-      expect(fromJson(false)).toEqual(false);
-    });
-
-    it("works for null", () => {
-      expect(fromJson(null)).toEqual(null);
-    });
-
-    it("works for arrays", () => {
-      expect(fromJson([])).toEqual([]);
-      expect(fromJson([1, 2, 3])).toEqual([1, 2, 3]);
-      expect(fromJson([1, [2, 3]])).toEqual([1, [2, 3]]);
-    });
-
-    it("works for dicts", () => {
-      expect(fromJson({})).toEqual({});
-      expect(fromJson({ foo: 1 })).toEqual({ foo: 1 });
-      expect(fromJson({ foo: 1, bar: 2 })).toEqual({ foo: 1, bar: 2 });
-      expect(fromJson({ foo: { bar: 1 } })).toEqual({ foo: { bar: 1 } });
-    });
-
-    it("works for strings", () => {
-      // "string:" prefix
-      expect(fromJson("string:")).toEqual("");
-      expect(fromJson("string:abc")).toEqual("abc");
-      expect(fromJson("string:\0")).toEqual("\0");
-
-      // "bytes:" prefix
-      expect(fromJson("bytes:")).toEqual(new Uint8Array([]));
-      expect(fromJson("bytes:12")).toEqual(new Uint8Array([0x12]));
-      expect(fromJson("bytes:aabb")).toEqual(new Uint8Array([0xaa, 0xbb]));
-
-      // other prefixes
-      expect(() => fromJson("")).toThrowError(/Found string with unknown prefix/i);
-      expect(() => fromJson("abc")).toThrowError(/Found string with unknown prefix/i);
-      expect(() => fromJson("Integer:123")).toThrowError(/Found string with unknown prefix/i);
-    });
-
-    it("decodes a full send transaction", () => {
-      const original: SendTransaction = {
-        kind: "bcp/send",
-        creator: {
-          chainId: "testchain" as ChainId,
-          pubkey: {
-            algo: Algorithm.Ed25519,
-            data: Encoding.fromHex("aabbccdd") as PublicKeyBytes,
-          },
-        },
-        memo: "Hello hello",
-        amount: {
-          quantity: "123",
-          tokenTicker: "CASH" as TokenTicker,
-          fractionalDigits: 2,
-        },
-        recipient: "aabbcc" as Address,
-        fee: {
-          tokens: {
-            quantity: "1",
-            tokenTicker: "ASH" as TokenTicker,
-            fractionalDigits: 2,
-          },
-        },
-      };
-
-      const restored = fromJson(toJson(original));
-      expect(restored).toEqual(original);
-      expect(isPublicIdentity(restored.creator)).toEqual(true);
-    });
-  });
-
   const ganacheSecondIdentity: PublicIdentity = {
     chainId: ethereumChainId,
     pubkey: {
@@ -266,7 +122,7 @@ describe("JsonRpcSigningServer", () => {
     if (isJsonRpcErrorResponse(response)) {
       throw new Error(`Response must not be an error, but got '${response.error.message}'`);
     }
-    const result = JsonRpcSigningServer.fromJson(response.result);
+    const result = TransactionEncoder.fromJson(response.result);
     expect(result).toEqual(jasmine.any(Array));
     expect((result as ReadonlyArray<any>).length).toEqual(1);
     expect(result[0].chainId).toEqual(bnsConnection.chainId());
@@ -298,7 +154,7 @@ describe("JsonRpcSigningServer", () => {
     if (isJsonRpcErrorResponse(response)) {
       throw new Error(`Response must not be an error, but got '${response.error.message}'`);
     }
-    const result = JsonRpcSigningServer.fromJson(response.result);
+    const result = TransactionEncoder.fromJson(response.result);
     expect(result).toEqual(jasmine.any(Array));
     expect((result as ReadonlyArray<any>).length).toEqual(1);
     expect(result[0]).toEqual(ganacheSecondIdentity);
@@ -327,7 +183,7 @@ describe("JsonRpcSigningServer", () => {
     if (isJsonRpcErrorResponse(response)) {
       throw new Error(`Response must not be an error, but got '${response.error.message}'`);
     }
-    const result = JsonRpcSigningServer.fromJson(response.result);
+    const result = TransactionEncoder.fromJson(response.result);
     expect(result).toEqual(jasmine.any(Array));
     expect((result as ReadonlyArray<any>).length).toEqual(2);
     expect(result[0].chainId).toEqual(bnsConnection.chainId());
@@ -363,7 +219,7 @@ describe("JsonRpcSigningServer", () => {
     }
     expect(identitiesResponse.result).toEqual(jasmine.any(Array));
     expect((identitiesResponse.result as ReadonlyArray<any>).length).toEqual(1);
-    const signer = JsonRpcSigningServer.fromJson(identitiesResponse.result[0]);
+    const signer = TransactionEncoder.fromJson(identitiesResponse.result[0]);
     if (!isPublicIdentity(signer)) {
       throw new Error("Identity element is not valid");
     }
@@ -382,13 +238,13 @@ describe("JsonRpcSigningServer", () => {
       method: "signAndPost",
       params: {
         reason: "Please sign",
-        transaction: JsonRpcSigningServer.toJson(send),
+        transaction: TransactionEncoder.toJson(send),
       },
     });
     if (isJsonRpcErrorResponse(signAndPostResponse)) {
       throw new Error(`Response must not be an error, but got '${signAndPostResponse.error.message}'`);
     }
-    const transactionId: TransactionId = JsonRpcSigningServer.fromJson(signAndPostResponse.result);
+    const transactionId: TransactionId = TransactionEncoder.fromJson(signAndPostResponse.result);
     expect(transactionId).toMatch(/^[0-9A-F]+$/);
 
     const result = await firstEvent(bnsConnection.liveTx({ id: transactionId }));

--- a/packages/iov-core/src/jsonrpcsigningserver.ts
+++ b/packages/iov-core/src/jsonrpcsigningserver.ts
@@ -104,7 +104,7 @@ export class JsonRpcSigningServer {
     }
 
     if (data instanceof Uint8Array) {
-      return `Uint8Array:${Encoding.toHex(data)}`;
+      return `bytes:${Encoding.toHex(data)}`;
     }
 
     if (Array.isArray(data)) {
@@ -144,8 +144,8 @@ export class JsonRpcSigningServer {
         return data.slice(7);
       }
 
-      if (data.startsWith("Uint8Array:")) {
-        return Encoding.fromHex(data.slice(11));
+      if (data.startsWith("bytes:")) {
+        return Encoding.fromHex(data.slice(6));
       }
 
       throw new Error("Found string with unknown prefix");

--- a/packages/iov-core/src/jsonrpcsigningserver.ts
+++ b/packages/iov-core/src/jsonrpcsigningserver.ts
@@ -88,6 +88,9 @@ export class JsonRpcSigningServer {
     this.core = core;
   }
 
+  /**
+   * Handles a request from a possible untrusted source.
+   */
   public async handleUnchecked(request: unknown): Promise<JsonRpcResponse> {
     let checkedRequest: JsonRpcRequest;
     try {
@@ -109,7 +112,8 @@ export class JsonRpcSigningServer {
   }
 
   /**
-   * Handles a checked JsonRpcRequest
+   * Handles a checked request, i.e. a request that is known to be a valid
+   * JSON-RPC "Request object".
    *
    * 1. convert JsRpcRequest into calls to SigningServerCore
    * 2. call SigningServerCore

--- a/packages/iov-core/src/jsonrpcsigningserver.ts
+++ b/packages/iov-core/src/jsonrpcsigningserver.ts
@@ -1,6 +1,89 @@
+import { ChainId, isUnsignedTransaction, UnsignedTransaction } from "@iov/bcp";
 import { Encoding } from "@iov/encoding";
-import { JsonCompatibleValue } from "@iov/jsonrpc";
+import {
+  isJsonCompatibleDictionary,
+  JsonCompatibleValue,
+  jsonRpcCode,
+  JsonRpcErrorResponse,
+  JsonRpcRequest,
+  JsonRpcResponse,
+  JsonRpcSuccessResponse,
+  parseJsonRpcId,
+  parseJsonRpcRequest,
+} from "@iov/jsonrpc";
 
+import { SigningServerCore } from "./signingservercore";
+
+interface RpcCallGetIdentities {
+  readonly name: "getIdentities";
+  readonly reason: string;
+  readonly chainIds: ReadonlyArray<ChainId>;
+}
+
+interface RpcCallSignAndPost {
+  readonly name: "signAndPost";
+  readonly reason: string;
+  readonly transaction: UnsignedTransaction;
+}
+
+type RpcCall = RpcCallGetIdentities | RpcCallSignAndPost;
+
+class ParamsError extends Error {}
+class MethodNotFoundError extends Error {}
+
+function isArrayOfStrings(array: ReadonlyArray<any>): array is ReadonlyArray<string> {
+  return array.every(element => typeof element === "string");
+}
+
+function parseRpcCall(data: JsonRpcRequest): RpcCall {
+  if (!isJsonCompatibleDictionary(data.params)) {
+    throw new Error("Request params are only supported as dictionary");
+  }
+
+  switch (data.method) {
+    case "getIdentities": {
+      const { reason, chainIds } = data.params;
+      if (typeof reason !== "string") {
+        throw new ParamsError("1st parameter (reason) must be a string");
+      }
+      if (!Array.isArray(chainIds)) {
+        throw new ParamsError("2nd parameter (chainIds) must be an array");
+      }
+      if (!isArrayOfStrings(chainIds)) {
+        throw new ParamsError("Found non-string element in chainIds array");
+      }
+      return {
+        name: "getIdentities",
+        reason: reason,
+        chainIds: chainIds,
+      };
+    }
+    case "signAndPost": {
+      const { reason, transaction } = data.params;
+      if (typeof reason !== "string") {
+        throw new ParamsError("1st parameter (reason) must be a string");
+      }
+      if (typeof transaction !== "object") {
+        throw new ParamsError("2nd parameter (transaction) must be an object");
+      }
+      const parsedTransaction = JsonRpcSigningServer.fromJson(transaction);
+      if (!isUnsignedTransaction(parsedTransaction)) {
+        throw new ParamsError("2nd parameter (transaction) does not look like an unsigned transaction");
+      }
+      return {
+        name: "signAndPost",
+        reason: reason,
+        transaction: parsedTransaction,
+      };
+    }
+    default:
+      throw new MethodNotFoundError("Unknown method name");
+  }
+}
+
+/**
+ * A transport-agnostic JSON-RPC wrapper around SigningServerCore
+ */
 export class JsonRpcSigningServer {
   /**
    * Encodes a non-recursive JavaScript object as JSON in a way that is
@@ -89,5 +172,104 @@ export class JsonRpcSigningServer {
     }
 
     throw new Error("Cannot decode type from JSON");
+  }
+
+  private readonly core: SigningServerCore;
+
+  constructor(core: SigningServerCore) {
+    this.core = core;
+  }
+
+  public async handleUnchecked(request: unknown): Promise<JsonRpcResponse> {
+    let checkedRequest: JsonRpcRequest;
+    try {
+      checkedRequest = parseJsonRpcRequest(request);
+    } catch (error) {
+      const requestId = parseJsonRpcId(request);
+      const errorResponse: JsonRpcErrorResponse = {
+        jsonrpc: "2.0",
+        id: requestId,
+        error: {
+          code: jsonRpcCode.invalidRequest,
+          message: error.toString(),
+        },
+      };
+      return errorResponse;
+    }
+
+    return this.handleChecked(checkedRequest);
+  }
+
+  /**
+   * Handles a checked JsonRpcRequest
+   *
+   * 1. convert JsRpcRequest into calls to SigningServerCore
+   * 2. call SigningServerCore
+   * 3. convert result to JSON-RPC format
+   */
+  public async handleChecked(request: JsonRpcRequest): Promise<JsonRpcResponse> {
+    let call: RpcCall;
+    try {
+      call = parseRpcCall(request);
+    } catch (error) {
+      const errorResponse: JsonRpcErrorResponse = {
+        jsonrpc: "2.0",
+        id: request.id,
+        error: {
+          code: jsonRpcCode.methodNotFound,
+          message: error.toString(),
+        },
+      };
+      return errorResponse;
+    }
+
+    try {
+      let response: JsonRpcSuccessResponse;
+      switch (call.name) {
+        case "getIdentities":
+          response = {
+            jsonrpc: "2.0",
+            id: request.id,
+            result: JsonRpcSigningServer.toJson(await this.core.getIdentities(call.reason, call.chainIds)),
+          };
+          break;
+        case "signAndPost":
+          response = {
+            jsonrpc: "2.0",
+            id: request.id,
+            result: JsonRpcSigningServer.toJson(await this.core.signAndPost(call.reason, call.transaction)),
+          };
+          break;
+        default:
+          throw new Error("Unsupported RPC call");
+      }
+      return response;
+    } catch (error) {
+      let errorCode: number;
+      if (error instanceof ParamsError) {
+        errorCode = jsonRpcCode.invalidParams;
+      } else if (error instanceof MethodNotFoundError) {
+        errorCode = jsonRpcCode.methodNotFound;
+      } else {
+        errorCode = jsonRpcCode.serverError.default;
+      }
+
+      const errorResponse: JsonRpcErrorResponse = {
+        jsonrpc: "2.0",
+        id: request.id,
+        error: {
+          code: errorCode,
+          message: error.toString(),
+        },
+      };
+      return errorResponse;
+    }
+  }
+
+  /**
+   * Call this to free ressources when server is not needed anymore
+   */
+  public shutdown(): void {
+    this.core.shutdown();
   }
 }

--- a/packages/iov-core/src/jsonrpcsigningserver.ts
+++ b/packages/iov-core/src/jsonrpcsigningserver.ts
@@ -120,11 +120,21 @@ export class JsonRpcSigningServer {
     try {
       call = parseRpcCall(request);
     } catch (error) {
+      let errorCode: number;
+      if (error instanceof MethodNotFoundError) {
+        errorCode = jsonRpcCode.methodNotFound;
+      } else if (error instanceof ParamsError) {
+        errorCode = jsonRpcCode.invalidParams;
+      } else {
+        // An unexpected error is the server's fault
+        errorCode = jsonRpcCode.serverError.default;
+      }
+
       const errorResponse: JsonRpcErrorResponse = {
         jsonrpc: "2.0",
         id: request.id,
         error: {
-          code: jsonRpcCode.methodNotFound,
+          code: errorCode,
           message: error.toString(),
         },
       };

--- a/packages/iov-core/src/jsrpc.spec.ts
+++ b/packages/iov-core/src/jsrpc.spec.ts
@@ -1,3 +1,4 @@
+// tslint:disable: deprecation
 import { isJsRpcCompatibleArray, isJsRpcCompatibleDictionary, isJsRpcCompatibleValue } from "./jsrpc";
 
 describe("jsrpc", () => {

--- a/packages/iov-core/src/jsrpc.ts
+++ b/packages/iov-core/src/jsrpc.ts
@@ -1,3 +1,4 @@
+// tslint:disable: deprecation
 import { jsonRpcCode, SimpleMessagingConnection } from "@iov/jsonrpc";
 import { firstEvent } from "@iov/stream";
 
@@ -5,7 +6,11 @@ import { firstEvent } from "@iov/stream";
 // all the data types from the structured clone algorithm
 // https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm#Supported_types
 
-/** A single structured clone algorithm compatible value */
+/**
+ * A single structured clone algorithm compatible value
+ *
+ * @deprecated use JsonRpcSigningServer and friends
+ */
 export declare type JsRpcCompatibleValue =
   | string
   | number
@@ -15,14 +20,23 @@ export declare type JsRpcCompatibleValue =
   | JsRpcCompatibleArray
   | JsRpcCompatibleDictionary;
 
-/** An array of JsRpcCompatibleValue */
+/**
+ * An array of JsRpcCompatibleValue
+ *
+ * @deprecated use JsonRpcSigningServer and friends
+ */
 export interface JsRpcCompatibleArray extends ReadonlyArray<JsRpcCompatibleValue> {}
 
-/** A string to JsRpcCompatibleValue dictionary. */
+/**
+ * A string to JsRpcCompatibleValue dictionary.
+ *
+ * @deprecated use JsonRpcSigningServer and friends
+ */
 export interface JsRpcCompatibleDictionary {
   readonly [key: string]: JsRpcCompatibleValue;
 }
 
+/** @deprecated use JsonRpcSigningServer and friends */
 export function isJsRpcCompatibleValue(value: unknown): value is JsRpcCompatibleValue {
   return (
     typeof value === "string" ||
@@ -35,6 +49,7 @@ export function isJsRpcCompatibleValue(value: unknown): value is JsRpcCompatible
   );
 }
 
+/** @deprecated use JsonRpcSigningServer and friends */
 export function isJsRpcCompatibleArray(value: unknown): value is JsRpcCompatibleArray {
   if (!Array.isArray(value)) {
     return false;
@@ -42,6 +57,7 @@ export function isJsRpcCompatibleArray(value: unknown): value is JsRpcCompatible
   return value.every(isJsRpcCompatibleValue);
 }
 
+/** @deprecated use JsonRpcSigningServer and friends */
 export function isJsRpcCompatibleDictionary(data: unknown): data is JsRpcCompatibleDictionary {
   if (typeof data !== "object" || data === null) {
     // data must be a non-null object
@@ -60,17 +76,20 @@ export function isJsRpcCompatibleDictionary(data: unknown): data is JsRpcCompati
   return values.every(isJsRpcCompatibleValue);
 }
 
+/** @deprecated use JsonRpcSigningServer and friends */
 export interface JsRpcRequest {
   readonly id: number;
   readonly method: string;
   readonly params: JsRpcCompatibleArray | JsRpcCompatibleDictionary;
 }
 
+/** @deprecated use JsonRpcSigningServer and friends */
 export interface JsRpcSuccessResponse {
   readonly id: number;
   readonly result: any;
 }
 
+/** @deprecated use JsonRpcSigningServer and friends */
 export interface JsRpcError {
   readonly code: number;
   readonly message: string;
@@ -79,18 +98,23 @@ export interface JsRpcError {
 
 /**
  * And error object as described in https://www.jsonrpc.org/specification#error_object
+ *
+ * @deprecated use JsonRpcSigningServer and friends
  */
 export interface JsRpcErrorResponse {
   readonly id: number | null;
   readonly error: JsRpcError;
 }
 
+/** @deprecated use JsonRpcSigningServer and friends */
 export type JsRpcResponse = JsRpcSuccessResponse | JsRpcErrorResponse;
 
+/** @deprecated use JsonRpcSigningServer and friends */
 export function isJsRpcErrorResponse(response: JsRpcResponse): response is JsRpcErrorResponse {
   return typeof (response as JsRpcErrorResponse).error === "object";
 }
 
+/** @deprecated use JsonRpcSigningServer and friends */
 export const jsRpcCode = {
   parseError: jsonRpcCode.parseError,
   invalidRequest: jsonRpcCode.invalidRequest,
@@ -100,6 +124,7 @@ export const jsRpcCode = {
   serverErrorDefault: jsonRpcCode.serverError.default,
 };
 
+/** @deprecated use JsonRpcSigningServer and friends */
 export function parseJsRpcId(data: unknown): number | null {
   if (!isJsRpcCompatibleDictionary(data)) {
     throw new Error("Data must be JS RPC compatible dictionary");
@@ -112,6 +137,7 @@ export function parseJsRpcId(data: unknown): number | null {
   return id;
 }
 
+/** @deprecated use JsonRpcSigningServer and friends */
 export function parseJsRpcRequest(data: unknown): JsRpcRequest {
   if (!isJsRpcCompatibleDictionary(data)) {
     throw new Error("Data must be JS RPC compatible dictionary");
@@ -164,6 +190,7 @@ function parseError(error: JsRpcCompatibleDictionary): JsRpcError {
   };
 }
 
+/** @deprecated use JsonRpcSigningServer and friends */
 export function parseJsRpcErrorResponse(data: unknown): JsRpcErrorResponse | undefined {
   if (!isJsRpcCompatibleDictionary(data)) {
     throw new Error("Data must be JS RPC compatible dictionary");
@@ -188,6 +215,7 @@ export function parseJsRpcErrorResponse(data: unknown): JsRpcErrorResponse | und
   };
 }
 
+/** @deprecated use JsonRpcSigningServer and friends */
 export function parseJsRpcResponse(data: unknown): JsRpcSuccessResponse {
   if (!isJsRpcCompatibleDictionary(data)) {
     throw new Error("Data must be JS RPC compatible dictionary");
@@ -206,6 +234,7 @@ export function parseJsRpcResponse(data: unknown): JsRpcSuccessResponse {
   };
 }
 
+/** @deprecated use JsonRpcSigningServer and friends */
 export class JsRpcClient {
   private readonly connection: SimpleMessagingConnection<JsRpcRequest, JsRpcResponse>;
 

--- a/packages/iov-core/src/jsrpc.ts
+++ b/packages/iov-core/src/jsrpc.ts
@@ -1,12 +1,4 @@
-import {
-  jsonRpcCodeInternalError,
-  jsonRpcCodeInvalidParams,
-  jsonRpcCodeInvalidRequest,
-  jsonRpcCodeMethodNotFound,
-  jsonRpcCodeParseError,
-  jsonRpcCodeServerErrorDefault,
-  SimpleMessagingConnection,
-} from "@iov/jsonrpc";
+import { jsonRpcCode, SimpleMessagingConnection } from "@iov/jsonrpc";
 import { firstEvent } from "@iov/stream";
 
 // An RPC interface very similar to JSON-RPC but supporting
@@ -100,12 +92,12 @@ export function isJsRpcErrorResponse(response: JsRpcResponse): response is JsRpc
 }
 
 export const jsRpcCode = {
-  parseError: jsonRpcCodeParseError,
-  invalidRequest: jsonRpcCodeInvalidRequest,
-  methodNotFound: jsonRpcCodeMethodNotFound,
-  invalidParams: jsonRpcCodeInvalidParams,
-  internalError: jsonRpcCodeInternalError,
-  serverErrorDefault: jsonRpcCodeServerErrorDefault,
+  parseError: jsonRpcCode.parseError,
+  invalidRequest: jsonRpcCode.invalidRequest,
+  methodNotFound: jsonRpcCode.methodNotFound,
+  invalidParams: jsonRpcCode.invalidParams,
+  internalError: jsonRpcCode.internalError,
+  serverErrorDefault: jsonRpcCode.serverError.default,
 };
 
 export function parseJsRpcId(data: unknown): number | null {

--- a/packages/iov-core/src/jsrpcsigningserver.spec.ts
+++ b/packages/iov-core/src/jsrpcsigningserver.spec.ts
@@ -1,3 +1,4 @@
+// tslint:disable: deprecation
 import {
   Address,
   Algorithm,

--- a/packages/iov-core/src/jsrpcsigningserver.spec.ts
+++ b/packages/iov-core/src/jsrpcsigningserver.spec.ts
@@ -190,7 +190,7 @@ describe("JsRpcSigningServer", () => {
     bnsConnection.disconnect();
   });
 
-  it("send a signing request to service", async () => {
+  it("handles signing requests", async () => {
     pendingWithoutBnsd();
     pendingWithoutEthereum();
 
@@ -242,7 +242,7 @@ describe("JsRpcSigningServer", () => {
 
     const result = await firstEvent(bnsConnection.liveTx({ id: transactionId }));
     if (!isConfirmedTransaction(result)) {
-      throw new Error("Confirmed transaction extected");
+      throw new Error("Expected confirmed transaction");
     }
     expect(result.transactionId).toEqual(transactionId);
     expect(result.transaction).toEqual(send);

--- a/packages/iov-core/src/jsrpcsigningserver.ts
+++ b/packages/iov-core/src/jsrpcsigningserver.ts
@@ -1,3 +1,4 @@
+// tslint:disable: deprecation
 import { ChainId, isUnsignedTransaction, UnsignedTransaction } from "@iov/bcp";
 import { parseJsonRpcId } from "@iov/jsonrpc";
 
@@ -80,6 +81,8 @@ function parseRpcCall(data: JsRpcRequest): RpcCall {
 
 /**
  * A transport-agnostic JavaScript RPC wrapper around SigningServerCore
+ *
+ * @deprecated use JsonRpcSigningServer and friends
  */
 export class JsRpcSigningServer {
   private readonly core: SigningServerCore;

--- a/packages/iov-core/src/signingservice.spec.ts
+++ b/packages/iov-core/src/signingservice.spec.ts
@@ -27,7 +27,8 @@ import {
   SimpleMessagingConnection,
 } from "@iov/jsonrpc";
 import { firstEvent } from "@iov/stream";
-import { JsonRpcSigningServer } from "./jsonrpcsigningserver";
+
+import { TransactionEncoder } from "./transactionencoder";
 
 const { fromHex } = Encoding;
 
@@ -138,7 +139,7 @@ describe("signingservice.worker", () => {
       },
     });
     expect(response.id).toEqual(123);
-    const result = JsonRpcSigningServer.fromJson(response.result);
+    const result = TransactionEncoder.fromJson(response.result);
     expect(result).toEqual(jasmine.any(Array));
     expect((result as ReadonlyArray<any>).length).toEqual(1);
     expect(result[0].chainId).toEqual(bnsConnection.chainId());
@@ -170,7 +171,7 @@ describe("signingservice.worker", () => {
       },
     });
     expect(response.id).toEqual(123);
-    const result = JsonRpcSigningServer.fromJson(response.result);
+    const result = TransactionEncoder.fromJson(response.result);
     expect(result).toEqual(jasmine.any(Array));
     expect((result as ReadonlyArray<any>).length).toEqual(1);
     expect(result[0]).toEqual(ganacheSecondIdentity);
@@ -200,7 +201,7 @@ describe("signingservice.worker", () => {
     });
     expect(response.id).toEqual(123);
 
-    const result = JsonRpcSigningServer.fromJson(response.result);
+    const result = TransactionEncoder.fromJson(response.result);
     expect(result).toEqual(jasmine.any(Array));
     expect((result as ReadonlyArray<any>).length).toEqual(2);
     expect(result[0].chainId).toEqual(bnsConnection.chainId());
@@ -236,7 +237,7 @@ describe("signingservice.worker", () => {
       },
     });
 
-    const result = JsonRpcSigningServer.fromJson(identitiesResponse.result);
+    const result = TransactionEncoder.fromJson(identitiesResponse.result);
     expect(result).toEqual(jasmine.any(Array));
     expect((result as ReadonlyArray<any>).length).toEqual(1);
     const signer = result[0];
@@ -258,10 +259,10 @@ describe("signingservice.worker", () => {
       method: "signAndPost",
       params: {
         reason: "Please sign",
-        transaction: JsonRpcSigningServer.toJson(send),
+        transaction: TransactionEncoder.toJson(send),
       },
     });
-    const transactionId: TransactionId = JsonRpcSigningServer.fromJson(signAndPostResponse.result);
+    const transactionId: TransactionId = TransactionEncoder.fromJson(signAndPostResponse.result);
     expect(transactionId).toMatch(/^[0-9A-F]+$/);
 
     const trandactionResult = await firstEvent(bnsConnection.liveTx({ id: transactionId }));

--- a/packages/iov-core/src/transactionencoder.spec.ts
+++ b/packages/iov-core/src/transactionencoder.spec.ts
@@ -1,0 +1,159 @@
+import {
+  Address,
+  Algorithm,
+  ChainId,
+  isPublicIdentity,
+  PublicKeyBytes,
+  SendTransaction,
+  TokenTicker,
+} from "@iov/bcp";
+import { Encoding } from "@iov/encoding";
+
+import { TransactionEncoder } from "./transactionencoder";
+
+const { fromJson, toJson } = TransactionEncoder;
+
+describe("TransactionEncoder", () => {
+  describe("toJson", () => {
+    it("works for numbers", () => {
+      expect(toJson(0)).toEqual(0);
+      expect(toJson(1)).toEqual(1);
+      expect(toJson(-1)).toEqual(-1);
+      expect(toJson(Number.POSITIVE_INFINITY)).toEqual(Number.POSITIVE_INFINITY);
+      expect(toJson(Number.NaN)).toEqual(Number.NaN);
+    });
+
+    it("works for booleans", () => {
+      expect(toJson(true)).toEqual(true);
+      expect(toJson(false)).toEqual(false);
+    });
+
+    it("works for null", () => {
+      expect(toJson(null)).toEqual(null);
+    });
+
+    it("works for arrays", () => {
+      expect(toJson([])).toEqual([]);
+      expect(toJson([1, 2, 3])).toEqual([1, 2, 3]);
+      expect(toJson([1, [2, 3]])).toEqual([1, [2, 3]]);
+    });
+
+    it("works for dicts", () => {
+      expect(toJson({})).toEqual({});
+      expect(toJson({ foo: 1 })).toEqual({ foo: 1 });
+      expect(toJson({ foo: 1, bar: 2 })).toEqual({ foo: 1, bar: 2 });
+      expect(toJson({ foo: { bar: 1 } })).toEqual({ foo: { bar: 1 } });
+    });
+
+    it("fails for unsupported objects", () => {
+      expect(() => toJson(() => 0)).toThrowError(/Cannot encode type to JSON/i);
+      expect(() => toJson(/[0-9]+/)).toThrowError(/Cannot encode type to JSON/i);
+      expect(() => toJson(new Uint32Array())).toThrowError(/Cannot encode type to JSON/i);
+      expect(() => toJson(undefined)).toThrowError(/Cannot encode type to JSON/i);
+    });
+
+    it("prefixes strings", () => {
+      expect(toJson("")).toEqual("string:");
+      expect(toJson("abc")).toEqual("string:abc");
+      expect(toJson("\0")).toEqual("string:\0");
+    });
+
+    it("prefixes and hex encodes Uint8Array", () => {
+      expect(toJson(new Uint8Array([]))).toEqual("bytes:");
+      expect(toJson(new Uint8Array([0x12]))).toEqual("bytes:12");
+      expect(toJson(new Uint8Array([0x12, 0xab]))).toEqual("bytes:12ab");
+    });
+
+    // Encoding recursive objects is explicitly undefined behavior. Just use this
+    // test to play around.
+    xit("fails for recursive objects", () => {
+      const a: any = {};
+      const b: any = {};
+      // tslint:disable-next-line: no-object-mutation
+      b.neighbour = a;
+      // tslint:disable-next-line: no-object-mutation
+      a.neighbour = b;
+      expect(() => toJson(a)).toThrowError(/Maximum call stack size exceeded/i);
+    });
+  });
+
+  describe("fromJson", () => {
+    it("works for numbers", () => {
+      expect(fromJson(0)).toEqual(0);
+      expect(fromJson(1)).toEqual(1);
+      expect(fromJson(-1)).toEqual(-1);
+      expect(fromJson(Number.POSITIVE_INFINITY)).toEqual(Number.POSITIVE_INFINITY);
+      expect(fromJson(Number.NaN)).toEqual(Number.NaN);
+    });
+
+    it("works for booleans", () => {
+      expect(fromJson(true)).toEqual(true);
+      expect(fromJson(false)).toEqual(false);
+    });
+
+    it("works for null", () => {
+      expect(fromJson(null)).toEqual(null);
+    });
+
+    it("works for arrays", () => {
+      expect(fromJson([])).toEqual([]);
+      expect(fromJson([1, 2, 3])).toEqual([1, 2, 3]);
+      expect(fromJson([1, [2, 3]])).toEqual([1, [2, 3]]);
+    });
+
+    it("works for dicts", () => {
+      expect(fromJson({})).toEqual({});
+      expect(fromJson({ foo: 1 })).toEqual({ foo: 1 });
+      expect(fromJson({ foo: 1, bar: 2 })).toEqual({ foo: 1, bar: 2 });
+      expect(fromJson({ foo: { bar: 1 } })).toEqual({ foo: { bar: 1 } });
+    });
+
+    it("works for strings", () => {
+      // "string:" prefix
+      expect(fromJson("string:")).toEqual("");
+      expect(fromJson("string:abc")).toEqual("abc");
+      expect(fromJson("string:\0")).toEqual("\0");
+
+      // "bytes:" prefix
+      expect(fromJson("bytes:")).toEqual(new Uint8Array([]));
+      expect(fromJson("bytes:12")).toEqual(new Uint8Array([0x12]));
+      expect(fromJson("bytes:aabb")).toEqual(new Uint8Array([0xaa, 0xbb]));
+
+      // other prefixes
+      expect(() => fromJson("")).toThrowError(/Found string with unknown prefix/i);
+      expect(() => fromJson("abc")).toThrowError(/Found string with unknown prefix/i);
+      expect(() => fromJson("Integer:123")).toThrowError(/Found string with unknown prefix/i);
+    });
+
+    it("decodes a full send transaction", () => {
+      const original: SendTransaction = {
+        kind: "bcp/send",
+        creator: {
+          chainId: "testchain" as ChainId,
+          pubkey: {
+            algo: Algorithm.Ed25519,
+            data: Encoding.fromHex("aabbccdd") as PublicKeyBytes,
+          },
+        },
+        memo: "Hello hello",
+        amount: {
+          quantity: "123",
+          tokenTicker: "CASH" as TokenTicker,
+          fractionalDigits: 2,
+        },
+        recipient: "aabbcc" as Address,
+        fee: {
+          tokens: {
+            quantity: "1",
+            tokenTicker: "ASH" as TokenTicker,
+            fractionalDigits: 2,
+          },
+        },
+      };
+
+      const restored = fromJson(toJson(original));
+      expect(restored).toEqual(original);
+      expect(isPublicIdentity(restored.creator)).toEqual(true);
+    });
+  });
+});

--- a/packages/iov-core/src/transactionencoder.ts
+++ b/packages/iov-core/src/transactionencoder.ts
@@ -1,0 +1,101 @@
+import { Encoding } from "@iov/encoding";
+import { JsonCompatibleValue } from "@iov/jsonrpc";
+
+/**
+ * Encodes non-circular JavaScript objects and primitives into JSON.
+ * Used for encoding/decoding transactions but works for kind of data consisting of the supported types.
+ *
+ * Supported types:
+ * - boolean
+ * - number
+ * - null
+ * - object
+ * - Array
+ * - string
+ * - Uint8Array
+ */
+export class TransactionEncoder {
+  public static toJson(data: unknown): JsonCompatibleValue {
+    if (typeof data === "number" || typeof data === "boolean") {
+      return data;
+    }
+
+    if (data === null) {
+      return null;
+    }
+
+    if (typeof data === "string") {
+      return `string:${data}`;
+    }
+
+    if (data instanceof Uint8Array) {
+      return `bytes:${Encoding.toHex(data)}`;
+    }
+
+    if (Array.isArray(data)) {
+      return data.map(TransactionEncoder.toJson);
+    }
+
+    // Exclude special kind of objects like Array, Date or Uint8Array
+    // Object.prototype.toString() returns a specified value:
+    // http://www.ecma-international.org/ecma-262/7.0/index.html#sec-object.prototype.tostring
+    if (
+      typeof data === "object" &&
+      data !== null &&
+      Object.prototype.toString.call(data) === "[object Object]"
+    ) {
+      const out: any = {};
+      for (const key of Object.keys(data)) {
+        // tslint:disable-next-line: no-object-mutation
+        out[key] = TransactionEncoder.toJson((data as any)[key]);
+      }
+      return out;
+    }
+
+    throw new Error("Cannot encode type to JSON");
+  }
+
+  public static fromJson(data: JsonCompatibleValue): any {
+    if (typeof data === "number" || typeof data === "boolean") {
+      return data;
+    }
+
+    if (data === null) {
+      return null;
+    }
+
+    if (typeof data === "string") {
+      if (data.startsWith("string:")) {
+        return data.slice(7);
+      }
+
+      if (data.startsWith("bytes:")) {
+        return Encoding.fromHex(data.slice(6));
+      }
+
+      throw new Error("Found string with unknown prefix");
+    }
+
+    if (Array.isArray(data)) {
+      return data.map(TransactionEncoder.fromJson);
+    }
+
+    // Exclude special kind of objects like Array, Date or Uint8Array
+    // Object.prototype.toString() returns a specified value:
+    // http://www.ecma-international.org/ecma-262/7.0/index.html#sec-object.prototype.tostring
+    if (
+      typeof data === "object" &&
+      data !== null &&
+      Object.prototype.toString.call(data) === "[object Object]"
+    ) {
+      const out: any = {};
+      for (const key of Object.keys(data)) {
+        // tslint:disable-next-line: no-object-mutation
+        out[key] = TransactionEncoder.fromJson((data as any)[key]);
+      }
+      return out;
+    }
+
+    throw new Error("Cannot decode type from JSON");
+  }
+}

--- a/packages/iov-core/src/transactionencoder.ts
+++ b/packages/iov-core/src/transactionencoder.ts
@@ -1,6 +1,11 @@
 import { Encoding } from "@iov/encoding";
 import { JsonCompatibleValue } from "@iov/jsonrpc";
 
+const prefixes = {
+  string: "string:",
+  bytes: "bytes:",
+};
+
 /**
  * Encodes non-circular JavaScript objects and primitives into JSON.
  * Used for encoding/decoding transactions but works for kind of data consisting of the supported types.
@@ -25,11 +30,11 @@ export class TransactionEncoder {
     }
 
     if (typeof data === "string") {
-      return `string:${data}`;
+      return `${prefixes.string}${data}`;
     }
 
     if (data instanceof Uint8Array) {
-      return `bytes:${Encoding.toHex(data)}`;
+      return `${prefixes.bytes}${Encoding.toHex(data)}`;
     }
 
     if (Array.isArray(data)) {
@@ -65,12 +70,12 @@ export class TransactionEncoder {
     }
 
     if (typeof data === "string") {
-      if (data.startsWith("string:")) {
-        return data.slice(7);
+      if (data.startsWith(prefixes.string)) {
+        return data.slice(prefixes.string.length);
       }
 
-      if (data.startsWith("bytes:")) {
-        return Encoding.fromHex(data.slice(6));
+      if (data.startsWith(prefixes.bytes)) {
+        return Encoding.fromHex(data.slice(prefixes.bytes.length));
       }
 
       throw new Error("Found string with unknown prefix");

--- a/packages/iov-core/src/workers/signingservice.worker.ts
+++ b/packages/iov-core/src/workers/signingservice.worker.ts
@@ -63,4 +63,5 @@ async function main(): Promise<void> {
   };
 }
 
+// tslint:disable-next-line: no-floating-promises
 main();

--- a/packages/iov-core/src/workers/signingservice.worker.ts
+++ b/packages/iov-core/src/workers/signingservice.worker.ts
@@ -7,7 +7,7 @@ import { bnsConnector } from "@iov/bns";
 import { ethereumConnector } from "@iov/ethereum";
 import { Ed25519HdWallet, HdPaths, Secp256k1HdWallet, UserProfile } from "@iov/keycontrol";
 
-import { JsRpcSigningServer } from "../jsrpcsigningserver";
+import { JsonRpcSigningServer } from "../jsonrpcsigningserver";
 import { MultiChainSigner } from "../multichainsigner";
 import { SigningServerCore } from "../signingservercore";
 
@@ -48,7 +48,7 @@ async function main(): Promise<void> {
       return true;
     },
   );
-  const server = new JsRpcSigningServer(core);
+  const server = new JsonRpcSigningServer(core);
 
   onmessage = async event => {
     // console.log("Received message", JSON.stringify(event));

--- a/packages/iov-core/src/workers/signingservice.worker.ts
+++ b/packages/iov-core/src/workers/signingservice.worker.ts
@@ -34,7 +34,7 @@ async function main(): Promise<void> {
   // faucet identity
   await profile.createIdentity(ed25519Wallet.id, bnsdChainId, HdPaths.simpleAddress(0));
   // ganache second identity
-  await profile.createIdentity(secp256k1Wallet.id, ethereumChainId, HdPaths.bip44(60, 0, 0, 1));
+  await profile.createIdentity(secp256k1Wallet.id, ethereumChainId, HdPaths.ethereum(1));
 
   const core = new SigningServerCore(
     profile,

--- a/packages/iov-core/types/index.d.ts
+++ b/packages/iov-core/types/index.d.ts
@@ -2,5 +2,6 @@ export { Address, ChainId, Nonce, SendTransaction, TokenTicker } from "@iov/bcp"
 export { Ed25519HdWallet, Ed25519Wallet, HdPaths, Keyring, Secp256k1HdWallet, UserProfile, Wallet, WalletId, WalletImplementationIdString, WalletSerializationString, } from "@iov/keycontrol";
 export { JsRpcClient, jsRpcCode, JsRpcErrorResponse, JsRpcRequest, JsRpcResponse, JsRpcSuccessResponse, parseJsRpcErrorResponse, parseJsRpcId, parseJsRpcRequest, parseJsRpcResponse, } from "./jsrpc";
 export { JsRpcSigningServer } from "./jsrpcsigningserver";
+export { JsonRpcSigningServer } from "./jsonrpcsigningserver";
 export { MultiChainSigner } from "./multichainsigner";
 export { GetIdentitiesAuthorization, SignAndPostAuthorization, SigningServerCore } from "./signingservercore";

--- a/packages/iov-core/types/index.d.ts
+++ b/packages/iov-core/types/index.d.ts
@@ -5,3 +5,4 @@ export { JsRpcSigningServer } from "./jsrpcsigningserver";
 export { JsonRpcSigningServer } from "./jsonrpcsigningserver";
 export { MultiChainSigner } from "./multichainsigner";
 export { GetIdentitiesAuthorization, SignAndPostAuthorization, SigningServerCore } from "./signingservercore";
+export { TransactionEncoder } from "./transactionencoder";

--- a/packages/iov-core/types/jsonrpcsigningserver.d.ts
+++ b/packages/iov-core/types/jsonrpcsigningserver.d.ts
@@ -1,4 +1,8 @@
-import { JsonCompatibleValue } from "@iov/jsonrpc";
+import { JsonCompatibleValue, JsonRpcRequest, JsonRpcResponse } from "@iov/jsonrpc";
+import { SigningServerCore } from "./signingservercore";
+/**
+ * A transport-agnostic JSON-RPC wrapper around SigningServerCore
+ */
 export declare class JsonRpcSigningServer {
     /**
      * Encodes a non-recursive JavaScript object as JSON in a way that is
@@ -7,4 +11,19 @@ export declare class JsonRpcSigningServer {
      */
     static toJson(data: unknown): JsonCompatibleValue;
     static fromJson(data: JsonCompatibleValue): any;
+    private readonly core;
+    constructor(core: SigningServerCore);
+    handleUnchecked(request: unknown): Promise<JsonRpcResponse>;
+    /**
+     * Handles a checked JsonRpcRequest
+     *
+     * 1. convert JsRpcRequest into calls to SigningServerCore
+     * 2. call SigningServerCore
+     * 3. convert result to JSON-RPC format
+     */
+    handleChecked(request: JsonRpcRequest): Promise<JsonRpcResponse>;
+    /**
+     * Call this to free ressources when server is not needed anymore
+     */
+    shutdown(): void;
 }

--- a/packages/iov-core/types/jsonrpcsigningserver.d.ts
+++ b/packages/iov-core/types/jsonrpcsigningserver.d.ts
@@ -1,16 +1,9 @@
-import { JsonCompatibleValue, JsonRpcRequest, JsonRpcResponse } from "@iov/jsonrpc";
+import { JsonRpcRequest, JsonRpcResponse } from "@iov/jsonrpc";
 import { SigningServerCore } from "./signingservercore";
 /**
  * A transport-agnostic JSON-RPC wrapper around SigningServerCore
  */
 export declare class JsonRpcSigningServer {
-    /**
-     * Encodes a non-recursive JavaScript object as JSON in a way that is
-     * 1. compact for binary data
-     * 2. supports serializing/deserializing non-JSON types like Uint8Array
-     */
-    static toJson(data: unknown): JsonCompatibleValue;
-    static fromJson(data: JsonCompatibleValue): any;
     private readonly core;
     constructor(core: SigningServerCore);
     handleUnchecked(request: unknown): Promise<JsonRpcResponse>;

--- a/packages/iov-core/types/jsonrpcsigningserver.d.ts
+++ b/packages/iov-core/types/jsonrpcsigningserver.d.ts
@@ -6,9 +6,13 @@ import { SigningServerCore } from "./signingservercore";
 export declare class JsonRpcSigningServer {
     private readonly core;
     constructor(core: SigningServerCore);
+    /**
+     * Handles a request from a possible untrusted source.
+     */
     handleUnchecked(request: unknown): Promise<JsonRpcResponse>;
     /**
-     * Handles a checked JsonRpcRequest
+     * Handles a checked request, i.e. a request that is known to be a valid
+     * JSON-RPC "Request object".
      *
      * 1. convert JsRpcRequest into calls to SigningServerCore
      * 2. call SigningServerCore

--- a/packages/iov-core/types/jsonrpcsigningserver.d.ts
+++ b/packages/iov-core/types/jsonrpcsigningserver.d.ts
@@ -1,0 +1,10 @@
+import { JsonCompatibleValue } from "@iov/jsonrpc";
+export declare class JsonRpcSigningServer {
+    /**
+     * Encodes a non-recursive JavaScript object as JSON in a way that is
+     * 1. compact for binary data
+     * 2. supports serializing/deserializing non-JSON types like Uint8Array
+     */
+    static toJson(data: unknown): JsonCompatibleValue;
+    static fromJson(data: JsonCompatibleValue): any;
+}

--- a/packages/iov-core/types/jsrpc.d.ts
+++ b/packages/iov-core/types/jsrpc.d.ts
@@ -1,25 +1,43 @@
 import { SimpleMessagingConnection } from "@iov/jsonrpc";
-/** A single structured clone algorithm compatible value */
+/**
+ * A single structured clone algorithm compatible value
+ *
+ * @deprecated use JsonRpcSigningServer and friends
+ */
 export declare type JsRpcCompatibleValue = string | number | boolean | null | Uint8Array | JsRpcCompatibleArray | JsRpcCompatibleDictionary;
-/** An array of JsRpcCompatibleValue */
+/**
+ * An array of JsRpcCompatibleValue
+ *
+ * @deprecated use JsonRpcSigningServer and friends
+ */
 export interface JsRpcCompatibleArray extends ReadonlyArray<JsRpcCompatibleValue> {
 }
-/** A string to JsRpcCompatibleValue dictionary. */
+/**
+ * A string to JsRpcCompatibleValue dictionary.
+ *
+ * @deprecated use JsonRpcSigningServer and friends
+ */
 export interface JsRpcCompatibleDictionary {
     readonly [key: string]: JsRpcCompatibleValue;
 }
+/** @deprecated use JsonRpcSigningServer and friends */
 export declare function isJsRpcCompatibleValue(value: unknown): value is JsRpcCompatibleValue;
+/** @deprecated use JsonRpcSigningServer and friends */
 export declare function isJsRpcCompatibleArray(value: unknown): value is JsRpcCompatibleArray;
+/** @deprecated use JsonRpcSigningServer and friends */
 export declare function isJsRpcCompatibleDictionary(data: unknown): data is JsRpcCompatibleDictionary;
+/** @deprecated use JsonRpcSigningServer and friends */
 export interface JsRpcRequest {
     readonly id: number;
     readonly method: string;
     readonly params: JsRpcCompatibleArray | JsRpcCompatibleDictionary;
 }
+/** @deprecated use JsonRpcSigningServer and friends */
 export interface JsRpcSuccessResponse {
     readonly id: number;
     readonly result: any;
 }
+/** @deprecated use JsonRpcSigningServer and friends */
 export interface JsRpcError {
     readonly code: number;
     readonly message: string;
@@ -27,13 +45,18 @@ export interface JsRpcError {
 }
 /**
  * And error object as described in https://www.jsonrpc.org/specification#error_object
+ *
+ * @deprecated use JsonRpcSigningServer and friends
  */
 export interface JsRpcErrorResponse {
     readonly id: number | null;
     readonly error: JsRpcError;
 }
+/** @deprecated use JsonRpcSigningServer and friends */
 export declare type JsRpcResponse = JsRpcSuccessResponse | JsRpcErrorResponse;
+/** @deprecated use JsonRpcSigningServer and friends */
 export declare function isJsRpcErrorResponse(response: JsRpcResponse): response is JsRpcErrorResponse;
+/** @deprecated use JsonRpcSigningServer and friends */
 export declare const jsRpcCode: {
     parseError: number;
     invalidRequest: number;
@@ -42,10 +65,15 @@ export declare const jsRpcCode: {
     internalError: number;
     serverErrorDefault: number;
 };
+/** @deprecated use JsonRpcSigningServer and friends */
 export declare function parseJsRpcId(data: unknown): number | null;
+/** @deprecated use JsonRpcSigningServer and friends */
 export declare function parseJsRpcRequest(data: unknown): JsRpcRequest;
+/** @deprecated use JsonRpcSigningServer and friends */
 export declare function parseJsRpcErrorResponse(data: unknown): JsRpcErrorResponse | undefined;
+/** @deprecated use JsonRpcSigningServer and friends */
 export declare function parseJsRpcResponse(data: unknown): JsRpcSuccessResponse;
+/** @deprecated use JsonRpcSigningServer and friends */
 export declare class JsRpcClient {
     private readonly connection;
     constructor(connection: SimpleMessagingConnection<JsRpcRequest, JsRpcResponse>);

--- a/packages/iov-core/types/jsrpcsigningserver.d.ts
+++ b/packages/iov-core/types/jsrpcsigningserver.d.ts
@@ -2,6 +2,8 @@ import { JsRpcRequest, JsRpcResponse } from "./jsrpc";
 import { SigningServerCore } from "./signingservercore";
 /**
  * A transport-agnostic JavaScript RPC wrapper around SigningServerCore
+ *
+ * @deprecated use JsonRpcSigningServer and friends
  */
 export declare class JsRpcSigningServer {
     private readonly core;

--- a/packages/iov-core/types/transactionencoder.d.ts
+++ b/packages/iov-core/types/transactionencoder.d.ts
@@ -1,0 +1,18 @@
+import { JsonCompatibleValue } from "@iov/jsonrpc";
+/**
+ * Encodes non-circular JavaScript objects and primitives into JSON.
+ * Used for encoding/decoding transactions but works for kind of data consisting of the supported types.
+ *
+ * Supported types:
+ * - boolean
+ * - number
+ * - null
+ * - object
+ * - Array
+ * - string
+ * - Uint8Array
+ */
+export declare class TransactionEncoder {
+    static toJson(data: unknown): JsonCompatibleValue;
+    static fromJson(data: JsonCompatibleValue): any;
+}

--- a/packages/iov-jsonrpc/src/index.ts
+++ b/packages/iov-jsonrpc/src/index.ts
@@ -14,6 +14,7 @@ export {
   JsonRpcErrorResponse,
   JsonRpcResponse,
   JsonRpcSuccessResponse,
+  jsonRpcCode,
   jsonRpcCodeInternalError,
   jsonRpcCodeInvalidParams,
   jsonRpcCodeInvalidRequest,

--- a/packages/iov-jsonrpc/src/jsonrpcclient.spec.ts
+++ b/packages/iov-jsonrpc/src/jsonrpcclient.spec.ts
@@ -19,7 +19,6 @@ function makeSimpleMessagingConnection(
     start: listener => {
       // tslint:disable-next-line:no-object-mutation
       worker.onmessage = event => {
-        // console.log("Got message from connection", event);
         const responseError = parseJsonRpcError(event.data);
         if (responseError) {
           listener.next(responseError);

--- a/packages/iov-jsonrpc/src/jsonrpcclient.ts
+++ b/packages/iov-jsonrpc/src/jsonrpcclient.ts
@@ -9,6 +9,12 @@ export interface SimpleMessagingConnection<Request, Response> {
   readonly sendRequest: (request: Request) => void;
 }
 
+/**
+ * A thin wrapper that is used to bring together requests and responses by ID.
+ *
+ * Using this class is only advised for continous communication channels like
+ * WebSockets or WebWorker messaging.
+ */
 export class JsonRpcClient {
   private readonly connection: SimpleMessagingConnection<JsonRpcRequest, JsonRpcResponse>;
 

--- a/packages/iov-jsonrpc/src/types.ts
+++ b/packages/iov-jsonrpc/src/types.ts
@@ -38,11 +38,33 @@ export function isJsonRpcErrorResponse(response: JsonRpcResponse): response is J
   return typeof (response as JsonRpcErrorResponse).error === "object";
 }
 
-export const jsonRpcCodeParseError = -32700;
-export const jsonRpcCodeInvalidRequest = -32600;
-export const jsonRpcCodeMethodNotFound = -32601;
-export const jsonRpcCodeInvalidParams = -32602;
-export const jsonRpcCodeInternalError = -32603;
-// server error (Reserved for implementation-defined server-errors.):
-// -32000 to -32099
-export const jsonRpcCodeServerErrorDefault = -32000;
+/**
+ * Error codes as specified in JSON-RPC 2.0
+ *
+ * @see https://www.jsonrpc.org/specification#error_object
+ */
+export const jsonRpcCode = {
+  parseError: -32700,
+  invalidRequest: -32600,
+  methodNotFound: -32601,
+  invalidParams: -32602,
+  internalError: -32603,
+  // server error (Reserved for implementation-defined server-errors.):
+  // -32000 to -32099
+  serverError: {
+    default: -32000,
+  },
+};
+
+/** @deprecated: use jsonRpcCode */
+export const jsonRpcCodeParseError = jsonRpcCode.parseError;
+/** @deprecated: use jsonRpcCode */
+export const jsonRpcCodeInvalidRequest = jsonRpcCode.invalidRequest;
+/** @deprecated: use jsonRpcCode */
+export const jsonRpcCodeMethodNotFound = jsonRpcCode.methodNotFound;
+/** @deprecated: use jsonRpcCode */
+export const jsonRpcCodeInvalidParams = jsonRpcCode.invalidParams;
+/** @deprecated: use jsonRpcCode */
+export const jsonRpcCodeInternalError = jsonRpcCode.internalError;
+/** @deprecated: use jsonRpcCode */
+export const jsonRpcCodeServerErrorDefault = jsonRpcCode.serverError.default;

--- a/packages/iov-jsonrpc/types/index.d.ts
+++ b/packages/iov-jsonrpc/types/index.d.ts
@@ -1,4 +1,4 @@
 export { JsonRpcClient, SimpleMessagingConnection } from "./jsonrpcclient";
 export { JsonCompatibleArray, JsonCompatibleDictionary, JsonCompatibleValue, isJsonCompatibleArray, isJsonCompatibleDictionary, isJsonCompatibleValue, } from "./jsoncompatibledictionary";
 export { parseJsonRpcId, parseJsonRpcRequest, parseJsonRpcResponse, parseJsonRpcError } from "./parse";
-export { isJsonRpcErrorResponse, JsonRpcRequest, JsonRpcErrorResponse, JsonRpcResponse, JsonRpcSuccessResponse, jsonRpcCodeInternalError, jsonRpcCodeInvalidParams, jsonRpcCodeInvalidRequest, jsonRpcCodeMethodNotFound, jsonRpcCodeParseError, jsonRpcCodeServerErrorDefault, } from "./types";
+export { isJsonRpcErrorResponse, JsonRpcRequest, JsonRpcErrorResponse, JsonRpcResponse, JsonRpcSuccessResponse, jsonRpcCode, jsonRpcCodeInternalError, jsonRpcCodeInvalidParams, jsonRpcCodeInvalidRequest, jsonRpcCodeMethodNotFound, jsonRpcCodeParseError, jsonRpcCodeServerErrorDefault, } from "./types";

--- a/packages/iov-jsonrpc/types/jsonrpcclient.d.ts
+++ b/packages/iov-jsonrpc/types/jsonrpcclient.d.ts
@@ -4,6 +4,12 @@ export interface SimpleMessagingConnection<Request, Response> {
     readonly responseStream: Stream<Response>;
     readonly sendRequest: (request: Request) => void;
 }
+/**
+ * A thin wrapper that is used to bring together requests and responses by ID.
+ *
+ * Using this class is only advised for continous communication channels like
+ * WebSockets or WebWorker messaging.
+ */
 export declare class JsonRpcClient {
     private readonly connection;
     constructor(connection: SimpleMessagingConnection<JsonRpcRequest, JsonRpcResponse>);

--- a/packages/iov-jsonrpc/types/types.d.ts
+++ b/packages/iov-jsonrpc/types/types.d.ts
@@ -25,9 +25,30 @@ export interface JsonRpcErrorResponse {
 }
 export declare type JsonRpcResponse = JsonRpcSuccessResponse | JsonRpcErrorResponse;
 export declare function isJsonRpcErrorResponse(response: JsonRpcResponse): response is JsonRpcErrorResponse;
-export declare const jsonRpcCodeParseError = -32700;
-export declare const jsonRpcCodeInvalidRequest = -32600;
-export declare const jsonRpcCodeMethodNotFound = -32601;
-export declare const jsonRpcCodeInvalidParams = -32602;
-export declare const jsonRpcCodeInternalError = -32603;
-export declare const jsonRpcCodeServerErrorDefault = -32000;
+/**
+ * Error codes as specified in JSON-RPC 2.0
+ *
+ * @see https://www.jsonrpc.org/specification#error_object
+ */
+export declare const jsonRpcCode: {
+    parseError: number;
+    invalidRequest: number;
+    methodNotFound: number;
+    invalidParams: number;
+    internalError: number;
+    serverError: {
+        default: number;
+    };
+};
+/** @deprecated: use jsonRpcCode */
+export declare const jsonRpcCodeParseError: number;
+/** @deprecated: use jsonRpcCode */
+export declare const jsonRpcCodeInvalidRequest: number;
+/** @deprecated: use jsonRpcCode */
+export declare const jsonRpcCodeMethodNotFound: number;
+/** @deprecated: use jsonRpcCode */
+export declare const jsonRpcCodeInvalidParams: number;
+/** @deprecated: use jsonRpcCode */
+export declare const jsonRpcCodeInternalError: number;
+/** @deprecated: use jsonRpcCode */
+export declare const jsonRpcCodeServerErrorDefault: number;


### PR DESCRIPTION
Closes #801
Closes #914

---

JsonRpcSigningServer is like JsRpcSigningServer but works over every JSON-based channel. Unfortunately the [website browser extension communication](https://github.com/iov-one/ponferrada/wiki/Communication-channels) does not support the [structured clone algorithm](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm) (website to WebWorker does), so we need a way to serialize/deserialize Uint8Array as JSON, which is done using "bytes:" prefixed hex strings.

Instead of wrapping JsonRpcSigningServer around JsRpcSigningServer, which adds mostly unnecessary complexity, I changed my mind and copied most of JsRpcSigningServer to prepare the removal of JsRpcSigningServer.