### PR TITLE
Update Ethereum ABI methods for ERC20 swaps

### DIFF
--- a/packages/iov-ethereum/src/abi.spec.ts
+++ b/packages/iov-ethereum/src/abi.spec.ts
@@ -334,9 +334,16 @@ describe("Abi", () => {
   });
 
   describe("decodeEventSignature", () => {
-    it("works for Opened", () => {
+    it("works for Opened (ETH)", () => {
       // Abi.calculateMethodHash("Opened(bytes32,address,address,bytes32,uint256,uint256)");
       const data = fromHex("22f9086560da4f3a67d5fcc1a440655671d27a7e0884f260be3ce12ead52e156");
+      const result = Abi.decodeEventSignature(data);
+      expect(result).toEqual(SwapContractEvent.Opened);
+    });
+
+    it("works for Opened (ERC20)", () => {
+      // Abi.calculateMethodHash("Opened(bytes32,address,address,bytes32,uint256,uint256,address)");
+      const data = fromHex("26bc31c92066e78c047aa344b0f41cf8ee926fe610bb21ee73329697475bc9d3");
       const result = Abi.decodeEventSignature(data);
       expect(result).toEqual(SwapContractEvent.Opened);
     });
@@ -363,9 +370,16 @@ describe("Abi", () => {
   });
 
   describe("decodeMethodId", () => {
-    it("works for Open", () => {
+    it("works for Open (ETH)", () => {
       // Abi.calculateMethodId("open(bytes32,address,bytes32,uint256)");
       const data = fromHex("0eed8548");
+      const result = Abi.decodeMethodId(data);
+      expect(result).toEqual(SwapContractMethod.Open);
+    });
+
+    it("works for Open (ERC20)", () => {
+      // Abi.calculateMethodId("open(bytes32,address,bytes32,uint256,address,uint256)");
+      const data = fromHex("e8d8a293");
       const result = Abi.decodeMethodId(data);
       expect(result).toEqual(SwapContractMethod.Open);
     });

--- a/packages/iov-ethereum/src/abi.ts
+++ b/packages/iov-ethereum/src/abi.ts
@@ -149,7 +149,8 @@ export class Abi {
     }
     const key = Encoding.toHex(data);
     const map: { readonly [key: string]: SwapContractEvent } = {
-      [Abi.eventSignatures.opened]: SwapContractEvent.Opened,
+      [Abi.eventSignatures.openedEth]: SwapContractEvent.Opened,
+      [Abi.eventSignatures.openedErc20]: SwapContractEvent.Opened,
       [Abi.eventSignatures.claimed]: SwapContractEvent.Claimed,
       [Abi.eventSignatures.aborted]: SwapContractEvent.Aborted,
     };
@@ -167,7 +168,8 @@ export class Abi {
     }
     const key = Encoding.toHex(data);
     const map: { readonly [key: string]: SwapContractMethod } = {
-      [Abi.methodIds.open]: SwapContractMethod.Open,
+      [Abi.methodIds.openEth]: SwapContractMethod.Open,
+      [Abi.methodIds.openErc20]: SwapContractMethod.Open,
       [Abi.methodIds.claim]: SwapContractMethod.Claim,
       [Abi.methodIds.abort]: SwapContractMethod.Abort,
     };
@@ -180,23 +182,29 @@ export class Abi {
   }
 
   private static readonly eventSignatures: {
-    readonly opened: string;
+    readonly openedEth: string;
+    readonly openedErc20: string;
     readonly claimed: string;
     readonly aborted: string;
   } = {
-    opened: Encoding.toHex(
+    openedEth: Encoding.toHex(
       Abi.calculateMethodHash("Opened(bytes32,address,address,bytes32,uint256,uint256)"),
+    ),
+    openedErc20: Encoding.toHex(
+      Abi.calculateMethodHash("Opened(bytes32,address,address,bytes32,uint256,uint256,address)"),
     ),
     claimed: Encoding.toHex(Abi.calculateMethodHash("Claimed(bytes32,bytes32)")),
     aborted: Encoding.toHex(Abi.calculateMethodHash("Aborted(bytes32)")),
   };
 
   private static readonly methodIds: {
-    readonly open: string;
+    readonly openEth: string;
+    readonly openErc20: string;
     readonly claim: string;
     readonly abort: string;
   } = {
-    open: Encoding.toHex(Abi.calculateMethodId("open(bytes32,address,bytes32,uint256)")),
+    openEth: Encoding.toHex(Abi.calculateMethodId("open(bytes32,address,bytes32,uint256)")),
+    openErc20: Encoding.toHex(Abi.calculateMethodId("open(bytes32,address,bytes32,uint256,address,uint256)")),
     claim: Encoding.toHex(Abi.calculateMethodId("claim(bytes32,bytes32)")),
     abort: Encoding.toHex(Abi.calculateMethodId("abort(bytes32)")),
   };


### PR DESCRIPTION
Partially addresses #821 

We should still refactor this out of this class, but following the pattern for now.