### PR TITLE
Standardize typedoc configs

### DIFF
--- a/packages/iov-bcp/typedoc.js
+++ b/packages/iov-bcp/typedoc.js
@@ -1,13 +1,14 @@
 const packageJson = require("./package.json");
 
 module.exports = {
-  out: "docs",
   src: ["./src"],
+  out: "docs",
+  exclude: "**/*.spec.ts",
   target: "es6",
   name: `${packageJson.name} Documentation`,
   readme: "README.md",
   mode: "file",
-  excludePrivate: true,
+  excludeExternals: true,
   excludeNotExported: true,
-  includeDefinitions: true,
+  excludePrivate: true,
 }

--- a/packages/iov-bns/typedoc.js
+++ b/packages/iov-bns/typedoc.js
@@ -8,6 +8,7 @@ module.exports = {
   name: `${packageJson.name} Documentation`,
   readme: "README.md",
   mode: "file",
-  excludePrivate: true,
+  excludeExternals: true,
   excludeNotExported: true,
+  excludePrivate: true,
 }

--- a/packages/iov-core/typedoc.js
+++ b/packages/iov-core/typedoc.js
@@ -8,11 +8,11 @@ module.exports = {
   name: `${packageJson.name} Documentation`,
   readme: "README.md",
   mode: "file",
+  excludeExternals: false,
+  // TODO: tweak this so we can ignore non iov (mono-repo) imports
+  externalPattern: "^((?!iov).)*$",
   excludePrivate: true,
   excludeNotExported: true,
   // this pulls in all dependencies
   includeDeclarations: true,
-  // TODO: tweak this so we can ignore non iov (mono-repo) imports
-  excludeExternals: false,
-  externalPattern: "^((?!iov).)*$",
 }

--- a/packages/iov-crypto/typedoc.js
+++ b/packages/iov-crypto/typedoc.js
@@ -9,6 +9,6 @@ module.exports = {
   readme: "README.md",
   mode: "file",
   excludeExternals: true,
-  excludePrivate: true,
   excludeNotExported: true,
+  excludePrivate: true,
 }

--- a/packages/iov-dpos/typedoc.js
+++ b/packages/iov-dpos/typedoc.js
@@ -8,6 +8,7 @@ module.exports = {
   name: `${packageJson.name} Documentation`,
   readme: "README.md",
   mode: "file",
-  excludePrivate: true,
+  excludeExternals: true,
   excludeNotExported: true,
+  excludePrivate: true,
 }

--- a/packages/iov-encoding/typedoc.js
+++ b/packages/iov-encoding/typedoc.js
@@ -8,7 +8,7 @@ module.exports = {
   name: `${packageJson.name} Documentation`,
   readme: "README.md",
   mode: "file",
-  excludePrivate: true,
+  excludeExternals: true,
   excludeNotExported: true,
-  ignoreCompilerErrors: true,
+  excludePrivate: true,
 }

--- a/packages/iov-ethereum/typedoc.js
+++ b/packages/iov-ethereum/typedoc.js
@@ -8,6 +8,7 @@ module.exports = {
   name: `${packageJson.name} Documentation`,
   readme: "README.md",
   mode: "file",
-  excludePrivate: true,
+  excludeExternals: true,
   excludeNotExported: true,
+  excludePrivate: true,
 }

--- a/packages/iov-faucets/typedoc.js
+++ b/packages/iov-faucets/typedoc.js
@@ -8,7 +8,7 @@ module.exports = {
   name: `${packageJson.name} Documentation`,
   readme: "README.md",
   mode: "file",
-  excludePrivate: true,
+  excludeExternals: true,
   excludeNotExported: true,
-  ignoreCompilerErrors: true,
+  excludePrivate: true,
 }

--- a/packages/iov-jsonrpc/typedoc.js
+++ b/packages/iov-jsonrpc/typedoc.js
@@ -8,11 +8,7 @@ module.exports = {
   name: `${packageJson.name} Documentation`,
   readme: "README.md",
   mode: "file",
-  excludePrivate: true,
+  excludeExternals: true,
   excludeNotExported: true,
-  // this pulls in all dependencies
-  includeDeclarations: true,
-  // TODO: tweak this so we can ignore non iov (mono-repo) imports
-  excludeExternals: false,
-  externalPattern: "^((?!iov).)*$",
+  excludePrivate: true,
 }

--- a/packages/iov-keycontrol/typedoc.js
+++ b/packages/iov-keycontrol/typedoc.js
@@ -8,6 +8,7 @@ module.exports = {
   name: `${packageJson.name} Documentation`,
   readme: "README.md",
   mode: "file",
-  excludePrivate: true,
+  excludeExternals: true,
   excludeNotExported: true,
+  excludePrivate: true,
 }

--- a/packages/iov-lisk/typedoc.js
+++ b/packages/iov-lisk/typedoc.js
@@ -8,6 +8,7 @@ module.exports = {
   name: `${packageJson.name} Documentation`,
   readme: "README.md",
   mode: "file",
-  excludePrivate: true,
+  excludeExternals: true,
   excludeNotExported: true,
+  excludePrivate: true,
 }

--- a/packages/iov-rise/typedoc.js
+++ b/packages/iov-rise/typedoc.js
@@ -8,6 +8,7 @@ module.exports = {
   name: `${packageJson.name} Documentation`,
   readme: "README.md",
   mode: "file",
-  excludePrivate: true,
+  excludeExternals: true,
   excludeNotExported: true,
+  excludePrivate: true,
 }

--- a/packages/iov-socket/typedoc.js
+++ b/packages/iov-socket/typedoc.js
@@ -8,6 +8,7 @@ module.exports = {
   name: `${packageJson.name} Documentation`,
   readme: "README.md",
   mode: "file",
-  excludePrivate: true,
+  excludeExternals: true,
   excludeNotExported: true,
+  excludePrivate: true,
 }

--- a/packages/iov-stream/typedoc.js
+++ b/packages/iov-stream/typedoc.js
@@ -8,11 +8,7 @@ module.exports = {
   name: `${packageJson.name} Documentation`,
   readme: "README.md",
   mode: "file",
-  excludePrivate: true,
+  excludeExternals: true,
   excludeNotExported: true,
-  // this pulls in all dependencies
-  includeDeclarations: true,
-  // TODO: tweak this so we can ignore non iov (mono-repo) imports
-  excludeExternals: false,
-  externalPattern: "^((?!iov).)*$",
+  excludePrivate: true,
 }

--- a/packages/iov-tendermint-rpc/typedoc.js
+++ b/packages/iov-tendermint-rpc/typedoc.js
@@ -7,7 +7,8 @@ module.exports = {
   target: "es6",
   name: `${packageJson.name} Documentation`,
   readme: "README.md",
-  mode: "modules",
-  excludePrivate: true,
+  mode: "file",
+  excludeExternals: true,
   excludeNotExported: true,
+  excludePrivate: true,
 }


### PR DESCRIPTION
Related to #786

Didn’t get to the bottom of these warnings, and it’s probably not worth spending any more time on them. The offending option is `includeDeclarations`, but I didn’t get to the bottom of why that causes a problem. It has something to do with internal usage of HighlightJS and Marked by TypeDoc.

I did notice that the configs for TypeDoc were pretty inconsistent, so took the opportunity to standardize them. I left `includeDeclarations` set for `@iov/core` with `excludeExternals` turned off since it’s pretty useful to be able to navigate around fully, but turned those settings off in the couple of other packages where they were turned on.