### PR TITLE
Support multisignature contracts in BNS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 - @iov/bcp: Add `isSwapTransaction` helper function.
 - @iov/bcp: Add `isOpenSwap`, `isClaimedSwap` and `isAbortedSwap` helper
   functions.
+- @iov/bns: Add support for multisignature transactions.
+- @iov/bns: Add `CreateMultisignatureTx` and `UpdateMultisignatureTx` types
+  along with `Participant`.
 - @iov/ethereum: Add `createEtherSwapId` and `createErc20SwapId` static methods.
 - @iov/ethereum: Add `SwapIdPrefix` enum.
 - @iov/ethereum: Add `Erc20TokensMap` type.

--- a/packages/iov-bns/src/bnsconnection.spec.ts
+++ b/packages/iov-bns/src/bnsconnection.spec.ts
@@ -48,11 +48,16 @@ import { BnsConnection } from "./bnsconnection";
 import { bnsSwapQueryTag } from "./tags";
 import {
   AddAddressToUsernameTx,
+  CreateMultisignatureTx,
+  isCreateMultisignatureTx,
   isRegisterUsernameTx,
+  isUpdateMultisignatureTx,
+  Participant,
   RegisterUsernameTx,
   RemoveAddressFromUsernameTx,
+  UpdateMultisignatureTx,
 } from "./types";
-import { encodeBnsAddress, identityToAddress } from "./util";
+import { decodeBnsAddress, encodeBnsAddress, identityToAddress } from "./util";
 
 const { fromHex, toHex } = Encoding;
 
@@ -826,6 +831,102 @@ describe("BnsConnection", () => {
         expect(blockInfo.code).toEqual(14);
         expect(blockInfo.message || "").toMatch(/invalid input/i);
       }
+
+      connection.disconnect();
+    });
+
+    it("can create and update a multisignature account", async () => {
+      pendingWithoutBnsd();
+      const connection = await BnsConnection.establish(bnsdTendermintUrl);
+      const registryChainId = connection.chainId();
+
+      const profile = new UserProfile();
+      const wallet = profile.addWallet(Ed25519HdWallet.fromEntropy(await Random.getBytes(32)));
+      const identity = await profile.createIdentity(wallet.id, registryChainId, HdPaths.iov(0));
+
+      // we need funds to pay the fees
+      const address = identityToAddress(identity);
+      await sendTokensFromFaucet(connection, address, registerAmount);
+
+      // Create multisignature
+      const otherIdentities = await Promise.all(
+        [10, 11, 12, 13, 14].map(i => profile.createIdentity(wallet.id, registryChainId, HdPaths.iov(i))),
+      );
+      const participants: ReadonlyArray<Participant> = [identity, ...otherIdentities].map((id, i) => ({
+        signature: decodeBnsAddress(identityToAddress(id)).data,
+        power: i === 0 ? 5 : 1,
+      }));
+      const tx1 = await connection.withDefaultFee<CreateMultisignatureTx>({
+        kind: "bns/create_multisignature_contract",
+        creator: identity,
+        participants: participants,
+        activationThreshold: 4,
+        adminThreshold: 5,
+      });
+      const nonce1 = await connection.getNonce({ pubkey: identity.pubkey });
+      const signed1 = await profile.signTransaction(tx1, bnsCodec, nonce1);
+      const txBytes1 = bnsCodec.bytesToPost(signed1);
+      const response1 = await connection.postTx(txBytes1);
+      const blockInfo1 = await response1.blockInfo.waitFor(info => !isBlockInfoPending(info));
+      expect(blockInfo1.state).toEqual(TransactionState.Succeeded);
+
+      await tendermintSearchIndexUpdated();
+
+      // Find transaction1
+      const searchResult1 = (await connection.searchTx({ signedBy: address })).filter(isConfirmedTransaction);
+      expect(searchResult1.length).toEqual(1);
+      const { result: contractId, transaction: firstSearchResultTransaction } = searchResult1[0];
+      if (!isCreateMultisignatureTx(firstSearchResultTransaction)) {
+        throw new Error("Unexpected transaction kind");
+      }
+      expect(firstSearchResultTransaction.participants.length).toEqual(6);
+      firstSearchResultTransaction.participants.forEach((participant, i) => {
+        expect(participant.signature).toEqual(participants[i].signature);
+        expect(participant.power).toEqual(participants[i].power);
+      });
+      expect(firstSearchResultTransaction.activationThreshold).toEqual(4);
+      expect(firstSearchResultTransaction.adminThreshold).toEqual(5);
+      expect(contractId).toBeDefined();
+
+      // Update multisignature
+      const participantsUpdated: ReadonlyArray<Participant> = (await Promise.all(
+        [15, 16, 17].map(i => profile.createIdentity(wallet.id, registryChainId, HdPaths.iov(i))),
+      )).map(id => ({
+        signature: decodeBnsAddress(identityToAddress(id)).data,
+        power: 6,
+      }));
+      const tx2 = await connection.withDefaultFee<UpdateMultisignatureTx>({
+        kind: "bns/update_multisignature_contract",
+        creator: identity,
+        contractId: contractId!,
+        participants: participantsUpdated,
+        activationThreshold: 2,
+        adminThreshold: 6,
+      });
+      const nonce2 = await connection.getNonce({ pubkey: identity.pubkey });
+      const signed2 = await profile.signTransaction(tx2, bnsCodec, nonce2);
+      const txBytes2 = bnsCodec.bytesToPost(signed2);
+      const response2 = await connection.postTx(txBytes2);
+      const blockInfo2 = await response2.blockInfo.waitFor(info => !isBlockInfoPending(info));
+      expect(blockInfo2.state).toEqual(TransactionState.Succeeded);
+
+      await tendermintSearchIndexUpdated();
+
+      // Find transaction2
+      const searchResult2 = (await connection.searchTx({ signedBy: address })).filter(isConfirmedTransaction);
+      expect(searchResult2.length).toEqual(2);
+      const { transaction: secondSearchResultTransaction } = searchResult2[1];
+      if (!isUpdateMultisignatureTx(secondSearchResultTransaction)) {
+        throw new Error("Unexpected transaction kind");
+      }
+      expect(secondSearchResultTransaction.participants.length).toEqual(3);
+      secondSearchResultTransaction.participants.forEach((participant, i) => {
+        expect(participant.signature).toEqual(participantsUpdated[i].signature);
+        expect(participant.power).toEqual(participantsUpdated[i].power);
+      });
+      expect(secondSearchResultTransaction.activationThreshold).toEqual(2);
+      expect(secondSearchResultTransaction.adminThreshold).toEqual(6);
+      expect(contractId).toBeDefined();
 
       connection.disconnect();
     });

--- a/packages/iov-bns/src/bnsconnection.spec.ts
+++ b/packages/iov-bns/src/bnsconnection.spec.ts
@@ -853,7 +853,7 @@ describe("BnsConnection", () => {
         [10, 11, 12, 13, 14].map(i => profile.createIdentity(wallet.id, registryChainId, HdPaths.iov(i))),
       );
       const participants: ReadonlyArray<Participant> = [identity, ...otherIdentities].map((id, i) => ({
-        signature: decodeBnsAddress(identityToAddress(id)).data,
+        address: identityToAddress(id),
         power: i === 0 ? 5 : 1,
       }));
       const tx1 = await connection.withDefaultFee<CreateMultisignatureTx>({
@@ -881,7 +881,7 @@ describe("BnsConnection", () => {
       }
       expect(firstSearchResultTransaction.participants.length).toEqual(6);
       firstSearchResultTransaction.participants.forEach((participant, i) => {
-        expect(participant.signature).toEqual(participants[i].signature);
+        expect(participant.address).toEqual(participants[i].address);
         expect(participant.power).toEqual(participants[i].power);
       });
       expect(firstSearchResultTransaction.activationThreshold).toEqual(4);
@@ -892,7 +892,7 @@ describe("BnsConnection", () => {
       const participantsUpdated: ReadonlyArray<Participant> = (await Promise.all(
         [15, 16, 17].map(i => profile.createIdentity(wallet.id, registryChainId, HdPaths.iov(i))),
       )).map(id => ({
-        signature: decodeBnsAddress(identityToAddress(id)).data,
+        address: identityToAddress(id),
         power: 6,
       }));
       const tx2 = await connection.withDefaultFee<UpdateMultisignatureTx>({
@@ -921,7 +921,7 @@ describe("BnsConnection", () => {
       }
       expect(secondSearchResultTransaction.participants.length).toEqual(3);
       secondSearchResultTransaction.participants.forEach((participant, i) => {
-        expect(participant.signature).toEqual(participantsUpdated[i].signature);
+        expect(participant.address).toEqual(participantsUpdated[i].address);
         expect(participant.power).toEqual(participantsUpdated[i].power);
       });
       expect(secondSearchResultTransaction.activationThreshold).toEqual(2);

--- a/packages/iov-bns/src/decode.spec.ts
+++ b/packages/iov-bns/src/decode.spec.ts
@@ -35,9 +35,12 @@ import {
   decodePrivkey,
   decodePubkey,
   isAddAddressToUsernameTx,
+  isCreateMultisignatureTx,
   isRegisterUsernameTx,
   isRemoveAddressFromUsernameTx,
+  isUpdateMultisignatureTx,
   Keyed,
+  Participant,
 } from "./types";
 
 const { fromHex, toUtf8 } = Encoding;
@@ -358,6 +361,72 @@ describe("Decode", () => {
       expect(parsed.username).toEqual("alice");
       expect(parsed.payload.chainId).toEqual("wonderland");
       expect(parsed.payload.address).toEqual("0xAABB001122DD");
+    });
+
+    it("works for CreateMultisignature", () => {
+      // tslint:disable-next-line:readonly-array
+      const participants: codecImpl.multisig.IParticipant[] = [
+        {
+          signature: fromHex("1234567890"),
+          power: 4,
+        },
+        {
+          signature: fromHex("abcdef0123"),
+          power: 1,
+        },
+        {
+          signature: fromHex("9999999999"),
+          power: 1,
+        },
+      ];
+      const transactionMessage: codecImpl.app.ITx = {
+        createContractMsg: {
+          participants: participants,
+          activationThreshold: 2,
+          adminThreshold: 3,
+        },
+      };
+      const parsed = parseMsg(defaultBaseTx, transactionMessage);
+      if (!isCreateMultisignatureTx(parsed)) {
+        throw new Error("unexpected transaction kind");
+      }
+      expect(parsed.participants).toEqual(participants as ReadonlyArray<Participant>);
+      expect(parsed.activationThreshold).toEqual(2);
+      expect(parsed.adminThreshold).toEqual(3);
+    });
+
+    it("works for UpdateMultisignature", () => {
+      // tslint:disable-next-line:readonly-array
+      const participants: codecImpl.multisig.IParticipant[] = [
+        {
+          signature: fromHex("1234567890"),
+          power: 4,
+        },
+        {
+          signature: fromHex("abcdef0123"),
+          power: 1,
+        },
+        {
+          signature: fromHex("9999999999"),
+          power: 1,
+        },
+      ];
+      const transactionMessage: codecImpl.app.ITx = {
+        updateContractMsg: {
+          contractId: fromHex("0123456789"),
+          participants: participants,
+          activationThreshold: 2,
+          adminThreshold: 3,
+        },
+      };
+      const parsed = parseMsg(defaultBaseTx, transactionMessage);
+      if (!isUpdateMultisignatureTx(parsed)) {
+        throw new Error("unexpected transaction kind");
+      }
+      expect(parsed.contractId).toEqual(fromHex("0123456789"));
+      expect(parsed.participants).toEqual(participants as ReadonlyArray<Participant>);
+      expect(parsed.activationThreshold).toEqual(2);
+      expect(parsed.adminThreshold).toEqual(3);
     });
   });
 });

--- a/packages/iov-bns/src/decode.spec.ts
+++ b/packages/iov-bns/src/decode.spec.ts
@@ -365,23 +365,37 @@ describe("Decode", () => {
 
     it("works for CreateMultisignature", () => {
       // tslint:disable-next-line:readonly-array
-      const participants: codecImpl.multisig.IParticipant[] = [
+      const iParticipants: codecImpl.multisig.IParticipant[] = [
         {
-          signature: fromHex("1234567890"),
+          signature: fromHex("1234567890123456789012345678901234567890"),
           power: 4,
         },
         {
-          signature: fromHex("abcdef0123"),
+          signature: fromHex("abcdef0123abcdef0123abcdef0123abcdef0123"),
           power: 1,
         },
         {
-          signature: fromHex("9999999999"),
+          signature: fromHex("9999999999999999999999999999999999999999"),
+          power: 1,
+        },
+      ];
+      const participants: ReadonlyArray<Participant> = [
+        {
+          address: "tiov1zg69v7yszg69v7yszg69v7yszg69v7ysy7xxgy" as Address,
+          power: 4,
+        },
+        {
+          address: "tiov140x77qfr40x77qfr40x77qfr40x77qfrj4zpp5" as Address,
+          power: 1,
+        },
+        {
+          address: "tiov1nxvenxvenxvenxvenxvenxvenxvenxverxe7mm" as Address,
           power: 1,
         },
       ];
       const transactionMessage: codecImpl.app.ITx = {
         createContractMsg: {
-          participants: participants,
+          participants: iParticipants,
           activationThreshold: 2,
           adminThreshold: 3,
         },
@@ -390,31 +404,45 @@ describe("Decode", () => {
       if (!isCreateMultisignatureTx(parsed)) {
         throw new Error("unexpected transaction kind");
       }
-      expect(parsed.participants).toEqual(participants as ReadonlyArray<Participant>);
+      expect(parsed.participants).toEqual(participants);
       expect(parsed.activationThreshold).toEqual(2);
       expect(parsed.adminThreshold).toEqual(3);
     });
 
     it("works for UpdateMultisignature", () => {
       // tslint:disable-next-line:readonly-array
-      const participants: codecImpl.multisig.IParticipant[] = [
+      const iParticipants: codecImpl.multisig.IParticipant[] = [
         {
-          signature: fromHex("1234567890"),
+          signature: fromHex("1234567890123456789012345678901234567890"),
           power: 4,
         },
         {
-          signature: fromHex("abcdef0123"),
+          signature: fromHex("abcdef0123abcdef0123abcdef0123abcdef0123"),
           power: 1,
         },
         {
-          signature: fromHex("9999999999"),
+          signature: fromHex("9999999999999999999999999999999999999999"),
+          power: 1,
+        },
+      ];
+      const participants: ReadonlyArray<Participant> = [
+        {
+          address: "tiov1zg69v7yszg69v7yszg69v7yszg69v7ysy7xxgy" as Address,
+          power: 4,
+        },
+        {
+          address: "tiov140x77qfr40x77qfr40x77qfr40x77qfrj4zpp5" as Address,
+          power: 1,
+        },
+        {
+          address: "tiov1nxvenxvenxvenxvenxvenxvenxvenxverxe7mm" as Address,
           power: 1,
         },
       ];
       const transactionMessage: codecImpl.app.ITx = {
         updateContractMsg: {
           contractId: fromHex("0123456789"),
-          participants: participants,
+          participants: iParticipants,
           activationThreshold: 2,
           adminThreshold: 3,
         },
@@ -424,7 +452,7 @@ describe("Decode", () => {
         throw new Error("unexpected transaction kind");
       }
       expect(parsed.contractId).toEqual(fromHex("0123456789"));
-      expect(parsed.participants).toEqual(participants as ReadonlyArray<Participant>);
+      expect(parsed.participants).toEqual(participants);
       expect(parsed.activationThreshold).toEqual(2);
       expect(parsed.adminThreshold).toEqual(3);
     });

--- a/packages/iov-bns/src/decode.ts
+++ b/packages/iov-bns/src/decode.ts
@@ -26,11 +26,14 @@ import {
   asIntegerNumber,
   BnsUsernameNft,
   ChainAddressPair,
+  CreateMultisignatureTx,
   decodeFullSig,
   ensure,
   Keyed,
+  Participant,
   RegisterUsernameTx,
   RemoveAddressFromUsernameTx,
+  UpdateMultisignatureTx,
 } from "./types";
 import { addressPrefix, encodeBnsAddress, hashFromIdentifier, isHashIdentifier } from "./util";
 
@@ -152,6 +155,10 @@ export function parseMsg(base: UnsignedTransaction, tx: codecImpl.app.ITx): Unsi
     return parseRegisterUsernameTx(base, tx.issueUsernameNftMsg);
   } else if (tx.removeUsernameAddressMsg) {
     return parseRemoveAddressFromUsernameTx(base, tx.removeUsernameAddressMsg);
+  } else if (tx.createContractMsg) {
+    return parseCreateMultisignatureTx(base, tx.createContractMsg);
+  } else if (tx.updateContractMsg) {
+    return parseUpdateMultisignatureTx(base, tx.updateContractMsg);
   }
   throw new Error("unknown message type in transaction");
 }
@@ -277,5 +284,46 @@ function parseRemoveAddressFromUsernameTx(
       chainId: fromUtf8(ensure(msg.blockchainId, "blockchainId")) as ChainId,
       address: ensure(msg.address, "address") as Address,
     },
+  };
+}
+
+function ensureParticipants(
+  maybe: ReadonlyArray<codecImpl.multisig.IParticipant> | null | undefined,
+): ReadonlyArray<Participant> {
+  const participants = ensure(maybe, "participants");
+  return participants.map(
+    (participant): Participant => {
+      if ([participant.power, participant.signature].some(p => p === undefined || p === null)) {
+        throw new Error("invalid participant in participants");
+      }
+      return participant as Participant;
+    },
+  );
+}
+
+function parseCreateMultisignatureTx(
+  base: UnsignedTransaction,
+  msg: codecImpl.multisig.ICreateContractMsg,
+): CreateMultisignatureTx {
+  return {
+    ...base,
+    kind: "bns/create_multisignature_contract",
+    participants: ensureParticipants(msg.participants),
+    activationThreshold: ensure(msg.activationThreshold, "activationThreshold"),
+    adminThreshold: ensure(msg.adminThreshold, "adminThreshold"),
+  };
+}
+
+function parseUpdateMultisignatureTx(
+  base: UnsignedTransaction,
+  msg: codecImpl.multisig.IUpdateContractMsg,
+): UpdateMultisignatureTx {
+  return {
+    ...base,
+    kind: "bns/update_multisignature_contract",
+    contractId: ensure(msg.contractId, "contractId"),
+    participants: ensureParticipants(msg.participants),
+    activationThreshold: ensure(msg.activationThreshold, "activationThreshold"),
+    adminThreshold: ensure(msg.adminThreshold, "adminThreshold"),
   };
 }

--- a/packages/iov-bns/src/encode.spec.ts
+++ b/packages/iov-bns/src/encode.spec.ts
@@ -303,15 +303,30 @@ describe("Encode", () => {
     it("works for CreateMultisignatureTx", () => {
       const participants: ReadonlyArray<Participant> = [
         {
-          signature: fromHex("1234567890"),
+          address: "tiov1zg69v7yszg69v7yszg69v7yszg69v7ysy7xxgy" as Address,
           power: 4,
         },
         {
-          signature: fromHex("abcdef0123"),
+          address: "tiov140x77qfr40x77qfr40x77qfr40x77qfrj4zpp5" as Address,
           power: 1,
         },
         {
-          signature: fromHex("9999999999"),
+          address: "tiov1nxvenxvenxvenxvenxvenxvenxvenxverxe7mm" as Address,
+          power: 1,
+        },
+      ];
+      // tslint:disable-next-line:readonly-array
+      const iParticipants: codecImpl.multisig.IParticipant[] = [
+        {
+          signature: fromHex("1234567890123456789012345678901234567890"),
+          power: 4,
+        },
+        {
+          signature: fromHex("abcdef0123abcdef0123abcdef0123abcdef0123"),
+          power: 1,
+        },
+        {
+          signature: fromHex("9999999999999999999999999999999999999999"),
           power: 1,
         },
       ];
@@ -323,7 +338,7 @@ describe("Encode", () => {
         adminThreshold: 3,
       };
       const msg = buildMsg(createMultisignature).createContractMsg!;
-      expect(msg.participants).toEqual(participants.map(p => p as codecImpl.multisig.IParticipant));
+      expect(msg.participants).toEqual(iParticipants);
       expect(msg.activationThreshold).toEqual(2);
       expect(msg.adminThreshold).toEqual(3);
     });
@@ -331,15 +346,30 @@ describe("Encode", () => {
     it("works for UpdateMultisignatureTx", () => {
       const participants: ReadonlyArray<Participant> = [
         {
-          signature: fromHex("1234567890"),
+          address: "tiov1zg69v7yszg69v7yszg69v7yszg69v7ysy7xxgy" as Address,
           power: 4,
         },
         {
-          signature: fromHex("abcdef0123"),
+          address: "tiov140x77qfr40x77qfr40x77qfr40x77qfrj4zpp5" as Address,
           power: 1,
         },
         {
-          signature: fromHex("9999999999"),
+          address: "tiov1nxvenxvenxvenxvenxvenxvenxvenxverxe7mm" as Address,
+          power: 1,
+        },
+      ];
+      // tslint:disable-next-line:readonly-array
+      const iParticipants: codecImpl.multisig.IParticipant[] = [
+        {
+          signature: fromHex("1234567890123456789012345678901234567890"),
+          power: 4,
+        },
+        {
+          signature: fromHex("abcdef0123abcdef0123abcdef0123abcdef0123"),
+          power: 1,
+        },
+        {
+          signature: fromHex("9999999999999999999999999999999999999999"),
           power: 1,
         },
       ];
@@ -353,7 +383,7 @@ describe("Encode", () => {
       };
       const msg = buildMsg(updateMultisignature).updateContractMsg!;
       expect(msg.contractId).toEqual(fromHex("abcdef0123"));
-      expect(msg.participants).toEqual(participants.map(p => p as codecImpl.multisig.IParticipant));
+      expect(msg.participants).toEqual(iParticipants);
       expect(msg.activationThreshold).toEqual(3);
       expect(msg.adminThreshold).toEqual(4);
     });

--- a/packages/iov-bns/src/encode.spec.ts
+++ b/packages/iov-bns/src/encode.spec.ts
@@ -24,7 +24,14 @@ import {
   encodePubkey,
 } from "./encode";
 import * as codecImpl from "./generated/codecimpl";
-import { AddAddressToUsernameTx, RegisterUsernameTx, RemoveAddressFromUsernameTx } from "./types";
+import {
+  AddAddressToUsernameTx,
+  CreateMultisignatureTx,
+  Participant,
+  RegisterUsernameTx,
+  RemoveAddressFromUsernameTx,
+  UpdateMultisignatureTx,
+} from "./types";
 import { appendSignBytes } from "./util";
 
 import {
@@ -291,6 +298,64 @@ describe("Encode", () => {
       expect(msg.usernameId).toEqual(toUtf8("alice"));
       expect(msg.blockchainId).toEqual(toUtf8("other-land"));
       expect(msg.address).toEqual("865765858O");
+    });
+
+    it("works for CreateMultisignatureTx", () => {
+      const participants: ReadonlyArray<Participant> = [
+        {
+          signature: fromHex("1234567890"),
+          power: 4,
+        },
+        {
+          signature: fromHex("abcdef0123"),
+          power: 1,
+        },
+        {
+          signature: fromHex("9999999999"),
+          power: 1,
+        },
+      ];
+      const createMultisignature: CreateMultisignatureTx = {
+        kind: "bns/create_multisignature_contract",
+        creator: defaultCreator,
+        participants: participants,
+        activationThreshold: 2,
+        adminThreshold: 3,
+      };
+      const msg = buildMsg(createMultisignature).createContractMsg!;
+      expect(msg.participants).toEqual(participants.map(p => p as codecImpl.multisig.IParticipant));
+      expect(msg.activationThreshold).toEqual(2);
+      expect(msg.adminThreshold).toEqual(3);
+    });
+
+    it("works for UpdateMultisignatureTx", () => {
+      const participants: ReadonlyArray<Participant> = [
+        {
+          signature: fromHex("1234567890"),
+          power: 4,
+        },
+        {
+          signature: fromHex("abcdef0123"),
+          power: 1,
+        },
+        {
+          signature: fromHex("9999999999"),
+          power: 1,
+        },
+      ];
+      const updateMultisignature: UpdateMultisignatureTx = {
+        kind: "bns/update_multisignature_contract",
+        creator: defaultCreator,
+        contractId: fromHex("abcdef0123"),
+        participants: participants,
+        activationThreshold: 3,
+        adminThreshold: 4,
+      };
+      const msg = buildMsg(updateMultisignature).updateContractMsg!;
+      expect(msg.contractId).toEqual(fromHex("abcdef0123"));
+      expect(msg.participants).toEqual(participants.map(p => p as codecImpl.multisig.IParticipant));
+      expect(msg.activationThreshold).toEqual(3);
+      expect(msg.adminThreshold).toEqual(4);
     });
   });
 });

--- a/packages/iov-bns/src/encode.ts
+++ b/packages/iov-bns/src/encode.ts
@@ -17,10 +17,12 @@ import { Encoding, Int53 } from "@iov/encoding";
 import * as codecImpl from "./generated/codecimpl";
 import {
   AddAddressToUsernameTx,
+  CreateMultisignatureTx,
   isBnsTx,
   PrivateKeyBundle,
   RegisterUsernameTx,
   RemoveAddressFromUsernameTx,
+  UpdateMultisignatureTx,
 } from "./types";
 import { decodeBnsAddress, hashIdentifier, identityToAddress } from "./util";
 
@@ -123,10 +125,15 @@ export function buildMsg(tx: UnsignedTransaction): codecImpl.app.ITx {
     // BNS
     case "bns/add_address_to_username":
       return buildAddAddressToUsernameTx(tx);
+    case "bns/create_multisignature_contract":
+      return buildCreateMultisignatureTx(tx);
     case "bns/register_username":
       return buildRegisterUsernameTx(tx);
     case "bns/remove_address_from_username":
       return buildRemoveAddressFromUsernameTx(tx);
+    case "bns/update_multisignature_contract":
+      return buildUpdateMultisignatureTx(tx);
+
     default:
       throw new Error("Received transaction of unsupported kind.");
   }
@@ -138,6 +145,17 @@ function buildAddAddressToUsernameTx(tx: AddAddressToUsernameTx): codecImpl.app.
       usernameId: toUtf8(tx.username),
       blockchainId: toUtf8(tx.payload.chainId),
       address: tx.payload.address,
+    },
+  };
+}
+
+function buildCreateMultisignatureTx(tx: CreateMultisignatureTx): codecImpl.app.ITx {
+  return {
+    createContractMsg: {
+      // tslint:disable-next-line:readonly-array
+      participants: tx.participants as codecImpl.multisig.IParticipant[],
+      activationThreshold: tx.activationThreshold,
+      adminThreshold: tx.adminThreshold,
     },
   };
 }
@@ -214,6 +232,18 @@ function buildRemoveAddressFromUsernameTx(tx: RemoveAddressFromUsernameTx): code
       usernameId: toUtf8(tx.username),
       blockchainId: toUtf8(tx.payload.chainId),
       address: tx.payload.address,
+    },
+  };
+}
+
+function buildUpdateMultisignatureTx(tx: UpdateMultisignatureTx): codecImpl.app.ITx {
+  return {
+    updateContractMsg: {
+      contractId: tx.contractId,
+      // tslint:disable-next-line:readonly-array
+      participants: tx.participants as codecImpl.multisig.IParticipant[],
+      activationThreshold: tx.activationThreshold,
+      adminThreshold: tx.adminThreshold,
     },
   };
 }

--- a/packages/iov-bns/src/encode.ts
+++ b/packages/iov-bns/src/encode.ts
@@ -19,6 +19,7 @@ import {
   AddAddressToUsernameTx,
   CreateMultisignatureTx,
   isBnsTx,
+  Participant,
   PrivateKeyBundle,
   RegisterUsernameTx,
   RemoveAddressFromUsernameTx,
@@ -87,6 +88,16 @@ export function encodeFullSignature(fullSignature: FullSignature): codecImpl.sig
   });
 }
 
+export function encodeParticipants(
+  participants: ReadonlyArray<Participant>,
+  // tslint:disable-next-line:readonly-array
+): codecImpl.multisig.IParticipant[] {
+  return participants.map(participant => ({
+    signature: decodeBnsAddress(participant.address).data,
+    power: participant.power,
+  }));
+}
+
 export function buildSignedTx(tx: SignedTransaction): codecImpl.app.ITx {
   const sigs: ReadonlyArray<FullSignature> = [tx.primarySignature, ...tx.otherSignatures];
   const built = buildUnsignedTx(tx.transaction);
@@ -152,8 +163,7 @@ function buildAddAddressToUsernameTx(tx: AddAddressToUsernameTx): codecImpl.app.
 function buildCreateMultisignatureTx(tx: CreateMultisignatureTx): codecImpl.app.ITx {
   return {
     createContractMsg: {
-      // tslint:disable-next-line:readonly-array
-      participants: tx.participants as codecImpl.multisig.IParticipant[],
+      participants: encodeParticipants(tx.participants),
       activationThreshold: tx.activationThreshold,
       adminThreshold: tx.adminThreshold,
     },
@@ -240,8 +250,7 @@ function buildUpdateMultisignatureTx(tx: UpdateMultisignatureTx): codecImpl.app.
   return {
     updateContractMsg: {
       contractId: tx.contractId,
-      // tslint:disable-next-line:readonly-array
-      participants: tx.participants as codecImpl.multisig.IParticipant[],
+      participants: encodeParticipants(tx.participants),
       activationThreshold: tx.activationThreshold,
       adminThreshold: tx.adminThreshold,
     },

--- a/packages/iov-bns/src/index.ts
+++ b/packages/iov-bns/src/index.ts
@@ -5,6 +5,7 @@ export { bnsSwapQueryTag } from "./tags";
 export {
   // helpers
   ChainAddressPair,
+  Participant,
   // NFTs
   BnsBlockchainNft,
   BnsBlockchainsByChainIdQuery,
@@ -17,6 +18,8 @@ export {
   // transactions
   BnsTx,
   AddAddressToUsernameTx,
+  CreateMultisignatureTx,
   RegisterUsernameTx,
   RemoveAddressFromUsernameTx,
+  UpdateMultisignatureTx,
 } from "./types";

--- a/packages/iov-bns/src/types.ts
+++ b/packages/iov-bns/src/types.ts
@@ -239,6 +239,14 @@ export interface RemoveAddressFromUsernameTx extends UnsignedTransaction {
   readonly payload: ChainAddressPair;
 }
 
+export interface UpdateMultisignatureTx extends UnsignedTransaction {
+  readonly kind: "bns/update_multisignature_contract";
+  readonly contractId: Uint8Array;
+  readonly participants: ReadonlyArray<Participant>;
+  readonly activationThreshold: number;
+  readonly adminThreshold: number;
+}
+
 export type BnsTx =
   // BCP
   | SendTransaction
@@ -249,7 +257,8 @@ export type BnsTx =
   | AddAddressToUsernameTx
   | CreateMultisignatureTx
   | RegisterUsernameTx
-  | RemoveAddressFromUsernameTx;
+  | RemoveAddressFromUsernameTx
+  | UpdateMultisignatureTx;
 
 export function isBnsTx(transaction: UnsignedTransaction): transaction is BnsTx {
   if (
@@ -284,4 +293,10 @@ export function isRemoveAddressFromUsernameTx(
   transaction: UnsignedTransaction,
 ): transaction is RemoveAddressFromUsernameTx {
   return isBnsTx(transaction) && transaction.kind === "bns/remove_address_from_username";
+}
+
+export function isUpdateMultisignatureTx(
+  transaction: UnsignedTransaction,
+): transaction is UpdateMultisignatureTx {
+  return isBnsTx(transaction) && transaction.kind === "bns/update_multisignature_contract";
 }

--- a/packages/iov-bns/src/types.ts
+++ b/packages/iov-bns/src/types.ts
@@ -215,7 +215,7 @@ export interface AddAddressToUsernameTx extends UnsignedTransaction {
 }
 
 export interface Participant {
-  readonly signature: Uint8Array;
+  readonly address: Address;
   readonly power: number;
 }
 

--- a/packages/iov-bns/src/types.ts
+++ b/packages/iov-bns/src/types.ts
@@ -214,6 +214,18 @@ export interface AddAddressToUsernameTx extends UnsignedTransaction {
   readonly payload: ChainAddressPair;
 }
 
+export interface Participant {
+  readonly signature: Uint8Array;
+  readonly power: number;
+}
+
+export interface CreateMultisignatureTx extends UnsignedTransaction {
+  readonly kind: "bns/create_multisignature_contract";
+  readonly participants: ReadonlyArray<Participant>;
+  readonly activationThreshold: number;
+  readonly adminThreshold: number;
+}
+
 export interface RegisterUsernameTx extends UnsignedTransaction {
   readonly kind: "bns/register_username";
   readonly username: string;
@@ -235,6 +247,7 @@ export type BnsTx =
   | SwapAbortTransaction
   // BNS
   | AddAddressToUsernameTx
+  | CreateMultisignatureTx
   | RegisterUsernameTx
   | RemoveAddressFromUsernameTx;
 
@@ -255,6 +268,12 @@ export function isAddAddressToUsernameTx(
   transaction: UnsignedTransaction,
 ): transaction is AddAddressToUsernameTx {
   return isBnsTx(transaction) && transaction.kind === "bns/add_address_to_username";
+}
+
+export function isCreateMultisignatureTx(
+  transaction: UnsignedTransaction,
+): transaction is CreateMultisignatureTx {
+  return isBnsTx(transaction) && transaction.kind === "bns/create_multisignature_contract";
 }
 
 export function isRegisterUsernameTx(transaction: UnsignedTransaction): transaction is RegisterUsernameTx {

--- a/packages/iov-bns/types/decode.d.ts
+++ b/packages/iov-bns/types/decode.d.ts
@@ -1,10 +1,11 @@
 import { Amount, ChainId, Nonce, SignedTransaction, Token, UnsignedTransaction } from "@iov/bcp";
 import * as codecImpl from "./generated/codecimpl";
-import { BnsUsernameNft, Keyed } from "./types";
+import { BnsUsernameNft, Keyed, Participant } from "./types";
 export declare function decodeUsernameNft(nft: codecImpl.username.IUsernameToken, registryChainId: ChainId): BnsUsernameNft;
 export declare function decodeNonce(acct: codecImpl.sigs.IUserData & Keyed): Nonce;
 export declare function decodeToken(data: codecImpl.currency.ITokenInfo & Keyed): Token;
 export declare function decodeAmount(coin: codecImpl.coin.ICoin): Amount;
 export declare function decodeJsonAmount(json: string): Amount;
+export declare function decodeParticipants(prefix: "iov" | "tiov", maybeParticipants?: codecImpl.multisig.IParticipant[] | null): ReadonlyArray<Participant>;
 export declare function parseTx(tx: codecImpl.app.ITx, chainId: ChainId): SignedTransaction;
 export declare function parseMsg(base: UnsignedTransaction, tx: codecImpl.app.ITx): UnsignedTransaction;

--- a/packages/iov-bns/types/encode.d.ts
+++ b/packages/iov-bns/types/encode.d.ts
@@ -1,10 +1,11 @@
 import { Amount, FullSignature, PublicKeyBundle, SignedTransaction, UnsignedTransaction } from "@iov/bcp";
 import * as codecImpl from "./generated/codecimpl";
-import { PrivateKeyBundle } from "./types";
+import { Participant, PrivateKeyBundle } from "./types";
 export declare function encodePubkey(publicKey: PublicKeyBundle): codecImpl.crypto.IPublicKey;
 export declare function encodePrivkey(privateKey: PrivateKeyBundle): codecImpl.crypto.IPrivateKey;
 export declare function encodeAmount(amount: Amount): codecImpl.coin.ICoin;
 export declare function encodeFullSignature(fullSignature: FullSignature): codecImpl.sigs.IStdSignature;
+export declare function encodeParticipants(participants: ReadonlyArray<Participant>): codecImpl.multisig.IParticipant[];
 export declare function buildSignedTx(tx: SignedTransaction): codecImpl.app.ITx;
 export declare function buildUnsignedTx(tx: UnsignedTransaction): codecImpl.app.ITx;
 export declare function buildMsg(tx: UnsignedTransaction): codecImpl.app.ITx;

--- a/packages/iov-bns/types/index.d.ts
+++ b/packages/iov-bns/types/index.d.ts
@@ -2,4 +2,4 @@ export { bnsCodec } from "./bnscodec";
 export { bnsConnector } from "./bnsconnector";
 export { BnsConnection } from "./bnsconnection";
 export { bnsSwapQueryTag } from "./tags";
-export { ChainAddressPair, BnsBlockchainNft, BnsBlockchainsByChainIdQuery, BnsBlockchainsQuery, BnsUsernamesByChainAndAddressQuery, BnsUsernamesByOwnerAddressQuery, BnsUsernamesByUsernameQuery, BnsUsernamesQuery, BnsUsernameNft, BnsTx, AddAddressToUsernameTx, RegisterUsernameTx, RemoveAddressFromUsernameTx, } from "./types";
+export { ChainAddressPair, Participant, BnsBlockchainNft, BnsBlockchainsByChainIdQuery, BnsBlockchainsQuery, BnsUsernamesByChainAndAddressQuery, BnsUsernamesByOwnerAddressQuery, BnsUsernamesByUsernameQuery, BnsUsernamesQuery, BnsUsernameNft, BnsTx, AddAddressToUsernameTx, CreateMultisignatureTx, RegisterUsernameTx, RemoveAddressFromUsernameTx, UpdateMultisignatureTx, } from "./types";

--- a/packages/iov-bns/types/types.d.ts
+++ b/packages/iov-bns/types/types.d.ts
@@ -103,9 +103,17 @@ export interface RemoveAddressFromUsernameTx extends UnsignedTransaction {
     readonly username: string;
     readonly payload: ChainAddressPair;
 }
-export declare type BnsTx = SendTransaction | SwapOfferTransaction | SwapClaimTransaction | SwapAbortTransaction | AddAddressToUsernameTx | CreateMultisignatureTx | RegisterUsernameTx | RemoveAddressFromUsernameTx;
+export interface UpdateMultisignatureTx extends UnsignedTransaction {
+    readonly kind: "bns/update_multisignature_contract";
+    readonly contractId: Uint8Array;
+    readonly participants: ReadonlyArray<Participant>;
+    readonly activationThreshold: number;
+    readonly adminThreshold: number;
+}
+export declare type BnsTx = SendTransaction | SwapOfferTransaction | SwapClaimTransaction | SwapAbortTransaction | AddAddressToUsernameTx | CreateMultisignatureTx | RegisterUsernameTx | RemoveAddressFromUsernameTx | UpdateMultisignatureTx;
 export declare function isBnsTx(transaction: UnsignedTransaction): transaction is BnsTx;
 export declare function isAddAddressToUsernameTx(transaction: UnsignedTransaction): transaction is AddAddressToUsernameTx;
 export declare function isCreateMultisignatureTx(transaction: UnsignedTransaction): transaction is CreateMultisignatureTx;
 export declare function isRegisterUsernameTx(transaction: UnsignedTransaction): transaction is RegisterUsernameTx;
 export declare function isRemoveAddressFromUsernameTx(transaction: UnsignedTransaction): transaction is RemoveAddressFromUsernameTx;
+export declare function isUpdateMultisignatureTx(transaction: UnsignedTransaction): transaction is UpdateMultisignatureTx;

--- a/packages/iov-bns/types/types.d.ts
+++ b/packages/iov-bns/types/types.d.ts
@@ -82,6 +82,16 @@ export interface AddAddressToUsernameTx extends UnsignedTransaction {
     readonly username: string;
     readonly payload: ChainAddressPair;
 }
+export interface Participant {
+    readonly signature: Uint8Array;
+    readonly power: number;
+}
+export interface CreateMultisignatureTx extends UnsignedTransaction {
+    readonly kind: "bns/create_multisignature_contract";
+    readonly participants: ReadonlyArray<Participant>;
+    readonly activationThreshold: number;
+    readonly adminThreshold: number;
+}
 export interface RegisterUsernameTx extends UnsignedTransaction {
     readonly kind: "bns/register_username";
     readonly username: string;
@@ -93,8 +103,9 @@ export interface RemoveAddressFromUsernameTx extends UnsignedTransaction {
     readonly username: string;
     readonly payload: ChainAddressPair;
 }
-export declare type BnsTx = SendTransaction | SwapOfferTransaction | SwapClaimTransaction | SwapAbortTransaction | AddAddressToUsernameTx | RegisterUsernameTx | RemoveAddressFromUsernameTx;
+export declare type BnsTx = SendTransaction | SwapOfferTransaction | SwapClaimTransaction | SwapAbortTransaction | AddAddressToUsernameTx | CreateMultisignatureTx | RegisterUsernameTx | RemoveAddressFromUsernameTx;
 export declare function isBnsTx(transaction: UnsignedTransaction): transaction is BnsTx;
 export declare function isAddAddressToUsernameTx(transaction: UnsignedTransaction): transaction is AddAddressToUsernameTx;
+export declare function isCreateMultisignatureTx(transaction: UnsignedTransaction): transaction is CreateMultisignatureTx;
 export declare function isRegisterUsernameTx(transaction: UnsignedTransaction): transaction is RegisterUsernameTx;
 export declare function isRemoveAddressFromUsernameTx(transaction: UnsignedTransaction): transaction is RemoveAddressFromUsernameTx;

--- a/packages/iov-bns/types/types.d.ts
+++ b/packages/iov-bns/types/types.d.ts
@@ -83,7 +83,7 @@ export interface AddAddressToUsernameTx extends UnsignedTransaction {
     readonly payload: ChainAddressPair;
 }
 export interface Participant {
-    readonly signature: Uint8Array;
+    readonly address: Address;
     readonly power: number;
 }
 export interface CreateMultisignatureTx extends UnsignedTransaction {


### PR DESCRIPTION
Closes #678 

Would be good to get some feedback before continuing. In particular, I'm unsure about the following:

1. Naming: to what extent should I be conforming to/diverging from the names in weave? Is `Contract` a term that only applies to these multisignature contracts for example?
1. Nullable values: should these be preserved in @iov/bns or should we enforce non-null values on our end? If we should enforce non-null values, should we provide defaults or throw?
1. Types: Should types from `codecImpl` be used by users of @iov/bns directly or does it make sense to export our own types? (E.g. `Participant` vs `codecImpl.multisig.IParticipant` in this PR.