### PR TITLE
Remove explicit workspaces-experimental setting

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,1 +1,0 @@
-workspaces-experimental true


### PR DESCRIPTION
> Starting Yarn 1.0 Workspaces are enabled by default and you may not need to set the below config. Refer to the updated steps at the following location https://yarnpkg.com/lang/en/docs/workspaces/

https://yarnpkg.com/blog/2017/08/02/introducing-workspaces/