### PR TITLE
Eslint rules: no-unused-vars and prefer-interface

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -32,7 +32,7 @@
     "@typescript-eslint/no-non-null-assertion": "off",
     "@typescript-eslint/no-object-literal-type-assertion": "off",
     "@typescript-eslint/no-parameter-properties": "off",
-    "@typescript-eslint/no-unused-vars": "off",
+    "@typescript-eslint/no-unused-vars": ["error", { "argsIgnorePattern": "^_", "varsIgnorePattern": "^_" }],
     "@typescript-eslint/no-use-before-define": "off",
     "@typescript-eslint/no-var-requires": "off"
   }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -34,7 +34,6 @@
     "@typescript-eslint/no-parameter-properties": "off",
     "@typescript-eslint/no-unused-vars": "off",
     "@typescript-eslint/no-use-before-define": "off",
-    "@typescript-eslint/no-var-requires": "off",
-    "@typescript-eslint/prefer-interface": "off"
+    "@typescript-eslint/no-var-requires": "off"
   }
 }

--- a/packages/iov-bns/src/bnsconnection.spec.ts
+++ b/packages/iov-bns/src/bnsconnection.spec.ts
@@ -85,7 +85,6 @@ const cash = "CASH" as TokenTicker;
 const blockTime = 1000;
 
 describe("BnsConnection", () => {
-  const defaultChain = "chain123" as ChainId;
   const defaultAmount: Amount = {
     quantity: "1000000001",
     fractionalDigits: 9,

--- a/packages/iov-bns/src/context.ts
+++ b/packages/iov-bns/src/context.ts
@@ -7,7 +7,6 @@ import {
   SwapIdBytes,
   SwapOfferTransaction,
   SwapProcessState,
-  Token,
 } from "@iov/bcp";
 
 import { decodeAmount } from "./decode";

--- a/packages/iov-dpos/webpack.web.config.js
+++ b/packages/iov-dpos/webpack.web.config.js
@@ -1,6 +1,5 @@
 const glob = require("glob");
 const path = require("path");
-const webpack = require("webpack");
 
 const target = "web";
 const distdir = path.join(__dirname, "dist", "web");

--- a/packages/iov-ethereum/src/ethereumconnection.ts
+++ b/packages/iov-ethereum/src/ethereumconnection.ts
@@ -31,7 +31,6 @@ import {
   isSwapProcessStateClaimed,
   isSwapProcessStateOpen,
   Nonce,
-  OpenSwap,
   PostableBytes,
   PostTxResponse,
   Preimage,

--- a/packages/iov-ethereum/src/integrationtests/atomicswap.spec.ts
+++ b/packages/iov-ethereum/src/integrationtests/atomicswap.spec.ts
@@ -15,7 +15,6 @@ import {
   PublicKeyBundle,
   SendTransaction,
   SwapClaimTransaction,
-  SwapIdBytes,
   SwapOfferTransaction,
   SwapProcessState,
   TokenTicker,


### PR DESCRIPTION
Partially addresses #876

I disabled rather than fixing for functions that throw a "not implemented" error.