### PR TITLE
Eslint rule: no-parameter-properties

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -31,7 +31,6 @@
     "@typescript-eslint/no-inferrable-types": "off",
     "@typescript-eslint/no-non-null-assertion": "off",
     "@typescript-eslint/no-object-literal-type-assertion": "off",
-    "@typescript-eslint/no-parameter-properties": "off",
     "@typescript-eslint/no-unused-vars": ["error", { "argsIgnorePattern": "^_", "varsIgnorePattern": "^_" }],
     "@typescript-eslint/no-use-before-define": "off",
     "@typescript-eslint/no-var-requires": "off"

--- a/packages/iov-crypto/src/libsodium.ts
+++ b/packages/iov-crypto/src/libsodium.ts
@@ -58,7 +58,13 @@ export class Ed25519Keypair {
     return new Ed25519Keypair(libsodiumPrivkey.slice(0, 32), libsodiumPrivkey.slice(32, 64));
   }
 
-  constructor(public readonly privkey: Uint8Array, public readonly pubkey: Uint8Array) {}
+  public readonly privkey: Uint8Array;
+  public readonly pubkey: Uint8Array;
+
+  constructor(privkey: Uint8Array, pubkey: Uint8Array) {
+    this.privkey = privkey;
+    this.pubkey = pubkey;
+  }
 
   public toLibsodiumPrivkey(): Uint8Array {
     return new Uint8Array([...this.privkey, ...this.pubkey]);

--- a/packages/iov-crypto/types/libsodium.d.ts
+++ b/packages/iov-crypto/types/libsodium.d.ts
@@ -15,9 +15,9 @@ export declare class Random {
     static getBytes(count: number): Promise<Uint8Array>;
 }
 export declare class Ed25519Keypair {
+    static fromLibsodiumPrivkey(libsodiumPrivkey: Uint8Array): Ed25519Keypair;
     readonly privkey: Uint8Array;
     readonly pubkey: Uint8Array;
-    static fromLibsodiumPrivkey(libsodiumPrivkey: Uint8Array): Ed25519Keypair;
     constructor(privkey: Uint8Array, pubkey: Uint8Array);
     toLibsodiumPrivkey(): Uint8Array;
 }

--- a/packages/iov-socket/src/socketwrapper.ts
+++ b/packages/iov-socket/src/socketwrapper.ts
@@ -35,19 +35,32 @@ export class SocketWrapper {
   private socket: WebSocket | undefined;
   private timeoutId: NodeJS.Timeout | undefined;
   private closed = false;
+  private readonly url: string;
+  private readonly messageHandler: (event: SocketWrapperMessageEvent) => void;
+  private readonly errorHandler: (event: SocketWrapperErrorEvent) => void;
+  private readonly openHandler?: () => void;
+  private readonly closeHandler?: (event: SocketWrapperCloseEvent) => void;
+  private readonly timeout: number;
 
   constructor(
-    private readonly url: string,
-    private readonly messageHandler: (event: SocketWrapperMessageEvent) => void,
-    private readonly errorHandler: (event: SocketWrapperErrorEvent) => void,
-    private readonly openHandler?: () => void,
-    private readonly closeHandler?: (event: SocketWrapperCloseEvent) => void,
-    private readonly timeout: number = 10_000,
+    url: string,
+    messageHandler: (event: SocketWrapperMessageEvent) => void,
+    errorHandler: (event: SocketWrapperErrorEvent) => void,
+    openHandler?: () => void,
+    closeHandler?: (event: SocketWrapperCloseEvent) => void,
+    timeout: number = 10_000,
   ) {
     this.connected = new Promise((resolve, reject) => {
       this.connectedResolver = resolve;
       this.connectedRejecter = reject;
     });
+
+    this.url = url;
+    this.messageHandler = messageHandler;
+    this.errorHandler = errorHandler;
+    this.openHandler = openHandler;
+    this.closeHandler = closeHandler;
+    this.timeout = timeout;
   }
 
   /**

--- a/packages/iov-socket/types/socketwrapper.d.ts
+++ b/packages/iov-socket/types/socketwrapper.d.ts
@@ -19,19 +19,19 @@ export interface SocketWrapperMessageEvent {
  * - handling of corner cases in the open and close behaviour
  */
 export declare class SocketWrapper {
-    private readonly url;
-    private readonly messageHandler;
-    private readonly errorHandler;
-    private readonly openHandler?;
-    private readonly closeHandler?;
-    private readonly timeout;
     readonly connected: Promise<void>;
     private connectedResolver;
     private connectedRejecter;
     private socket;
     private timeoutId;
     private closed;
-    constructor(url: string, messageHandler: (event: SocketWrapperMessageEvent) => void, errorHandler: (event: SocketWrapperErrorEvent) => void, openHandler?: (() => void) | undefined, closeHandler?: ((event: SocketWrapperCloseEvent) => void) | undefined, timeout?: number);
+    private readonly url;
+    private readonly messageHandler;
+    private readonly errorHandler;
+    private readonly openHandler?;
+    private readonly closeHandler?;
+    private readonly timeout;
+    constructor(url: string, messageHandler: (event: SocketWrapperMessageEvent) => void, errorHandler: (event: SocketWrapperErrorEvent) => void, openHandler?: () => void, closeHandler?: (event: SocketWrapperCloseEvent) => void, timeout?: number);
     /**
      * returns a promise that resolves when connection is open
      */


### PR DESCRIPTION
Merge after #1016 
Partially addresses #876
I liked the succinctness we had before but the reasoning is it’s confusing for developers new to TS, which seems like a fair point.