### PR TITLE
Run yarn format explicitly

### DIFF
--- a/packages/iov-bcp/package.json
+++ b/packages/iov-bcp/package.json
@@ -17,7 +17,6 @@
     "docs": "shx rm -rf docs && typedoc --options typedoc.js",
     "format": "prettier --write --loglevel warn \"./src/**/*.ts\"",
     "lint": "eslint --max-warnings 0 \"**/*.{js,ts}\" && tslint -t verbose --project .",
-    "prebuild": "yarn format",
     "move-types": "shx rm -r ./types/* && shx mv build/types/* ./types && shx rm ./types/*.spec.d.ts",
     "build": "shx rm -rf ./build && tsc && yarn move-types",
     "build-or-skip": "[ -n \"$SKIP_BUILD\" ] || yarn build",

--- a/packages/iov-bns/package.json
+++ b/packages/iov-bns/package.json
@@ -24,7 +24,6 @@
     "test-chrome": "yarn pack-web && karma start --single-run --browsers ChromeHeadless",
     "test-safari": "yarn pack-web && karma start --single-run --browsers Safari",
     "test": "yarn build-or-skip && yarn test-node",
-    "prebuild": "yarn format",
     "move-types": "shx rm -r ./types/* && shx mv build/types/* ./types && shx rm ./types/*.spec.d.ts",
     "build": "shx rm -rf ./build && tsc && shx mkdir -p build/generated && shx cp ./src/generated/*.js ./build/generated && shx mkdir -p ./build/types/generated && shx cp ./src/generated/*.d.ts ./build/types/generated && yarn move-types",
     "build-or-skip": "[ -n \"$SKIP_BUILD\" ] || yarn build",

--- a/packages/iov-cli/package.json
+++ b/packages/iov-cli/package.json
@@ -15,7 +15,6 @@
     "format": "prettier --write --loglevel warn \"./src/**/*.ts\"",
     "format-text": "prettier --write --prose-wrap always --print-width 80 \"./*.md\"",
     "lint": "eslint --max-warnings 0 \"**/*.{js,ts}\" && tslint -t verbose --project .",
-    "prebuild": "yarn format",
     "build": "tsc",
     "build-or-skip": "[ -n \"$SKIP_BUILD\" ] || yarn build",
     "test-node": "node jasmine-testrunner.js",

--- a/packages/iov-core/package.json
+++ b/packages/iov-core/package.json
@@ -23,7 +23,6 @@
     "test-chrome": "yarn pack-web && karma start --single-run --browsers ChromeHeadless",
     "test-safari": "yarn pack-web && karma start --single-run --browsers Safari",
     "test": "yarn build-or-skip && yarn test-node",
-    "prebuild": "yarn format",
     "move-types": "shx rm -r ./types/* && shx mv build/types/* ./types && shx rm ./types/*.spec.d.ts && shx rm ./types/**/*.spec.d.ts",
     "build": "shx rm -rf ./build && tsc && tsc -p tsconfig.workers.json && yarn move-types",
     "build-or-skip": "[ -n \"$SKIP_BUILD\" ] || yarn build",

--- a/packages/iov-crypto/package.json
+++ b/packages/iov-crypto/package.json
@@ -24,7 +24,6 @@
     "test-chrome": "yarn pack-web && karma start --single-run --browsers ChromeHeadless",
     "test-safari": "yarn pack-web && karma start --single-run --browsers Safari",
     "test": "yarn build-or-skip && yarn test-node",
-    "prebuild": "yarn format",
     "move-types": "shx rm -r ./types/* && shx mv build/types/* ./types && shx rm ./types/*.spec.d.ts",
     "build": "shx rm -rf ./build && tsc && yarn move-types",
     "build-or-skip": "[ -n \"$SKIP_BUILD\" ] || yarn build",

--- a/packages/iov-dpos/package.json
+++ b/packages/iov-dpos/package.json
@@ -17,7 +17,6 @@
     "docs": "shx rm -rf docs && typedoc --options typedoc.js",
     "format": "prettier --write --loglevel warn \"./src/**/*.ts\"",
     "lint": "eslint --max-warnings 0 \"**/*.{js,ts}\" && tslint -t verbose --project .",
-    "prebuild": "yarn format",
     "move-types": "shx rm -r ./types/* && shx mv build/types/* ./types && shx rm ./types/*.spec.d.ts",
     "build": "shx rm -rf ./build && tsc && yarn move-types",
     "build-or-skip": "[ -n \"$SKIP_BUILD\" ] || yarn build",

--- a/packages/iov-encoding/package.json
+++ b/packages/iov-encoding/package.json
@@ -23,7 +23,6 @@
     "test-chrome": "yarn pack-web && karma start --single-run --browsers ChromeHeadless",
     "test-safari": "yarn pack-web && karma start --single-run --browsers Safari",
     "test": "yarn build-or-skip && yarn test-node",
-    "prebuild": "yarn format",
     "move-types": "shx rm -r ./types/* && shx mv build/types/* ./types && shx rm ./types/*.spec.d.ts",
     "build": "shx rm -rf ./build && tsc && yarn move-types",
     "build-or-skip": "[ -n \"$SKIP_BUILD\" ] || yarn build",

--- a/packages/iov-ethereum/package.json
+++ b/packages/iov-ethereum/package.json
@@ -17,7 +17,6 @@
     "docs": "shx rm -rf docs && typedoc --options typedoc.js",
     "format": "prettier --write --loglevel warn \"./src/**/*.ts\"",
     "lint": "eslint --max-warnings 0 \"**/*.{js,ts}\" && tslint -t verbose --project .",
-    "prebuild": "yarn format",
     "move-types": "shx rm -r ./types/* && shx mv build/types/* ./types && shx rm ./types/*.spec.d.ts && shx rm ./types/**/*.spec.d.ts",
     "build": "shx rm -rf ./build && tsc && yarn move-types",
     "build-or-skip": "[ -n \"$SKIP_BUILD\" ] || yarn build",

--- a/packages/iov-faucets/package.json
+++ b/packages/iov-faucets/package.json
@@ -17,7 +17,6 @@
     "docs": "shx rm -rf docs && typedoc --options typedoc.js",
     "format": "prettier --write --loglevel warn \"./src/**/*.ts\"",
     "lint": "eslint --max-warnings 0 \"**/*.{js,ts}\" && tslint -t verbose --project .",
-    "prebuild": "yarn format",
     "move-types": "shx rm -r ./types/* && shx mv build/types/* ./types && shx rm ./types/*.spec.d.ts",
     "build": "shx rm -rf ./build && tsc && yarn move-types",
     "build-or-skip": "[ -n \"$SKIP_BUILD\" ] || yarn build",

--- a/packages/iov-jsonrpc/package.json
+++ b/packages/iov-jsonrpc/package.json
@@ -23,7 +23,6 @@
     "test-chrome": "yarn pack-web && karma start --single-run --browsers ChromeHeadless",
     "test-safari": "yarn pack-web && karma start --single-run --browsers Safari",
     "test": "yarn build-or-skip && yarn test-node",
-    "prebuild": "yarn format",
     "move-types": "shx rm -r ./types/* && shx mv build/types/* ./types && shx rm ./types/*.spec.d.ts",
     "build": "shx rm -rf ./build && tsc && tsc -p tsconfig.workers.json && yarn move-types",
     "build-or-skip": "[ -n \"$SKIP_BUILD\" ] || yarn build",

--- a/packages/iov-keycontrol/package.json
+++ b/packages/iov-keycontrol/package.json
@@ -24,7 +24,6 @@
     "test-chrome": "yarn pack-web && karma start --single-run --browsers ChromeHeadless",
     "test-safari": "yarn pack-web && karma start --single-run --browsers Safari",
     "test": "yarn build-or-skip && yarn test-node",
-    "prebuild": "yarn format",
     "move-types": "shx rm -r ./types/* && shx mv build/types/* ./types && shx rm ./types/*.spec.d.ts && shx rm ./types/**/*.spec.d.ts",
     "build": "shx rm -rf ./build && tsc && yarn move-types",
     "build-or-skip": "[ -n \"$SKIP_BUILD\" ] || yarn build",

--- a/packages/iov-lisk/package.json
+++ b/packages/iov-lisk/package.json
@@ -17,7 +17,6 @@
     "docs": "shx rm -rf docs && typedoc --options typedoc.js",
     "format": "prettier --write --loglevel warn \"./src/**/*.ts\"",
     "lint": "eslint --max-warnings 0 \"**/*.{js,ts}\" && tslint -t verbose --project .",
-    "prebuild": "yarn format",
     "move-types": "shx rm -r ./types/* && shx mv build/types/* ./types && shx rm ./types/*.spec.d.ts",
     "build": "shx rm -rf ./build && tsc && yarn move-types",
     "build-or-skip": "[ -n \"$SKIP_BUILD\" ] || yarn build",

--- a/packages/iov-rise/package.json
+++ b/packages/iov-rise/package.json
@@ -17,7 +17,6 @@
     "docs": "shx rm -rf docs && typedoc --options typedoc.js",
     "format": "prettier --write --loglevel warn \"./src/**/*.ts\"",
     "lint": "eslint --max-warnings 0 \"**/*.{js,ts}\" && tslint -t verbose --project .",
-    "prebuild": "yarn format",
     "move-types": "shx rm -r ./types/* && shx mv build/types/* ./types && shx rm ./types/*.spec.d.ts",
     "build": "shx rm -rf ./build && tsc && yarn move-types",
     "build-or-skip": "[ -n \"$SKIP_BUILD\" ] || yarn build",

--- a/packages/iov-socket/package.json
+++ b/packages/iov-socket/package.json
@@ -23,7 +23,6 @@
     "test-chrome": "yarn pack-web && karma start --single-run --browsers ChromeHeadless",
     "test-safari": "yarn pack-web && karma start --single-run --browsers Safari",
     "test": "yarn build-or-skip && yarn test-node",
-    "prebuild": "yarn format",
     "move-types": "shx rm -r ./types/* && shx mv build/types/* ./types && shx rm ./types/*.spec.d.ts",
     "build": "shx rm -rf ./build && tsc && yarn move-types",
     "build-or-skip": "[ -n \"$SKIP_BUILD\" ] || yarn build",

--- a/packages/iov-stream/package.json
+++ b/packages/iov-stream/package.json
@@ -24,7 +24,6 @@
     "test-chrome": "yarn pack-web && karma start --single-run --browsers ChromeHeadless",
     "test-safari": "yarn pack-web && karma start --single-run --browsers Safari",
     "test": "yarn build-or-skip && yarn test-node",
-    "prebuild": "yarn format",
     "move-types": "shx rm -r ./types/* && shx mv build/types/* ./types && shx rm ./types/*.spec.d.ts",
     "build": "shx rm -rf ./build && tsc && yarn move-types",
     "build-or-skip": "[ -n \"$SKIP_BUILD\" ] || yarn build",

--- a/packages/iov-tendermint-rpc/package.json
+++ b/packages/iov-tendermint-rpc/package.json
@@ -23,7 +23,6 @@
     "test-chrome": "yarn pack-web && karma start --single-run --browsers ChromeHeadless",
     "test-safari": "yarn pack-web && karma start --single-run --browsers Safari",
     "test": "yarn build-or-skip && yarn test-node",
-    "prebuild": "yarn format",
     "move-types": "shx rm -r ./types/* && shx mv build/types/* ./types && shx rm ./types/*.spec.d.ts && shx rm ./types/**/*.spec.d.ts",
     "build": "shx rm -rf ./build && tsc && yarn move-types",
     "build-or-skip": "[ -n \"$SKIP_BUILD\" ] || yarn build",

--- a/scripts/travis/mode_lint.sh
+++ b/scripts/travis/mode_lint.sh
@@ -17,3 +17,34 @@ source "$SCRIPT_DIR/_includes.sh";
 fold_start "yarn-lint"
 yarn lint
 fold_end
+
+#
+# Sanity
+#
+
+fold_start "format"
+# This in combination with check-dirty (below) ensures code formatting is up-to-date
+yarn format
+fold_end
+
+fold_start "format-text"
+# This in combination with check-dirty (below) ensures text formatting is up-to-date
+yarn format-text
+fold_end
+
+fold_start "update-npmipgnore"
+# This in combination with check-dirty (below) ensures .npmignore files are up-to-date
+./scripts/update_npmignore.sh
+fold_end
+
+fold_start "check-dirty"
+# Ensure build step didn't modify source files to avoid unprettified repository state
+SOURCE_CHANGES=$(git status --porcelain)
+if [[ -n "$SOURCE_CHANGES" ]]; then
+  echo "Error: repository contains changes."
+  echo "Showing 'git status' and 'git diff' for debugging reasons now:"
+  git status
+  git diff
+  exit 1
+fi
+fold_end


### PR DESCRIPTION
With eslint+prettier support in the IDE, it is very easy to ensure files are prettified during development. Removing the prettier step from the build makes things faster. CI will take care of the cases where someone tries to commit unprettified code.