### PR TITLE
Eslint: no-use-before-define

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -26,7 +26,7 @@
     "@typescript-eslint/no-empty-interface": "off",
     "@typescript-eslint/no-explicit-any": "off",
     "@typescript-eslint/no-unused-vars": ["warn", { "argsIgnorePattern": "^_", "varsIgnorePattern": "^_" }],
-    "@typescript-eslint/no-use-before-define": "off"
+    "@typescript-eslint/no-use-before-define": ["error", { "functions": false }]
   },
   "overrides": [
     {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -17,16 +17,16 @@
     "plugin:prettier/recommended"
   ],
   "rules": {
-    "curly": ["error", "all"],
+    "curly": ["warn", "all"],
     "no-console": ["warn", { "allow": ["error", "info", "warn"] }],
-    "no-shadow": "error",
-    "prefer-const": "error",
+    "no-shadow": "warn",
+    "prefer-const": "warn",
     "spaced-comment": ["warn", "always", { "line": { "markers": ["/ <reference"] } }],
-    "@typescript-eslint/explicit-function-return-type": ["error", { "allowExpressions": true }],
+    "@typescript-eslint/explicit-function-return-type": ["warn", { "allowExpressions": true }],
     "@typescript-eslint/no-empty-interface": "off",
     "@typescript-eslint/no-explicit-any": "off",
     "@typescript-eslint/no-unused-vars": ["warn", { "argsIgnorePattern": "^_", "varsIgnorePattern": "^_" }],
-    "@typescript-eslint/no-use-before-define": ["error", { "functions": false }]
+    "@typescript-eslint/no-use-before-define": ["warn", { "functions": false }]
   },
   "overrides": [
     {

--- a/packages/iov-bns/src/decode.ts
+++ b/packages/iov-bns/src/decode.ts
@@ -94,6 +94,9 @@ export function decodeAmount(coin: codecImpl.coin.ICoin): Amount {
   };
 }
 
+// we only allow up to 9 decimal places
+const humanCoinFormat = new RegExp(/^(\d+)(\.\d{1,9})?\s*([A-Z]{3,4})$/);
+
 export function decodeJsonAmount(json: string): Amount {
   const data = JSON.parse(json);
   if (typeof data === "string") {
@@ -115,9 +118,6 @@ export function decodeJsonAmount(json: string): Amount {
   }
   throw new Error("Impossible type for amount json");
 }
-
-// we only allow up to 9 decimal places
-const humanCoinFormat = new RegExp(/^(\d+)(\.\d{1,9})?\s*([A-Z]{3,4})$/);
 
 // adds zeros to the right as needed to ensure given length
 function rightPadZeros(short: string, length: number): string {

--- a/packages/iov-core/src/jsonrpcsigningserver.spec.ts
+++ b/packages/iov-core/src/jsonrpcsigningserver.spec.ts
@@ -20,8 +20,10 @@ import { isJsonRpcErrorResponse } from "@iov/jsonrpc";
 import { Ed25519HdWallet, HdPaths, Secp256k1HdWallet, UserProfile } from "@iov/keycontrol";
 import { firstEvent } from "@iov/stream";
 
+import { JsonRpcSigningServer } from "./jsonrpcsigningserver";
 import { MultiChainSigner } from "./multichainsigner";
 import { GetIdentitiesAuthorization, SignAndPostAuthorization, SigningServerCore } from "./signingservercore";
+import { TransactionEncoder } from "./transactionencoder";
 
 const { fromHex } = Encoding;
 
@@ -83,9 +85,6 @@ async function makeBnsEthereumSigningServer(
   const core = new SigningServerCore(profile, signer, authorizeGetIdentities, authorizeSignAndPost);
   return new JsonRpcSigningServer(core);
 }
-
-import { JsonRpcSigningServer } from "./jsonrpcsigningserver";
-import { TransactionEncoder } from "./transactionencoder";
 
 describe("JsonRpcSigningServer", () => {
   const bnsdFaucetPubkey: PublicKeyBundle = {

--- a/packages/iov-ethereum/src/ethereumconnection.spec.ts
+++ b/packages/iov-ethereum/src/ethereumconnection.spec.ts
@@ -944,6 +944,9 @@ describe("EthereumConnection", () => {
         });
 
         const recipientAddress = await randomAddress();
+        const profile = new UserProfile();
+        const wallet = profile.addWallet(Secp256k1HdWallet.fromMnemonic(testConfig.mnemonic));
+        const sender = await profile.createIdentity(wallet.id, testConfig.chainId, HdPaths.ethereum(0));
 
         // setup listener
         const transactionIds = new Set<TransactionId>();
@@ -977,10 +980,6 @@ describe("EthereumConnection", () => {
         });
 
         // send transactions
-
-        const profile = new UserProfile();
-        const wallet = profile.addWallet(Secp256k1HdWallet.fromMnemonic(testConfig.mnemonic));
-        const sender = await profile.createIdentity(wallet.id, testConfig.chainId, HdPaths.ethereum(0));
 
         const sendA: SendTransaction = {
           kind: "bcp/send",

--- a/packages/iov-tendermint-rpc/src/rpcclients/websocketclient.ts
+++ b/packages/iov-tendermint-rpc/src/rpcclients/websocketclient.ts
@@ -29,87 +29,6 @@ function toJsonRpcResponse(message: SocketWrapperMessageEvent): JsonRpcResponse 
   return jsonRpcEvent;
 }
 
-export class WebsocketClient implements RpcStreamingClient {
-  private readonly url: string;
-  private readonly socket: StreamingSocket;
-  /** Same events as in socket.events but in the format we need */
-  private readonly jsonRpcResponseStream: Stream<JsonRpcResponse>;
-
-  // Lazily create streams and use the same stream when listening to the same query twice.
-  //
-  // Creating streams is cheap since producer is not started as long as nobody listens to events. Thus this
-  // map is never cleared and there is no need to do so. But unsubscribe all the subscriptions!
-  private readonly subscriptionStreams = new Map<string, Stream<JsonRpcEvent>>();
-
-  public constructor(
-    baseUrl: string = "ws://localhost:46657",
-    onError: (err: any) => void = defaultErrorHandler,
-  ) {
-    // accept host.name:port and assume ws protocol
-    // make sure we don't end up with ...//websocket
-    const path = baseUrl.endsWith("/") ? "websocket" : "/websocket";
-    const cleanBaseUrl = hasProtocol(baseUrl) ? baseUrl : "ws://" + baseUrl;
-    this.url = cleanBaseUrl + path;
-
-    this.socket = new StreamingSocket(this.url);
-
-    const errorSubscription = this.socket.events.subscribe({
-      error: error => {
-        onError(error);
-        errorSubscription.unsubscribe();
-      },
-    });
-
-    this.jsonRpcResponseStream = this.socket.events.map(toJsonRpcResponse);
-
-    this.socket.connect();
-  }
-
-  public async execute(request: JsonRpcRequest): Promise<JsonRpcSuccess> {
-    const pendingResponse = this.responseForRequestId(request.id);
-    await this.socket.connected;
-    const pendingSend = this.socket.send(JSON.stringify(request));
-
-    const response = (await Promise.all([pendingResponse, pendingSend]))[0];
-    return throwIfError(response);
-  }
-
-  public listen(request: JsonRpcRequest): Stream<JsonRpcEvent> {
-    if (request.method !== "subscribe") {
-      throw new Error(`Request method must be "subscribe" to start event listening`);
-    }
-
-    const query = (request.params as any).query;
-    if (typeof query !== "string") {
-      throw new Error("request.params.query must be a string");
-    }
-
-    if (!this.subscriptionStreams.has(query)) {
-      const producer = new RpcEventProducer(request, this.socket);
-      const stream = Stream.create(producer);
-      this.subscriptionStreams.set(query, stream);
-    }
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    return this.subscriptionStreams.get(query)!;
-  }
-
-  /**
-   * Resolves as soon as websocket is connected. execute() queues requests automatically,
-   * so this should be required for testing purposes only.
-   */
-  public async connected(): Promise<void> {
-    return this.socket.connected;
-  }
-
-  public disconnect(): void {
-    this.socket.disconnect();
-  }
-
-  protected async responseForRequestId(id: string): Promise<JsonRpcResponse> {
-    return firstEvent(this.jsonRpcResponseStream.filter(r => r.id === id));
-  }
-}
-
 class RpcEventProducer implements Producer<JsonRpcEvent> {
   private readonly request: JsonRpcRequest;
   private readonly socket: StreamingSocket;
@@ -210,5 +129,86 @@ class RpcEventProducer implements Producer<JsonRpcEvent> {
     }
     // clear unused subscriptions
     this.subscriptions = [];
+  }
+}
+
+export class WebsocketClient implements RpcStreamingClient {
+  private readonly url: string;
+  private readonly socket: StreamingSocket;
+  /** Same events as in socket.events but in the format we need */
+  private readonly jsonRpcResponseStream: Stream<JsonRpcResponse>;
+
+  // Lazily create streams and use the same stream when listening to the same query twice.
+  //
+  // Creating streams is cheap since producer is not started as long as nobody listens to events. Thus this
+  // map is never cleared and there is no need to do so. But unsubscribe all the subscriptions!
+  private readonly subscriptionStreams = new Map<string, Stream<JsonRpcEvent>>();
+
+  public constructor(
+    baseUrl: string = "ws://localhost:46657",
+    onError: (err: any) => void = defaultErrorHandler,
+  ) {
+    // accept host.name:port and assume ws protocol
+    // make sure we don't end up with ...//websocket
+    const path = baseUrl.endsWith("/") ? "websocket" : "/websocket";
+    const cleanBaseUrl = hasProtocol(baseUrl) ? baseUrl : "ws://" + baseUrl;
+    this.url = cleanBaseUrl + path;
+
+    this.socket = new StreamingSocket(this.url);
+
+    const errorSubscription = this.socket.events.subscribe({
+      error: error => {
+        onError(error);
+        errorSubscription.unsubscribe();
+      },
+    });
+
+    this.jsonRpcResponseStream = this.socket.events.map(toJsonRpcResponse);
+
+    this.socket.connect();
+  }
+
+  public async execute(request: JsonRpcRequest): Promise<JsonRpcSuccess> {
+    const pendingResponse = this.responseForRequestId(request.id);
+    await this.socket.connected;
+    const pendingSend = this.socket.send(JSON.stringify(request));
+
+    const response = (await Promise.all([pendingResponse, pendingSend]))[0];
+    return throwIfError(response);
+  }
+
+  public listen(request: JsonRpcRequest): Stream<JsonRpcEvent> {
+    if (request.method !== "subscribe") {
+      throw new Error(`Request method must be "subscribe" to start event listening`);
+    }
+
+    const query = (request.params as any).query;
+    if (typeof query !== "string") {
+      throw new Error("request.params.query must be a string");
+    }
+
+    if (!this.subscriptionStreams.has(query)) {
+      const producer = new RpcEventProducer(request, this.socket);
+      const stream = Stream.create(producer);
+      this.subscriptionStreams.set(query, stream);
+    }
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    return this.subscriptionStreams.get(query)!;
+  }
+
+  /**
+   * Resolves as soon as websocket is connected. execute() queues requests automatically,
+   * so this should be required for testing purposes only.
+   */
+  public async connected(): Promise<void> {
+    return this.socket.connected;
+  }
+
+  public disconnect(): void {
+    this.socket.disconnect();
+  }
+
+  protected async responseForRequestId(id: string): Promise<JsonRpcResponse> {
+    return firstEvent(this.jsonRpcResponseStream.filter(r => r.id === id));
   }
 }


### PR DESCRIPTION
Partially addresses #876

Functions are hoisted, so I left them as-is (we even have circular definitions in places which require breaking the rule). Classes and `const`s aren't, so I fixed those.