### PR TITLE
Add reconnect method to QueueingStreamingSocket

### DIFF
--- a/packages/iov-socket/src/queueingstreamingsocket.spec.ts
+++ b/packages/iov-socket/src/queueingstreamingsocket.spec.ts
@@ -74,7 +74,6 @@ describe("QueueingStreamingSocket", () => {
 
       requests.forEach(request => socket.queueRequest(request));
 
-      socket.reconnect();
       socket.events.subscribe({
         next: event => {
           expect(event.data).toEqual(requests[eventsSeen++]);
@@ -85,6 +84,7 @@ describe("QueueingStreamingSocket", () => {
           }
         },
       });
+      socket.reconnect();
     });
   });
 });

--- a/packages/iov-socket/src/queueingstreamingsocket.spec.ts
+++ b/packages/iov-socket/src/queueingstreamingsocket.spec.ts
@@ -18,7 +18,7 @@ describe("QueueingStreamingSocket", () => {
     it("can queue and process requests with a connection", done => {
       pendingWithoutSocketServer();
       const socket = new QueueingStreamingSocket(socketServerUrl);
-      const requests: readonly string[] = ["request 1", "request 2", "request 3"];
+      const requests = ["request 1", "request 2", "request 3"] as const;
       let eventsSeen = 0;
       socket.events.subscribe({
         next: event => {
@@ -32,16 +32,13 @@ describe("QueueingStreamingSocket", () => {
       });
 
       socket.connect();
-      // tslint:disable-next-line:no-floating-promises
-      socket.connected.then(() => {
-        requests.forEach(request => socket.queueRequest(request));
-      });
+      requests.forEach(request => socket.queueRequest(request));
     });
 
     it("can queue requests without a connection and process them later", done => {
       pendingWithoutSocketServer();
       const socket = new QueueingStreamingSocket(socketServerUrl);
-      const requests: readonly string[] = ["request 1", "request 2", "request 3"];
+      const requests = ["request 1", "request 2", "request 3"] as const;
       let eventsSeen = 0;
       socket.events.subscribe({
         next: event => {
@@ -66,7 +63,7 @@ describe("QueueingStreamingSocket", () => {
     it("can reconnect and process remaining queue", done => {
       pendingWithoutSocketServer();
       const socket = new QueueingStreamingSocket(socketServerUrl);
-      const requests: readonly string[] = ["request 1", "request 2", "request 3"];
+      const requests = ["request 1", "request 2", "request 3"] as const;
       let eventsSeen = 0;
 
       socket.connect();

--- a/packages/iov-socket/src/queueingstreamingsocket.ts
+++ b/packages/iov-socket/src/queueingstreamingsocket.ts
@@ -9,7 +9,7 @@ import { StreamingSocket } from "./streamingsocket";
  */
 export class QueueingStreamingSocket {
   public connected: Promise<void>;
-  public events: Stream<SocketWrapperMessageEvent>;
+  public readonly events: Stream<SocketWrapperMessageEvent>;
 
   private readonly url: string;
   private readonly timeout: number;
@@ -37,7 +37,7 @@ export class QueueingStreamingSocket {
 
   public reconnect(): void {
     this.socket = new StreamingSocket(this.url, this.timeout);
-    this.events = this.socket.events;
+    this.events.imitate(this.socket.events);
     this.connected = this.socket.connected.then(() => this.processQueue());
     this.connect();
   }

--- a/packages/iov-socket/types/queueingstreamingsocket.d.ts
+++ b/packages/iov-socket/types/queueingstreamingsocket.d.ts
@@ -5,7 +5,7 @@ import { SocketWrapperMessageEvent } from "./socketwrapper";
  */
 export declare class QueueingStreamingSocket {
     connected: Promise<void>;
-    events: Stream<SocketWrapperMessageEvent>;
+    readonly events: Stream<SocketWrapperMessageEvent>;
     private readonly url;
     private readonly timeout;
     private readonly queue;

--- a/packages/iov-socket/types/queueingstreamingsocket.d.ts
+++ b/packages/iov-socket/types/queueingstreamingsocket.d.ts
@@ -4,17 +4,19 @@ import { SocketWrapperMessageEvent } from "./socketwrapper";
  * A wrapper around StreamingSocket that can queue requests.
  */
 export declare class QueueingStreamingSocket {
-    readonly connected: Promise<void>;
-    readonly events: Stream<SocketWrapperMessageEvent>;
-    private errorProducerListener;
-    private readonly socket;
+    connected: Promise<void>;
+    events: Stream<SocketWrapperMessageEvent>;
+    private readonly url;
+    private readonly timeout;
     private readonly queue;
+    private socket;
     private isProcessingQueue;
     private timeoutIndex;
     private processQueueTimeout;
     constructor(url: string, timeout?: number);
     connect(): void;
     disconnect(): void;
+    reconnect(): void;
     getQueueLength(): number;
     queueRequest(request: string): void;
     private processQueue;

--- a/packages/iov-socket/types/queueingstreamingsocket.d.ts
+++ b/packages/iov-socket/types/queueingstreamingsocket.d.ts
@@ -4,7 +4,6 @@ import { SocketWrapperMessageEvent } from "./socketwrapper";
  * A wrapper around StreamingSocket that can queue requests.
  */
 export declare class QueueingStreamingSocket {
-    connected: Promise<void>;
     readonly events: Stream<SocketWrapperMessageEvent>;
     private readonly url;
     private readonly timeout;


### PR DESCRIPTION
~WIP: Creating draft PR now to check direction.~
Part 2 of #229
~Depends on #1060~

~Main things I’m uncertain about:~
~1. Relationships between classes (also affects #1060)~
~2. Changes of accessibility/readonly status~

Note unconventional use of `.imitate` to switch the `events` stream to the new socket. From [the docs](https://github.com/staltz/xstream#-imitatetarget):

> This method exists to allow one thing: **circular dependency of streams**

which is definitely not what it's being used for here.
