### PR TITLE
Deactivate no-conditional-assignment from tslint

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -10,6 +10,7 @@
     "interface-name": [true, "never-prefix"],
     "max-classes-per-file": false,
     "no-class": false,
+    "no-conditional-assignment": false,
     "no-console": [true, "log"],
     "no-delete": true,
     "no-empty-interface": false,


### PR DESCRIPTION
eslint handles the case in a smarter way (defaults to except-parens, see https://eslint.org/docs/rules/no-cond-assign)