### PR TITLE
Implement BNS escrow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@
 - @iov/bns: Add `CreateMultisignatureTx` and `UpdateMultisignatureTx` types
   along with `Participant`.
 - @iov/bns: Add `getTx` method to `BnsConnection`.
+- @iov/bns: Add support for escrow transactions.
+- @iov/bns: Add `CreateEscrowTx`, `ReleaseEscrowTx`, `ReturnEscrowTx` and
+  `UpdateEscrowPartiesTx` types.
 - @iov/ethereum: Add `createEtherSwapId` and `createErc20SwapId` static methods.
 - @iov/ethereum: Add `SwapIdPrefix` enum.
 - @iov/ethereum: Add `Erc20TokensMap` type.

--- a/packages/iov-bns/src/types.ts
+++ b/packages/iov-bns/src/types.ts
@@ -14,6 +14,7 @@ import {
   SwapAbortTransaction,
   SwapClaimTransaction,
   SwapOfferTransaction,
+  TimestampTimeout,
 } from "@iov/bcp";
 
 // config (those are not used outside of @iov/bns)
@@ -140,6 +141,53 @@ export function isUpdateMultisignatureTx(tx: LightTransaction): tx is UpdateMult
   return tx.kind === "bns/update_multisignature_contract";
 }
 
+// Transactions: Escrows
+
+export interface CreateEscrowTx extends LightTransaction {
+  readonly kind: "bns/create_escrow";
+  readonly sender: Address;
+  readonly arbiter: Address;
+  readonly recipient: Address;
+  readonly amounts: readonly Amount[];
+  readonly timeout: TimestampTimeout;
+  readonly memo?: string;
+}
+
+export function isCreateEscrowTx(tx: LightTransaction): tx is CreateEscrowTx {
+  return tx.kind === "bns/create_escrow";
+}
+
+export interface ReleaseEscrowTx extends LightTransaction {
+  readonly kind: "bns/release_escrow";
+  readonly escrowId: Uint8Array;
+  readonly amounts: readonly Amount[];
+}
+
+export function isReleaseEscrowTx(tx: LightTransaction): tx is ReleaseEscrowTx {
+  return tx.kind === "bns/release_escrow";
+}
+
+export interface ReturnEscrowTx extends LightTransaction {
+  readonly kind: "bns/return_escrow";
+  readonly escrowId: Uint8Array;
+}
+
+export function isReturnEscrowTx(tx: LightTransaction): tx is ReturnEscrowTx {
+  return tx.kind === "bns/return_escrow";
+}
+
+export interface UpdateEscrowPartiesTx extends LightTransaction {
+  readonly kind: "bns/update_escrow_parties";
+  readonly escrowId: Uint8Array;
+  readonly sender?: Address;
+  readonly arbiter?: Address;
+  readonly recipient?: Address;
+}
+
+export function isUpdateEscrowPartiesTx(tx: LightTransaction): tx is UpdateEscrowPartiesTx {
+  return tx.kind === "bns/update_escrow_parties";
+}
+
 // Transactions: BNS
 
 export type BnsTx =
@@ -155,7 +203,12 @@ export type BnsTx =
   | RemoveAddressFromUsernameTx
   // BNS: Multisignature contracts
   | CreateMultisignatureTx
-  | UpdateMultisignatureTx;
+  | UpdateMultisignatureTx
+  // BNS: Escrows
+  | CreateEscrowTx
+  | ReleaseEscrowTx
+  | ReturnEscrowTx
+  | UpdateEscrowPartiesTx;
 
 export function isBnsTx(transaction: LightTransaction): transaction is BnsTx {
   if (

--- a/packages/iov-bns/types/types.d.ts
+++ b/packages/iov-bns/types/types.d.ts
@@ -1,5 +1,5 @@
 import { As } from "type-tagger";
-import { Address, Algorithm, Amount, ChainId, LightTransaction, SendTransaction, SwapAbortTransaction, SwapClaimTransaction, SwapOfferTransaction } from "@iov/bcp";
+import { Address, Algorithm, Amount, ChainId, LightTransaction, SendTransaction, SwapAbortTransaction, SwapClaimTransaction, SwapOfferTransaction, TimestampTimeout } from "@iov/bcp";
 export interface CashConfiguration {
     readonly minimalFee: Amount;
 }
@@ -75,5 +75,34 @@ export interface UpdateMultisignatureTx extends LightTransaction {
     readonly adminThreshold: number;
 }
 export declare function isUpdateMultisignatureTx(tx: LightTransaction): tx is UpdateMultisignatureTx;
-export declare type BnsTx = SendTransaction | SwapOfferTransaction | SwapClaimTransaction | SwapAbortTransaction | RegisterUsernameTx | AddAddressToUsernameTx | RemoveAddressFromUsernameTx | CreateMultisignatureTx | UpdateMultisignatureTx;
+export interface CreateEscrowTx extends LightTransaction {
+    readonly kind: "bns/create_escrow";
+    readonly sender: Address;
+    readonly arbiter: Address;
+    readonly recipient: Address;
+    readonly amounts: readonly Amount[];
+    readonly timeout: TimestampTimeout;
+    readonly memo?: string;
+}
+export declare function isCreateEscrowTx(tx: LightTransaction): tx is CreateEscrowTx;
+export interface ReleaseEscrowTx extends LightTransaction {
+    readonly kind: "bns/release_escrow";
+    readonly escrowId: Uint8Array;
+    readonly amounts: readonly Amount[];
+}
+export declare function isReleaseEscrowTx(tx: LightTransaction): tx is ReleaseEscrowTx;
+export interface ReturnEscrowTx extends LightTransaction {
+    readonly kind: "bns/return_escrow";
+    readonly escrowId: Uint8Array;
+}
+export declare function isReturnEscrowTx(tx: LightTransaction): tx is ReturnEscrowTx;
+export interface UpdateEscrowPartiesTx extends LightTransaction {
+    readonly kind: "bns/update_escrow_parties";
+    readonly escrowId: Uint8Array;
+    readonly sender?: Address;
+    readonly arbiter?: Address;
+    readonly recipient?: Address;
+}
+export declare function isUpdateEscrowPartiesTx(tx: LightTransaction): tx is UpdateEscrowPartiesTx;
+export declare type BnsTx = SendTransaction | SwapOfferTransaction | SwapClaimTransaction | SwapAbortTransaction | RegisterUsernameTx | AddAddressToUsernameTx | RemoveAddressFromUsernameTx | CreateMultisignatureTx | UpdateMultisignatureTx | CreateEscrowTx | ReleaseEscrowTx | ReturnEscrowTx | UpdateEscrowPartiesTx;
 export declare function isBnsTx(transaction: LightTransaction): transaction is BnsTx;


### PR DESCRIPTION
Closes #1058

I'm not 100% sure I've got the logic right here (especially with `buildUpdateEscrowPartiesTx` and amounts), but did what made most sense given the types and error messages from the node during testing.

A few naming issues surfaced:
- `CreateEscrowTx` has an `amount` field which looks singular but takes an array of amounts
- The `ITx` type from the codec has an `updateEscrowMsg` but elsewhere the same concept is referred to as `UpdateEscrowParties` rather than just `UpdateEscrow`. I opted for the more verbose option where relevant.
- I wasn't sure what the relationship between `src` when creating an escrow and `sender` when updating was (or what `src` is if not the same thing as `sender`). The documentation says "If sender is not defined, it defaults to the first signer" for `CreateEscrowMsg`, but there is not field for `sender`.