### PR TITLE
Use ReconnectingSocket in Tendermint and Ethereum

### DIFF
--- a/packages/iov-ethereum/src/ethereumconnection.spec.ts
+++ b/packages/iov-ethereum/src/ethereumconnection.spec.ts
@@ -736,7 +736,6 @@ describe("EthereumConnection", () => {
 
         const result = await connection.getTx(transactionId);
         expect(result.height).toBeGreaterThanOrEqual(2);
-        expect(result.height).toBeLessThan(100);
         expect(result.transactionId).toEqual(transactionId);
         const transaction = result.transaction;
         if (!isSendTransaction(transaction)) {

--- a/packages/iov-ethereum/src/ethereumconnection.ts
+++ b/packages/iov-ethereum/src/ethereumconnection.ts
@@ -638,7 +638,7 @@ export class EthereumConnection implements AtomicSwapConnection {
             params: [subscriptionId],
           },
           // Calling unsubscribe() and disconnect() leads to this stop callback being
-          // called after disconneting (due to the async nature of xstream's Producer
+          // called after disconnecting (due to the async nature of xstream's Producer
           // stop callbacks). Thus we may not be able to send eth_unsubscribe anymore.
           true,
         );

--- a/packages/iov-socket/src/reconnectingsocket.spec.ts
+++ b/packages/iov-socket/src/reconnectingsocket.spec.ts
@@ -80,6 +80,15 @@ describe("ReconnectingSocket", () => {
         done();
       }, 1000);
     });
+
+    it("can disconnect without waiting for open", () => {
+      pendingWithoutSocketServer();
+      const socket = new ReconnectingSocket(socketServerUrl);
+      expect(() => {
+        socket.connect();
+        socket.disconnect();
+      }).not.toThrow();
+    });
   });
 
   describe("reconnection", () => {

--- a/packages/iov-socket/src/reconnectingsocket.ts
+++ b/packages/iov-socket/src/reconnectingsocket.ts
@@ -34,12 +34,14 @@ export class ReconnectingSocket {
     this.socket = new QueueingStreamingSocket(url, timeout, reconnectedHandler);
     this.socket.events.subscribe({
       next: event => {
-        if (!this.eventProducerListener) throw new Error("No event producer listener set");
-        this.eventProducerListener.next(event);
+        if (this.eventProducerListener) {
+          this.eventProducerListener.next(event);
+        }
       },
       error: error => {
-        if (!this.eventProducerListener) throw new Error("No event producer listener set");
-        this.eventProducerListener.error(error);
+        if (this.eventProducerListener) {
+          this.eventProducerListener.error(error);
+        }
       },
     });
 

--- a/packages/iov-socket/src/reconnectingsocket.ts
+++ b/packages/iov-socket/src/reconnectingsocket.ts
@@ -47,7 +47,6 @@ export class ReconnectingSocket {
     this.connectionStatus.updates.subscribe({
       next: status => {
         if (status === ConnectionStatus.Connected) {
-          this.unconnected = false;
           this.timeoutIndex = 0;
         }
         if (status === ConnectionStatus.Disconnected) {
@@ -69,6 +68,7 @@ export class ReconnectingSocket {
       throw new Error("Cannot connect: socket has already connected");
     }
     this.socket.connect();
+    this.unconnected = false;
   }
 
   public disconnect(): void {

--- a/packages/iov-socket/src/reconnectingsocket.ts
+++ b/packages/iov-socket/src/reconnectingsocket.ts
@@ -76,8 +76,9 @@ export class ReconnectingSocket {
       throw new Error("Cannot disconnect: socket has not yet connected");
     }
     this.socket.disconnect();
-    if (!this.eventProducerListener) throw new Error("xxxNo event producer listener set");
-    this.eventProducerListener.complete();
+    if (this.eventProducerListener) {
+      this.eventProducerListener.complete();
+    }
   }
 
   public queueRequest(request: string): void {

--- a/packages/iov-socket/src/reconnectingsocket.ts
+++ b/packages/iov-socket/src/reconnectingsocket.ts
@@ -21,6 +21,7 @@ export class ReconnectingSocket {
   private readonly socket: QueueingStreamingSocket;
   private eventProducerListener: Listener<SocketWrapperMessageEvent> | undefined;
   private unconnected: boolean = true;
+  private disconnected: boolean = false;
   private timeoutIndex = 0;
   private reconnectTimeout: NodeJS.Timeout | null = null;
 
@@ -81,9 +82,13 @@ export class ReconnectingSocket {
     if (this.eventProducerListener) {
       this.eventProducerListener.complete();
     }
+    this.disconnected = true;
   }
 
   public queueRequest(request: string): void {
+    if (this.disconnected) {
+      throw new Error("Cannot queue request: socket has disconnected");
+    }
     this.socket.queueRequest(request);
   }
 }

--- a/packages/iov-socket/types/reconnectingsocket.d.ts
+++ b/packages/iov-socket/types/reconnectingsocket.d.ts
@@ -13,6 +13,7 @@ export declare class ReconnectingSocket {
     private readonly socket;
     private eventProducerListener;
     private unconnected;
+    private disconnected;
     private timeoutIndex;
     private reconnectTimeout;
     constructor(url: string, timeout?: number, reconnectedHandler?: () => void);

--- a/packages/iov-tendermint-rpc/src/rpcclients/websocketclient.spec.ts
+++ b/packages/iov-tendermint-rpc/src/rpcclients/websocketclient.spec.ts
@@ -181,7 +181,7 @@ describe("WebsocketClient", () => {
     await client
       .execute(createJsonRpcRequest(Method.Health))
       .then(() => fail("must not resolve"))
-      .catch(error => expect(error).toMatch(/is not open/i));
+      .catch(error => expect(error).toMatch(/socket has disconnected/i));
   });
 
   it("fails when listening to a disconnected client", done => {
@@ -197,14 +197,8 @@ describe("WebsocketClient", () => {
 
       const query = "tm.event='NewBlockHeader'";
       const req = createJsonRpcRequest("subscribe", { query: query });
-      client.listen(req).subscribe({
-        error: error => {
-          expect(error.toString()).toMatch(/is not open/);
-          done();
-        },
-        next: () => done.fail("No event expected"),
-        complete: () => done.fail("Must not complete"),
-      });
+      expect(() => client.listen(req).subscribe({})).toThrowError(/socket has disconnected/i);
+      done();
     })().catch(done.fail);
   });
 


### PR DESCRIPTION
Closes #229

Opening a draft PR to discuss API. In particular, the `EthereumConnection` tests call `socket.disconnect()` but currently if you do this on `ReconnectingSocket` before the connection has been successfully established you get an error. Should this be changed or should the higher-level WS clients expose a stream of connection statuses?