### PR TITLE
Fix disconnect check

### DIFF
--- a/packages/iov-tendermint-rpc/src/rpcclients/websocketclient.ts
+++ b/packages/iov-tendermint-rpc/src/rpcclients/websocketclient.ts
@@ -68,7 +68,11 @@ class RpcEventProducer implements Producer<SubscriptionEvent> {
     try {
       this.socket.queueRequest(JSON.stringify(endRequest));
     } catch (error) {
-      if (!error.match(/socket has disconnected/i)) throw error;
+      if (error instanceof Error && error.message.match(/socket has disconnected/i)) {
+        // ignore
+      } else {
+        throw error;
+      }
     }
   }
 


### PR DESCRIPTION
error has no `match` method. This could fail with

```
HeadlessChrome 75.0.3770 (Linux 0.0.0) MultiChainSigner BNS
compatibility can add two chains FAILED
	Uncaught TypeError: error.match is not a function thrown
```

See https://travis-ci.com/iov-one/iov-core/jobs/211463761