### PR TITLE
Improve import tooling

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -9,7 +9,7 @@
   "parserOptions": {
     "ecmaVersion": 2018
   },
-  "plugins": ["@typescript-eslint", "prettier"],
+  "plugins": ["@typescript-eslint", "prettier", "simple-import-sort"],
   "extends": [
     "eslint:recommended",
     "plugin:@typescript-eslint/recommended",
@@ -22,6 +22,7 @@
     "no-shadow": "warn",
     "prefer-const": "warn",
     "spaced-comment": ["warn", "always", { "line": { "markers": ["/ <reference"] } }],
+    "simple-import-sort/sort": "warn",
     "@typescript-eslint/explicit-function-return-type": ["warn", { "allowExpressions": true }],
     "@typescript-eslint/no-empty-interface": "off",
     "@typescript-eslint/no-explicit-any": "off",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "format": "lerna run format",
     "format-text": "prettier --write --prose-wrap always --print-width 80 \"./*.md\" \"./docs/**/*.md\" \"./scripts/**/*.{json,md}\" && lerna run format-text",
     "lint": "lerna run lint",
+    "lint-fix": "lerna exec 'eslint \"**/*.{js,ts}\" --fix'",
     "test": "lerna run test",
     "build": "lerna run build",
     "docs": "lerna run docs",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "eslint": "^5.16.0",
     "eslint-config-prettier": "^4.3.0",
     "eslint-plugin-prettier": "^3.1.0",
+    "eslint-plugin-simple-import-sort": "^4.0.0",
     "jasmine": "^3.3.1",
     "jasmine-spec-reporter": "^4.2.1",
     "karma": "^4.1.0",

--- a/packages/iov-bcp/src/connection.ts
+++ b/packages/iov-bcp/src/connection.ts
@@ -1,8 +1,7 @@
+import { ValueAndUpdates } from "@iov/stream";
 import { ReadonlyDate } from "readonly-date";
 import { As } from "type-tagger";
 import { Stream } from "xstream";
-
-import { ValueAndUpdates } from "@iov/stream";
 
 import { PostableBytes } from "./codec";
 import {

--- a/packages/iov-bcp/types/connection.d.ts
+++ b/packages/iov-bcp/types/connection.d.ts
@@ -1,7 +1,7 @@
+import { ValueAndUpdates } from "@iov/stream";
 import { ReadonlyDate } from "readonly-date";
 import { As } from "type-tagger";
 import { Stream } from "xstream";
-import { ValueAndUpdates } from "@iov/stream";
 import { PostableBytes } from "./codec";
 import { Address, Amount, ChainId, Fee, LightTransaction, Nonce, PubkeyBundle, SignedTransaction, TokenTicker, TransactionId, UnsignedTransaction } from "./transactions";
 export interface Account {

--- a/packages/iov-bns-governance/src/governor.spec.ts
+++ b/packages/iov-bns-governance/src/governor.spec.ts
@@ -1,10 +1,9 @@
 /* eslint-disable @typescript-eslint/camelcase */
-import { ReadonlyDate } from "readonly-date";
-
 import { Address, Algorithm, Identity, PubkeyBytes, TokenTicker } from "@iov/bcp";
 import { ActionKind, bnsCodec, BnsConnection, VoteOption } from "@iov/bns";
 import { Encoding } from "@iov/encoding";
 import { Ed25519HdWallet, HdPaths, UserProfile } from "@iov/keycontrol";
+import { ReadonlyDate } from "readonly-date";
 
 import { CommitteeId } from "./committees";
 import { Governor } from "./governor";

--- a/packages/iov-bns-governance/src/governor.ts
+++ b/packages/iov-bns-governance/src/governor.ts
@@ -1,4 +1,4 @@
-import BN = require("bn.js");
+import BN from "bn.js";
 
 import { Address, Identity, WithCreator } from "@iov/bcp";
 import {

--- a/packages/iov-bns-governance/src/governor.ts
+++ b/packages/iov-bns-governance/src/governor.ts
@@ -1,5 +1,3 @@
-import BN from "bn.js";
-
 import { Address, Identity, WithCreator } from "@iov/bcp";
 import {
   ActionKind,
@@ -14,6 +12,7 @@ import {
   VoteTx,
 } from "@iov/bns";
 import { Encoding } from "@iov/encoding";
+import BN from "bn.js";
 
 import { ProposalOptions, ProposalType } from "./proposals";
 import { groupByCallback, maxWithComparatorCallback } from "./utils";

--- a/packages/iov-bns-governance/src/proposals.ts
+++ b/packages/iov-bns-governance/src/proposals.ts
@@ -1,7 +1,6 @@
-import { ReadonlyDate } from "readonly-date";
-
 import { Address, Amount, PubkeyBundle } from "@iov/bcp";
 import { Fraction } from "@iov/bns";
+import { ReadonlyDate } from "readonly-date";
 
 import { CommitteeId } from "./committees";
 

--- a/packages/iov-bns-governance/types/proposals.d.ts
+++ b/packages/iov-bns-governance/types/proposals.d.ts
@@ -1,6 +1,6 @@
-import { ReadonlyDate } from "readonly-date";
 import { Address, Amount, PubkeyBundle } from "@iov/bcp";
 import { Fraction } from "@iov/bns";
+import { ReadonlyDate } from "readonly-date";
 import { CommitteeId } from "./committees";
 export declare enum ProposalType {
     AddCommitteeMember = 0,

--- a/packages/iov-bns/src/bnsconnection.spec.ts
+++ b/packages/iov-bns/src/bnsconnection.spec.ts
@@ -1,4 +1,4 @@
-import BN = require("bn.js");
+import BN from "bn.js";
 import Long from "long";
 
 import {

--- a/packages/iov-bns/src/bnsconnection.spec.ts
+++ b/packages/iov-bns/src/bnsconnection.spec.ts
@@ -1,6 +1,3 @@
-import BN from "bn.js";
-import Long from "long";
-
 import {
   Account,
   Address,
@@ -46,6 +43,8 @@ import { Ed25519, Random, Sha512 } from "@iov/crypto";
 import { Encoding, Uint64 } from "@iov/encoding";
 import { Ed25519HdWallet, HdPaths, UserProfile, WalletId } from "@iov/keycontrol";
 import { asArray, firstEvent, lastValue, toListPromise } from "@iov/stream";
+import BN from "bn.js";
+import Long from "long";
 
 import { bnsCodec } from "./bnscodec";
 import { BnsConnection } from "./bnsconnection";

--- a/packages/iov-bns/src/bnsconnection.ts
+++ b/packages/iov-bns/src/bnsconnection.ts
@@ -1,6 +1,3 @@
-import equal from "fast-deep-equal";
-import { Stream, Subscription } from "xstream";
-
 import {
   Account,
   AccountQuery,
@@ -49,6 +46,8 @@ import {
 import { Encoding, Uint53 } from "@iov/encoding";
 import { concat, DefaultValueProducer, dropDuplicates, fromListPromise, ValueAndUpdates } from "@iov/stream";
 import { broadcastTxSyncSuccess, Client as TendermintClient } from "@iov/tendermint-rpc";
+import equal from "fast-deep-equal";
+import { Stream, Subscription } from "xstream";
 
 import { bnsCodec } from "./bnscodec";
 import { ChainData, Context } from "./context";

--- a/packages/iov-bns/src/decode.ts
+++ b/packages/iov-bns/src/decode.ts
@@ -1,4 +1,4 @@
-import BN = require("bn.js");
+import BN from "bn.js";
 import * as Long from "long";
 
 import {

--- a/packages/iov-bns/src/decode.ts
+++ b/packages/iov-bns/src/decode.ts
@@ -1,6 +1,3 @@
-import BN from "bn.js";
-import * as Long from "long";
-
 import {
   Address,
   Algorithm,
@@ -25,6 +22,8 @@ import {
   WithCreator,
 } from "@iov/bcp";
 import { Encoding } from "@iov/encoding";
+import BN from "bn.js";
+import * as Long from "long";
 
 import * as codecImpl from "./generated/codecimpl";
 import {

--- a/packages/iov-bns/src/encode.spec.ts
+++ b/packages/iov-bns/src/encode.spec.ts
@@ -1,5 +1,3 @@
-import Long from "long";
-
 import {
   Address,
   Algorithm,
@@ -18,6 +16,7 @@ import {
 } from "@iov/bcp";
 import { Ed25519, Ed25519Keypair, Sha512 } from "@iov/crypto";
 import { Encoding } from "@iov/encoding";
+import Long from "long";
 
 import {
   buildMsg,
@@ -29,6 +28,20 @@ import {
   encodePubkey,
 } from "./encode";
 import * as codecImpl from "./generated/codecimpl";
+import {
+  coinBin,
+  coinJson,
+  privBin,
+  privJson,
+  pubBin,
+  pubJson,
+  sendTxBin,
+  sendTxJson,
+  sendTxSignBytes,
+  signedTxBin,
+  signedTxJson,
+  signedTxSig,
+} from "./testdata.spec";
 import {
   ActionKind,
   CreateEscrowTx,
@@ -46,21 +59,6 @@ import {
   VoteTx,
 } from "./types";
 import { appendSignBytes } from "./util";
-
-import {
-  coinBin,
-  coinJson,
-  privBin,
-  privJson,
-  pubBin,
-  pubJson,
-  sendTxBin,
-  sendTxJson,
-  sendTxSignBytes,
-  signedTxBin,
-  signedTxJson,
-  signedTxSig,
-} from "./testdata.spec";
 
 const { fromHex, toAscii, toUtf8 } = Encoding;
 

--- a/packages/iov-bns/src/encode.ts
+++ b/packages/iov-bns/src/encode.ts
@@ -1,4 +1,4 @@
-import BN = require("bn.js");
+import BN from "bn.js";
 
 import {
   Address,

--- a/packages/iov-bns/src/encode.ts
+++ b/packages/iov-bns/src/encode.ts
@@ -1,5 +1,3 @@
-import BN from "bn.js";
-
 import {
   Address,
   Algorithm,
@@ -17,6 +15,7 @@ import {
   WithCreator,
 } from "@iov/bcp";
 import { Encoding, Int53 } from "@iov/encoding";
+import BN from "bn.js";
 
 import * as codecImpl from "./generated/codecimpl";
 import {

--- a/packages/iov-bns/src/integrationtests/atomicswapbnsbns.spec.ts
+++ b/packages/iov-bns/src/integrationtests/atomicswapbnsbns.spec.ts
@@ -1,4 +1,4 @@
-import BN = require("bn.js");
+import BN from "bn.js";
 
 import {
   Address,

--- a/packages/iov-bns/src/integrationtests/atomicswapbnsbns.spec.ts
+++ b/packages/iov-bns/src/integrationtests/atomicswapbnsbns.spec.ts
@@ -1,5 +1,3 @@
-import BN from "bn.js";
-
 import {
   Address,
   Amount,
@@ -25,6 +23,7 @@ import {
 } from "@iov/bcp";
 import { Slip10RawIndex } from "@iov/crypto";
 import { Ed25519HdWallet, HdPaths, UserProfile } from "@iov/keycontrol";
+import BN from "bn.js";
 
 import { bnsCodec } from "../bnscodec";
 import { BnsConnection } from "../bnsconnection";

--- a/packages/iov-bns/src/types.ts
+++ b/packages/iov-bns/src/types.ts
@@ -1,5 +1,3 @@
-import { As } from "type-tagger";
-
 import {
   Address,
   Algorithm,
@@ -17,6 +15,7 @@ import {
   SwapOfferTransaction,
   TimestampTimeout,
 } from "@iov/bcp";
+import { As } from "type-tagger";
 
 // config (those are not used outside of @iov/bns)
 

--- a/packages/iov-bns/src/util.ts
+++ b/packages/iov-bns/src/util.ts
@@ -1,6 +1,3 @@
-import Long from "long";
-import { As } from "type-tagger";
-
 import {
   Address,
   Algorithm,
@@ -26,6 +23,8 @@ import {
 import { Sha256 } from "@iov/crypto";
 import { Bech32, Encoding } from "@iov/encoding";
 import { QueryString } from "@iov/tendermint-rpc";
+import Long from "long";
+import { As } from "type-tagger";
 
 const bnsMainnetChainId = "PLEASE_INSERT_HERE_WHEN_GENESIS_EXISTS" as ChainId;
 

--- a/packages/iov-bns/types/bnsconnection.d.ts
+++ b/packages/iov-bns/types/bnsconnection.d.ts
@@ -1,5 +1,5 @@
-import { Stream } from "xstream";
 import { Account, AccountQuery, AddressQuery, Amount, AtomicSwap, AtomicSwapConnection, AtomicSwapQuery, BlockHeader, ChainId, ConfirmedTransaction, FailedTransaction, Fee, LightTransaction, Nonce, PostableBytes, PostTxResponse, PubkeyQuery, Token, TokenTicker, TransactionId, TransactionQuery, UnsignedTransaction } from "@iov/bcp";
+import { Stream } from "xstream";
 import { BnsUsernameNft, BnsUsernamesQuery, ElectionRule, Electorate, Proposal, Result, Validator } from "./types";
 export interface QueryResponse {
     readonly height?: number;

--- a/packages/iov-bns/types/decode.d.ts
+++ b/packages/iov-bns/types/decode.d.ts
@@ -1,5 +1,5 @@
-import * as Long from "long";
 import { Amount, ChainId, FullSignature, Nonce, PubkeyBundle, SignatureBytes, SignedTransaction, Token, UnsignedTransaction } from "@iov/bcp";
+import * as Long from "long";
 import * as codecImpl from "./generated/codecimpl";
 import { BnsUsernameNft, CashConfiguration, ElectionRule, Electorate, Keyed, Participant, PrivkeyBundle, Proposal } from "./types";
 /**

--- a/packages/iov-bns/types/types.d.ts
+++ b/packages/iov-bns/types/types.d.ts
@@ -1,5 +1,5 @@
-import { As } from "type-tagger";
 import { Address, Algorithm, Amount, ChainId, LightTransaction, PubkeyBundle, SendTransaction, SwapAbortTransaction, SwapClaimTransaction, SwapOfferTransaction, TimestampTimeout } from "@iov/bcp";
+import { As } from "type-tagger";
 export interface CashConfiguration {
     readonly minimalFee: Amount;
 }

--- a/packages/iov-bns/types/util.d.ts
+++ b/packages/iov-bns/types/util.d.ts
@@ -1,6 +1,6 @@
-import { As } from "type-tagger";
 import { Address, ChainId, ConfirmedTransaction, Hash, Identity, Nonce, SignableBytes, SwapAbortTransaction, SwapClaimTransaction, SwapData, SwapOfferTransaction, TransactionQuery, UnsignedTransaction, WithCreator } from "@iov/bcp";
 import { QueryString } from "@iov/tendermint-rpc";
+import { As } from "type-tagger";
 export declare function addressPrefix(chainId: ChainId): "iov" | "tiov";
 /** Encodes raw bytes into a bech32 address */
 export declare function encodeBnsAddress(prefix: "iov" | "tiov", bytes: Uint8Array): Address;

--- a/packages/iov-cli/src/tsrepl.ts
+++ b/packages/iov-cli/src/tsrepl.ts
@@ -1,7 +1,7 @@
 import { diffLines } from "diff";
 import { join } from "path";
 import { Recoverable, REPLServer, start } from "repl";
-import { register, Register, TSError } from "ts-node";
+import { Register, register, TSError } from "ts-node";
 import { Context, createContext } from "vm";
 
 import { executeJavaScriptAsync, isRecoverable } from "./helpers";

--- a/packages/iov-core/src/integrationtests/atomicswapbnseth.spec.ts
+++ b/packages/iov-core/src/integrationtests/atomicswapbnseth.spec.ts
@@ -1,4 +1,4 @@
-import BN = require("bn.js");
+import BN from "bn.js";
 
 import {
   Address,

--- a/packages/iov-core/src/integrationtests/atomicswapbnseth.spec.ts
+++ b/packages/iov-core/src/integrationtests/atomicswapbnseth.spec.ts
@@ -1,5 +1,3 @@
-import BN from "bn.js";
-
 import {
   Address,
   Amount,
@@ -26,6 +24,7 @@ import { bnsConnector } from "@iov/bns";
 import { Slip10RawIndex } from "@iov/crypto";
 import { Erc20ApproveTransaction, EthereumConnection, ethereumConnector } from "@iov/ethereum";
 import { Ed25519HdWallet, HdPaths, Secp256k1HdWallet, UserProfile } from "@iov/keycontrol";
+import BN from "bn.js";
 
 import { MultiChainSigner } from "../multichainsigner";
 

--- a/packages/iov-core/src/signingservice.spec.ts
+++ b/packages/iov-core/src/signingservice.spec.ts
@@ -1,7 +1,5 @@
 /// <reference lib="dom" />
 
-import { Producer, Stream } from "xstream";
-
 import {
   Address,
   Algorithm,
@@ -28,6 +26,7 @@ import {
   SimpleMessagingConnection,
 } from "@iov/jsonrpc";
 import { firstEvent } from "@iov/stream";
+import { Producer, Stream } from "xstream";
 
 import { TransactionEncoder } from "./transactionencoder";
 

--- a/packages/iov-crypto/src/bip39.spec.ts
+++ b/packages/iov-crypto/src/bip39.spec.ts
@@ -2,7 +2,6 @@ import { Encoding } from "@iov/encoding";
 
 import { Bip39 } from "./bip39";
 import { EnglishMnemonic } from "./englishmnemonic";
-
 import bip39Vectors from "./testdata/bip39.json";
 
 const fromHex = Encoding.fromHex;

--- a/packages/iov-crypto/src/bip39.ts
+++ b/packages/iov-crypto/src/bip39.ts
@@ -1,8 +1,7 @@
+import { Encoding } from "@iov/encoding";
 import * as bip39 from "bip39";
 import { pbkdf2 } from "pbkdf2";
 import * as unorm from "unorm";
-
-import { Encoding } from "@iov/encoding";
 
 import { EnglishMnemonic } from "./englishmnemonic";
 

--- a/packages/iov-crypto/src/keccak.ts
+++ b/packages/iov-crypto/src/keccak.ts
@@ -1,4 +1,5 @@
 import jssha3 from "js-sha3";
+
 import { HashFunction } from "./sha";
 
 export class Keccak256 implements HashFunction {

--- a/packages/iov-crypto/src/libsodium.ts
+++ b/packages/iov-crypto/src/libsodium.ts
@@ -3,8 +3,6 @@
 //
 // libsodium.js API: https://gist.github.com/webmaster128/b2dbe6d54d36dd168c9fabf441b9b09c
 
-// use require instead of import because of this bug
-// https://github.com/jedisct1/libsodium.js/issues/148
 import sodium from "libsodium-wrappers";
 import { As } from "type-tagger";
 

--- a/packages/iov-crypto/src/libsodium.ts
+++ b/packages/iov-crypto/src/libsodium.ts
@@ -5,7 +5,7 @@
 
 // use require instead of import because of this bug
 // https://github.com/jedisct1/libsodium.js/issues/148
-import sodium = require("libsodium-wrappers");
+import sodium from "libsodium-wrappers";
 import { As } from "type-tagger";
 
 export type Xchacha20poly1305IetfKey = Uint8Array & As<"xchacha20poly1305ietf-key">;

--- a/packages/iov-crypto/src/secp256k1.ts
+++ b/packages/iov-crypto/src/secp256k1.ts
@@ -1,5 +1,5 @@
 import BN from "bn.js";
-import elliptic = require("elliptic");
+import elliptic from "elliptic";
 import { As } from "type-tagger";
 
 import { Encoding } from "@iov/encoding";

--- a/packages/iov-crypto/src/secp256k1.ts
+++ b/packages/iov-crypto/src/secp256k1.ts
@@ -1,4 +1,4 @@
-import BN = require("bn.js");
+import BN from "bn.js";
 import elliptic = require("elliptic");
 import { As } from "type-tagger";
 

--- a/packages/iov-crypto/src/secp256k1.ts
+++ b/packages/iov-crypto/src/secp256k1.ts
@@ -1,8 +1,7 @@
+import { Encoding } from "@iov/encoding";
 import BN from "bn.js";
 import elliptic from "elliptic";
 import { As } from "type-tagger";
-
-import { Encoding } from "@iov/encoding";
 
 import { ExtendedSecp256k1Signature, Secp256k1Signature } from "./secp256k1signature";
 

--- a/packages/iov-crypto/src/slip10.ts
+++ b/packages/iov-crypto/src/slip10.ts
@@ -1,7 +1,6 @@
+import { Encoding, Uint32 } from "@iov/encoding";
 import BN from "bn.js";
 import elliptic from "elliptic";
-
-import { Encoding, Uint32 } from "@iov/encoding";
 
 import { Hmac } from "./hmac";
 import { Sha512 } from "./sha";

--- a/packages/iov-crypto/src/slip10.ts
+++ b/packages/iov-crypto/src/slip10.ts
@@ -1,4 +1,4 @@
-import BN = require("bn.js");
+import BN from "bn.js";
 import elliptic = require("elliptic");
 
 import { Encoding, Uint32 } from "@iov/encoding";

--- a/packages/iov-crypto/src/slip10.ts
+++ b/packages/iov-crypto/src/slip10.ts
@@ -1,5 +1,5 @@
 import BN from "bn.js";
-import elliptic = require("elliptic");
+import elliptic from "elliptic";
 
 import { Encoding, Uint32 } from "@iov/encoding";
 

--- a/packages/iov-dpos/src/derivation.ts
+++ b/packages/iov-dpos/src/derivation.ts
@@ -1,8 +1,7 @@
-import Long from "long";
-
 import { Address } from "@iov/bcp";
 import { Ed25519, Ed25519Keypair, Sha256 } from "@iov/crypto";
 import { Encoding } from "@iov/encoding";
+import Long from "long";
 
 export class Derivation {
   public static isValidAddressWithEnding(address: string, ending: string): boolean {

--- a/packages/iov-dpos/src/parse.spec.ts
+++ b/packages/iov-dpos/src/parse.spec.ts
@@ -1,6 +1,5 @@
-import { ReadonlyDate } from "readonly-date";
-
 import { Nonce } from "@iov/bcp";
+import { ReadonlyDate } from "readonly-date";
 
 import { Parse } from "./parse";
 

--- a/packages/iov-dpos/src/parse.ts
+++ b/packages/iov-dpos/src/parse.ts
@@ -1,7 +1,6 @@
-import { ReadonlyDate } from "readonly-date";
-
 import { Nonce } from "@iov/bcp";
 import { Uint64 } from "@iov/encoding";
+import { ReadonlyDate } from "readonly-date";
 
 export class Parse {
   /** validates string to be a non-negative integer and cuts leading zeros */

--- a/packages/iov-dpos/src/serialization.spec.ts
+++ b/packages/iov-dpos/src/serialization.spec.ts
@@ -1,5 +1,3 @@
-import { ReadonlyDate } from "readonly-date";
-
 import {
   Address,
   Algorithm,
@@ -13,6 +11,7 @@ import {
   WithCreator,
 } from "@iov/bcp";
 import { Encoding } from "@iov/encoding";
+import { ReadonlyDate } from "readonly-date";
 
 import { Serialization, TransactionSerializationOptions } from "./serialization";
 

--- a/packages/iov-dpos/src/serialization.ts
+++ b/packages/iov-dpos/src/serialization.ts
@@ -1,10 +1,9 @@
 // tslint:disable:no-bitwise
-import Long from "long";
-import { ReadonlyDate } from "readonly-date";
-
 import { FullSignature, isSendTransaction, TransactionId, UnsignedTransaction } from "@iov/bcp";
 import { Sha256 } from "@iov/crypto";
 import { Encoding, Uint64 } from "@iov/encoding";
+import Long from "long";
+import { ReadonlyDate } from "readonly-date";
 
 import { Derivation } from "./derivation";
 

--- a/packages/iov-dpos/types/parse.d.ts
+++ b/packages/iov-dpos/types/parse.d.ts
@@ -1,5 +1,5 @@
-import { ReadonlyDate } from "readonly-date";
 import { Nonce } from "@iov/bcp";
+import { ReadonlyDate } from "readonly-date";
 export declare class Parse {
     /** validates string to be a non-negative integer and cuts leading zeros */
     static parseQuantity(quantity: string): string;

--- a/packages/iov-dpos/types/serialization.d.ts
+++ b/packages/iov-dpos/types/serialization.d.ts
@@ -1,5 +1,5 @@
-import { ReadonlyDate } from "readonly-date";
 import { FullSignature, TransactionId, UnsignedTransaction } from "@iov/bcp";
+import { ReadonlyDate } from "readonly-date";
 export interface TransactionSerializationOptions {
     readonly maxMemoLength: number;
 }

--- a/packages/iov-encoding/src/integers.ts
+++ b/packages/iov-encoding/src/integers.ts
@@ -1,5 +1,5 @@
 /* tslint:disable:no-bitwise */
-import BN = require("bn.js");
+import BN from "bn.js";
 
 const uint64MaxValue = new BN("18446744073709551615", 10, "be");
 

--- a/packages/iov-ethereum/src/abi.ts
+++ b/packages/iov-ethereum/src/abi.ts
@@ -1,8 +1,7 @@
-import BN from "bn.js";
-
 import { Address, SwapProcessState } from "@iov/bcp";
 import { Keccak256 } from "@iov/crypto";
 import { Encoding } from "@iov/encoding";
+import BN from "bn.js";
 
 import { isValidAddress, toChecksummedAddress } from "./address";
 

--- a/packages/iov-ethereum/src/encoding.ts
+++ b/packages/iov-ethereum/src/encoding.ts
@@ -1,6 +1,5 @@
-import * as rlp from "rlp";
-
 import { Int53 } from "@iov/encoding";
+import * as rlp from "rlp";
 
 /**
  * Encode as RLP (Recursive Length Prefix)

--- a/packages/iov-ethereum/src/erc20reader.spec.ts
+++ b/packages/iov-ethereum/src/erc20reader.spec.ts
@@ -1,4 +1,4 @@
-import BN = require("bn.js");
+import BN from "bn.js";
 
 import { Address, Algorithm, PubkeyBytes } from "@iov/bcp";
 import { Random, Secp256k1 } from "@iov/crypto";

--- a/packages/iov-ethereum/src/erc20reader.spec.ts
+++ b/packages/iov-ethereum/src/erc20reader.spec.ts
@@ -1,9 +1,8 @@
-import BN from "bn.js";
-
 import { Address, Algorithm, PubkeyBytes } from "@iov/bcp";
 import { Random, Secp256k1 } from "@iov/crypto";
 import { Encoding } from "@iov/encoding";
 import { isJsonRpcErrorResponse } from "@iov/jsonrpc";
+import BN from "bn.js";
 
 import { pubkeyToAddress } from "./address";
 import { Erc20Options } from "./erc20";

--- a/packages/iov-ethereum/src/erc20reader.ts
+++ b/packages/iov-ethereum/src/erc20reader.ts
@@ -1,5 +1,5 @@
 // Make sure this file is not importet from index.d.ts to avoid a dependency on @types/bn.js
-import BN = require("bn.js");
+import BN from "bn.js";
 
 import { Address } from "@iov/bcp";
 import { Encoding } from "@iov/encoding";

--- a/packages/iov-ethereum/src/erc20reader.ts
+++ b/packages/iov-ethereum/src/erc20reader.ts
@@ -1,8 +1,7 @@
 // Make sure this file is not importet from index.d.ts to avoid a dependency on @types/bn.js
-import BN from "bn.js";
-
 import { Address } from "@iov/bcp";
 import { Encoding } from "@iov/encoding";
+import BN from "bn.js";
 
 import { Abi } from "./abi";
 import { Erc20Options } from "./erc20";

--- a/packages/iov-ethereum/src/ethereumcodec.ts
+++ b/packages/iov-ethereum/src/ethereumcodec.ts
@@ -1,5 +1,3 @@
-import BN from "bn.js";
-
 import {
   Address,
   Algorithm,
@@ -30,6 +28,7 @@ import {
 } from "@iov/bcp";
 import { ExtendedSecp256k1Signature, Keccak256, Secp256k1 } from "@iov/crypto";
 import { Encoding } from "@iov/encoding";
+import BN from "bn.js";
 
 import { Abi, SwapContractMethod } from "./abi";
 import { isValidAddress, pubkeyToAddress, toChecksummedAddress } from "./address";

--- a/packages/iov-ethereum/src/ethereumconnection.ts
+++ b/packages/iov-ethereum/src/ethereumconnection.ts
@@ -1,9 +1,3 @@
-import axios from "axios";
-import BN from "bn.js";
-import equal from "fast-deep-equal";
-import { ReadonlyDate } from "readonly-date";
-import { Producer, Stream, Subscription } from "xstream";
-
 import {
   Account,
   AccountQuery,
@@ -52,6 +46,11 @@ import { Random } from "@iov/crypto";
 import { Encoding, Uint53 } from "@iov/encoding";
 import { isJsonRpcErrorResponse, makeJsonRpcId } from "@iov/jsonrpc";
 import { concat, DefaultValueProducer, dropDuplicates, ValueAndUpdates } from "@iov/stream";
+import axios from "axios";
+import BN from "bn.js";
+import equal from "fast-deep-equal";
+import { ReadonlyDate } from "readonly-date";
+import { Producer, Stream, Subscription } from "xstream";
 
 import { Abi, SwapContractEvent } from "./abi";
 import { pubkeyToAddress } from "./address";

--- a/packages/iov-ethereum/src/ethereumrpcclient.ts
+++ b/packages/iov-ethereum/src/ethereumrpcclient.ts
@@ -1,7 +1,6 @@
-import { Stream } from "xstream";
-
 import { JsonRpcRequest, JsonRpcResponse } from "@iov/jsonrpc";
 import { SocketWrapperMessageEvent } from "@iov/socket";
+import { Stream } from "xstream";
 
 export interface EthereumRpcClient {
   readonly events: Stream<SocketWrapperMessageEvent>;

--- a/packages/iov-ethereum/src/httpethereumrpcclient.ts
+++ b/packages/iov-ethereum/src/httpethereumrpcclient.ts
@@ -1,7 +1,6 @@
+import { JsonRpcRequest, JsonRpcResponse, parseJsonRpcResponse2 } from "@iov/jsonrpc";
 import axios from "axios";
 import xstream from "xstream";
-
-import { JsonRpcRequest, JsonRpcResponse, parseJsonRpcResponse2 } from "@iov/jsonrpc";
 
 import { EthereumRpcClient } from "./ethereumrpcclient";
 

--- a/packages/iov-ethereum/src/integrationtests/atomicswap.spec.ts
+++ b/packages/iov-ethereum/src/integrationtests/atomicswap.spec.ts
@@ -1,5 +1,3 @@
-import BN from "bn.js";
-
 import {
   Address,
   Amount,
@@ -24,6 +22,7 @@ import {
   WithCreator,
 } from "@iov/bcp";
 import { HdPaths, Secp256k1HdWallet, UserProfile } from "@iov/keycontrol";
+import BN from "bn.js";
 
 import { Erc20ApproveTransaction } from "../erc20";
 import { EthereumCodec } from "../ethereumcodec";

--- a/packages/iov-ethereum/src/serialization.ts
+++ b/packages/iov-ethereum/src/serialization.ts
@@ -1,5 +1,3 @@
-import BN from "bn.js";
-
 import {
   Address,
   BlockHeightTimeout,
@@ -21,6 +19,7 @@ import {
 } from "@iov/bcp";
 import { ExtendedSecp256k1Signature } from "@iov/crypto";
 import { Encoding, Int53 } from "@iov/encoding";
+import BN from "bn.js";
 
 import { Abi } from "./abi";
 import { isValidAddress, pubkeyToAddress } from "./address";

--- a/packages/iov-ethereum/src/utils.ts
+++ b/packages/iov-ethereum/src/utils.ts
@@ -1,4 +1,4 @@
-import BN = require("bn.js");
+import BN from "bn.js";
 
 import { ChainId, Nonce } from "@iov/bcp";
 import { Encoding, Uint53 } from "@iov/encoding";

--- a/packages/iov-ethereum/src/utils.ts
+++ b/packages/iov-ethereum/src/utils.ts
@@ -1,7 +1,6 @@
-import BN from "bn.js";
-
 import { ChainId, Nonce } from "@iov/bcp";
 import { Encoding, Uint53 } from "@iov/encoding";
+import BN from "bn.js";
 
 const bcpChainIdPrefix = "ethereum-eip155-";
 

--- a/packages/iov-ethereum/src/wsethereumrpcclient.ts
+++ b/packages/iov-ethereum/src/wsethereumrpcclient.ts
@@ -1,7 +1,6 @@
-import { Stream } from "xstream";
-
 import { JsonRpcRequest, JsonRpcResponse, parseJsonRpcResponse2 } from "@iov/jsonrpc";
 import { ReconnectingSocket, SocketWrapperMessageEvent } from "@iov/socket";
+import { Stream } from "xstream";
 
 import { EthereumRpcClient } from "./ethereumrpcclient";
 

--- a/packages/iov-ethereum/types/erc20reader.d.ts
+++ b/packages/iov-ethereum/types/erc20reader.d.ts
@@ -1,4 +1,4 @@
-import BN = require("bn.js");
+import BN from "bn.js";
 import { Address } from "@iov/bcp";
 import { Erc20Options } from "./erc20";
 export interface EthereumRpcClient {

--- a/packages/iov-ethereum/types/erc20reader.d.ts
+++ b/packages/iov-ethereum/types/erc20reader.d.ts
@@ -1,5 +1,5 @@
-import BN from "bn.js";
 import { Address } from "@iov/bcp";
+import BN from "bn.js";
 import { Erc20Options } from "./erc20";
 export interface EthereumRpcClient {
     readonly ethCall: (to: Address, data: Uint8Array) => Promise<Uint8Array>;

--- a/packages/iov-ethereum/types/ethereumconnection.d.ts
+++ b/packages/iov-ethereum/types/ethereumconnection.d.ts
@@ -1,5 +1,5 @@
-import { Stream } from "xstream";
 import { Account, AccountQuery, Address, AddressQuery, AtomicSwap, AtomicSwapConnection, AtomicSwapQuery, BlockHeader, ChainId, ConfirmedTransaction, FailedTransaction, Fee, LightTransaction, Nonce, PostableBytes, PostTxResponse, PubkeyQuery, SwapId, Token, TokenTicker, TransactionId, TransactionQuery, UnsignedTransaction } from "@iov/bcp";
+import { Stream } from "xstream";
 import { Erc20TokensMap } from "./erc20";
 export interface EthereumLog {
     readonly transactionIndex: string;

--- a/packages/iov-ethereum/types/ethereumrpcclient.d.ts
+++ b/packages/iov-ethereum/types/ethereumrpcclient.d.ts
@@ -1,6 +1,6 @@
-import { Stream } from "xstream";
 import { JsonRpcRequest, JsonRpcResponse } from "@iov/jsonrpc";
 import { SocketWrapperMessageEvent } from "@iov/socket";
+import { Stream } from "xstream";
 export interface EthereumRpcClient {
     readonly events: Stream<SocketWrapperMessageEvent>;
     readonly run: (request: JsonRpcRequest) => Promise<JsonRpcResponse>;

--- a/packages/iov-ethereum/types/wsethereumrpcclient.d.ts
+++ b/packages/iov-ethereum/types/wsethereumrpcclient.d.ts
@@ -1,6 +1,6 @@
-import { Stream } from "xstream";
 import { JsonRpcRequest, JsonRpcResponse } from "@iov/jsonrpc";
 import { SocketWrapperMessageEvent } from "@iov/socket";
+import { Stream } from "xstream";
 import { EthereumRpcClient } from "./ethereumrpcclient";
 export declare class WsEthereumRpcClient implements EthereumRpcClient {
     readonly events: Stream<SocketWrapperMessageEvent>;

--- a/packages/iov-faucets/src/iovfaucet.ts
+++ b/packages/iov-faucets/src/iovfaucet.ts
@@ -1,6 +1,5 @@
-import axios from "axios";
-
 import { Address, TokenTicker } from "@iov/bcp";
+import axios from "axios";
 
 export class IovFaucet {
   private readonly baseUrl: string;

--- a/packages/iov-jsonrpc/src/jsonrpcclient.ts
+++ b/packages/iov-jsonrpc/src/jsonrpcclient.ts
@@ -1,6 +1,5 @@
-import { Stream } from "xstream";
-
 import { firstEvent } from "@iov/stream";
+import { Stream } from "xstream";
 
 import { isJsonRpcErrorResponse, JsonRpcRequest, JsonRpcResponse, JsonRpcSuccessResponse } from "./types";
 

--- a/packages/iov-keycontrol/src/keyring.ts
+++ b/packages/iov-keycontrol/src/keyring.ts
@@ -1,7 +1,6 @@
-import { As } from "type-tagger";
-
 import { ChainId, Identity, identityEquals } from "@iov/bcp";
 import { Ed25519Keypair, Slip10RawIndex } from "@iov/crypto";
+import { As } from "type-tagger";
 
 import {
   ReadonlyWallet,

--- a/packages/iov-keycontrol/src/keyringencryptor.ts
+++ b/packages/iov-keycontrol/src/keyringencryptor.ts
@@ -1,5 +1,3 @@
-import { As } from "type-tagger";
-
 import {
   Random,
   Xchacha20poly1305Ietf,
@@ -9,6 +7,7 @@ import {
   Xchacha20poly1305IetfNonce,
 } from "@iov/crypto";
 import { Encoding, Uint32 } from "@iov/encoding";
+import { As } from "type-tagger";
 
 import { KeyringSerializationString } from "./keyring";
 

--- a/packages/iov-keycontrol/src/userprofile.spec.ts
+++ b/packages/iov-keycontrol/src/userprofile.spec.ts
@@ -1,7 +1,3 @@
-import levelup from "levelup";
-import MemDownConstructor from "memdown";
-import { ReadonlyDate } from "readonly-date";
-
 import {
   Address,
   Algorithm,
@@ -22,6 +18,9 @@ import {
 } from "@iov/bcp";
 import { Ed25519, Slip10RawIndex } from "@iov/crypto";
 import { Encoding } from "@iov/encoding";
+import levelup from "levelup";
+import MemDownConstructor from "memdown";
+import { ReadonlyDate } from "readonly-date";
 
 import { HdPaths } from "./hdpaths";
 import { Keyring } from "./keyring";

--- a/packages/iov-keycontrol/src/userprofile.ts
+++ b/packages/iov-keycontrol/src/userprofile.ts
@@ -1,7 +1,3 @@
-import { AbstractLevelDOWN } from "abstract-leveldown";
-import { LevelUp } from "levelup";
-import { ReadonlyDate } from "readonly-date";
-
 import {
   ChainId,
   FullSignature,
@@ -14,6 +10,9 @@ import {
 import { Argon2id, Argon2idOptions, Ed25519Keypair, Slip10RawIndex } from "@iov/crypto";
 import { Encoding, Int53 } from "@iov/encoding";
 import { DefaultValueProducer, ValueAndUpdates } from "@iov/stream";
+import { AbstractLevelDOWN } from "abstract-leveldown";
+import { LevelUp } from "levelup";
+import { ReadonlyDate } from "readonly-date";
 
 import { Keyring, WalletInfo } from "./keyring";
 import { EncryptedKeyring, KeyringEncryptor } from "./keyringencryptor";

--- a/packages/iov-keycontrol/src/wallet.ts
+++ b/packages/iov-keycontrol/src/wallet.ts
@@ -1,8 +1,7 @@
-import { As } from "type-tagger";
-
 import { ChainId, Identity, PrehashType, SignableBytes, SignatureBytes } from "@iov/bcp";
 import { Ed25519Keypair, Slip10RawIndex } from "@iov/crypto";
 import { ValueAndUpdates } from "@iov/stream";
+import { As } from "type-tagger";
 
 export type WalletId = string & As<"wallet-id">;
 export type WalletImplementationIdString = string & As<"wallet-implementation-id">;

--- a/packages/iov-keycontrol/src/wallets/ed25519wallet.ts
+++ b/packages/iov-keycontrol/src/wallets/ed25519wallet.ts
@@ -1,6 +1,3 @@
-import PseudoRandom from "random-js";
-import { As } from "type-tagger";
-
 import {
   Algorithm,
   ChainId,
@@ -13,6 +10,8 @@ import {
 import { Ed25519, Ed25519Keypair } from "@iov/crypto";
 import { Encoding } from "@iov/encoding";
 import { DefaultValueProducer, ValueAndUpdates } from "@iov/stream";
+import PseudoRandom from "random-js";
+import { As } from "type-tagger";
 
 import { prehash } from "../prehashing";
 import { Wallet, WalletId, WalletImplementationIdString, WalletSerializationString } from "../wallet";

--- a/packages/iov-keycontrol/src/wallets/slip10wallet.ts
+++ b/packages/iov-keycontrol/src/wallets/slip10wallet.ts
@@ -1,6 +1,3 @@
-import PseudoRandom from "random-js";
-import { As } from "type-tagger";
-
 import {
   Algorithm,
   ChainId,
@@ -22,6 +19,8 @@ import {
 } from "@iov/crypto";
 import { Encoding } from "@iov/encoding";
 import { DefaultValueProducer, ValueAndUpdates } from "@iov/stream";
+import PseudoRandom from "random-js";
+import { As } from "type-tagger";
 
 import { prehash } from "../prehashing";
 import { Wallet, WalletId, WalletImplementationIdString, WalletSerializationString } from "../wallet";

--- a/packages/iov-keycontrol/types/keyring.d.ts
+++ b/packages/iov-keycontrol/types/keyring.d.ts
@@ -1,6 +1,6 @@
-import { As } from "type-tagger";
 import { ChainId, Identity } from "@iov/bcp";
 import { Ed25519Keypair, Slip10RawIndex } from "@iov/crypto";
+import { As } from "type-tagger";
 import { ReadonlyWallet, Wallet, WalletId, WalletImplementationIdString, WalletSerializationString } from "./wallet";
 export declare type KeyringSerializationString = string & As<"keyring-serialization">;
 /**

--- a/packages/iov-keycontrol/types/userprofile.d.ts
+++ b/packages/iov-keycontrol/types/userprofile.d.ts
@@ -1,9 +1,9 @@
-import { AbstractLevelDOWN } from "abstract-leveldown";
-import { LevelUp } from "levelup";
-import { ReadonlyDate } from "readonly-date";
 import { ChainId, Identity, Nonce, SignedTransaction, TxCodec, UnsignedTransaction } from "@iov/bcp";
 import { Ed25519Keypair, Slip10RawIndex } from "@iov/crypto";
 import { ValueAndUpdates } from "@iov/stream";
+import { AbstractLevelDOWN } from "abstract-leveldown";
+import { LevelUp } from "levelup";
+import { ReadonlyDate } from "readonly-date";
 import { Keyring, WalletInfo } from "./keyring";
 import { ReadonlyWallet, WalletId } from "./wallet";
 export interface UserProfileEncryptionKey {

--- a/packages/iov-keycontrol/types/wallet.d.ts
+++ b/packages/iov-keycontrol/types/wallet.d.ts
@@ -1,7 +1,7 @@
-import { As } from "type-tagger";
 import { ChainId, Identity, PrehashType, SignableBytes, SignatureBytes } from "@iov/bcp";
 import { Ed25519Keypair, Slip10RawIndex } from "@iov/crypto";
 import { ValueAndUpdates } from "@iov/stream";
+import { As } from "type-tagger";
 export declare type WalletId = string & As<"wallet-id">;
 export declare type WalletImplementationIdString = string & As<"wallet-implementation-id">;
 export declare type WalletSerializationString = string & As<"wallet-serialization">;

--- a/packages/iov-lisk/src/liskcodec.ts
+++ b/packages/iov-lisk/src/liskcodec.ts
@@ -1,5 +1,3 @@
-import { ReadonlyDate } from "readonly-date";
-
 import {
   Address,
   Algorithm,
@@ -22,6 +20,7 @@ import {
 } from "@iov/bcp";
 import { Parse, Serialization } from "@iov/dpos";
 import { Encoding, Int53 } from "@iov/encoding";
+import { ReadonlyDate } from "readonly-date";
 
 import { constants } from "./constants";
 import { isValidAddress, pubkeyToAddress } from "./derivation";

--- a/packages/iov-lisk/src/liskconnection.spec.ts
+++ b/packages/iov-lisk/src/liskconnection.spec.ts
@@ -1,6 +1,3 @@
-import Long from "long";
-import { ReadonlyDate } from "readonly-date";
-
 import {
   Account,
   AccountQuery,
@@ -33,6 +30,8 @@ import { Derivation } from "@iov/dpos";
 import { Encoding } from "@iov/encoding";
 import { Ed25519Wallet, UserProfile } from "@iov/keycontrol";
 import { toListPromise } from "@iov/stream";
+import Long from "long";
+import { ReadonlyDate } from "readonly-date";
 
 import { pubkeyToAddress } from "./derivation";
 import { liskCodec } from "./liskcodec";

--- a/packages/iov-lisk/src/liskconnection.ts
+++ b/packages/iov-lisk/src/liskconnection.ts
@@ -1,8 +1,3 @@
-import axios from "axios";
-import equal from "fast-deep-equal";
-import { ReadonlyDate } from "readonly-date";
-import { Producer, Stream } from "xstream";
-
 import {
   Account,
   AccountQuery,
@@ -34,6 +29,10 @@ import {
 import { Parse } from "@iov/dpos";
 import { Encoding, Uint53, Uint64 } from "@iov/encoding";
 import { concat, DefaultValueProducer, ValueAndUpdates } from "@iov/stream";
+import axios from "axios";
+import equal from "fast-deep-equal";
+import { ReadonlyDate } from "readonly-date";
+import { Producer, Stream } from "xstream";
 
 import { constants } from "./constants";
 import { pubkeyToAddress } from "./derivation";

--- a/packages/iov-lisk/types/liskconnection.d.ts
+++ b/packages/iov-lisk/types/liskconnection.d.ts
@@ -1,5 +1,5 @@
-import { Stream } from "xstream";
 import { Account, AccountQuery, AddressQuery, BlockchainConnection, BlockHeader, ChainId, ConfirmedTransaction, FailedTransaction, Fee, LightTransaction, Nonce, PostableBytes, PostTxResponse, PubkeyQuery, Token, TokenTicker, TransactionId, TransactionQuery, UnsignedTransaction } from "@iov/bcp";
+import { Stream } from "xstream";
 /**
  * Encodes the current date and time as a nonce
  */

--- a/packages/iov-rise/src/risecodec.ts
+++ b/packages/iov-rise/src/risecodec.ts
@@ -1,5 +1,3 @@
-import { ReadonlyDate } from "readonly-date";
-
 import {
   Address,
   Algorithm,
@@ -22,6 +20,7 @@ import {
 } from "@iov/bcp";
 import { Parse, Serialization } from "@iov/dpos";
 import { Encoding, Int53 } from "@iov/encoding";
+import { ReadonlyDate } from "readonly-date";
 
 import { constants } from "./constants";
 import { isValidAddress, pubkeyToAddress } from "./derivation";

--- a/packages/iov-rise/src/riseconnection.spec.ts
+++ b/packages/iov-rise/src/riseconnection.spec.ts
@@ -1,6 +1,3 @@
-import Long from "long";
-import { ReadonlyDate } from "readonly-date";
-
 import {
   Account,
   AccountQuery,
@@ -32,6 +29,8 @@ import { Ed25519, Random, Sha256 } from "@iov/crypto";
 import { Derivation } from "@iov/dpos";
 import { Encoding } from "@iov/encoding";
 import { Ed25519Wallet, UserProfile } from "@iov/keycontrol";
+import Long from "long";
+import { ReadonlyDate } from "readonly-date";
 
 import { pubkeyToAddress } from "./derivation";
 import { riseCodec } from "./risecodec";

--- a/packages/iov-rise/src/riseconnection.ts
+++ b/packages/iov-rise/src/riseconnection.ts
@@ -1,8 +1,3 @@
-import axios from "axios";
-import equal from "fast-deep-equal";
-import { ReadonlyDate } from "readonly-date";
-import { Producer, Stream } from "xstream";
-
 import {
   Account,
   AccountQuery,
@@ -34,6 +29,10 @@ import {
 import { Parse } from "@iov/dpos";
 import { Encoding, Uint53, Uint64 } from "@iov/encoding";
 import { concat, DefaultValueProducer, ValueAndUpdates } from "@iov/stream";
+import axios from "axios";
+import equal from "fast-deep-equal";
+import { ReadonlyDate } from "readonly-date";
+import { Producer, Stream } from "xstream";
 
 import { constants } from "./constants";
 import { pubkeyToAddress } from "./derivation";

--- a/packages/iov-rise/types/riseconnection.d.ts
+++ b/packages/iov-rise/types/riseconnection.d.ts
@@ -1,5 +1,5 @@
-import { Stream } from "xstream";
 import { Account, AccountQuery, AddressQuery, BlockchainConnection, BlockHeader, ChainId, ConfirmedTransaction, FailedTransaction, Fee, LightTransaction, Nonce, PostableBytes, PostTxResponse, PubkeyQuery, Token, TokenTicker, TransactionId, TransactionQuery, UnsignedTransaction } from "@iov/bcp";
+import { Stream } from "xstream";
 /**
  * Encodes the current date and time as a nonce
  */

--- a/packages/iov-socket/src/queueingstreamingsocket.ts
+++ b/packages/iov-socket/src/queueingstreamingsocket.ts
@@ -1,7 +1,6 @@
 // tslint:disable:no-object-mutation readonly-array readonly-keyword
-import { Listener, Producer, Stream } from "xstream";
-
 import { DefaultValueProducer, ValueAndUpdates } from "@iov/stream";
+import { Listener, Producer, Stream } from "xstream";
 
 import { SocketWrapperMessageEvent } from "./socketwrapper";
 import { StreamingSocket } from "./streamingsocket";

--- a/packages/iov-socket/src/reconnectingsocket.ts
+++ b/packages/iov-socket/src/reconnectingsocket.ts
@@ -1,7 +1,6 @@
 // tslint:disable:no-object-mutation readonly-keyword
-import { Listener, Producer, Stream } from "xstream";
-
 import { ValueAndUpdates } from "@iov/stream";
+import { Listener, Producer, Stream } from "xstream";
 
 import { ConnectionStatus, QueueingStreamingSocket } from "./queueingstreamingsocket";
 import { SocketWrapperMessageEvent } from "./socketwrapper";

--- a/packages/iov-socket/types/queueingstreamingsocket.d.ts
+++ b/packages/iov-socket/types/queueingstreamingsocket.d.ts
@@ -1,5 +1,5 @@
-import { Stream } from "xstream";
 import { ValueAndUpdates } from "@iov/stream";
+import { Stream } from "xstream";
 import { SocketWrapperMessageEvent } from "./socketwrapper";
 export declare enum ConnectionStatus {
     Unconnected = 0,

--- a/packages/iov-socket/types/reconnectingsocket.d.ts
+++ b/packages/iov-socket/types/reconnectingsocket.d.ts
@@ -1,5 +1,5 @@
-import { Stream } from "xstream";
 import { ValueAndUpdates } from "@iov/stream";
+import { Stream } from "xstream";
 import { ConnectionStatus } from "./queueingstreamingsocket";
 import { SocketWrapperMessageEvent } from "./socketwrapper";
 /**

--- a/packages/iov-tendermint-rpc/src/client.spec.ts
+++ b/packages/iov-tendermint-rpc/src/client.spec.ts
@@ -1,9 +1,8 @@
 // tslint:disable:readonly-array
-import { ReadonlyDate } from "readonly-date";
-import { Stream } from "xstream";
-
 import { Encoding } from "@iov/encoding";
 import { firstEvent, toListPromise } from "@iov/stream";
+import { ReadonlyDate } from "readonly-date";
+import { Stream } from "xstream";
 
 import { Adaptor, adatorForVersion } from "./adaptor";
 import { Client } from "./client";

--- a/packages/iov-tendermint-rpc/src/encodings.ts
+++ b/packages/iov-tendermint-rpc/src/encodings.ts
@@ -1,7 +1,6 @@
+import { Encoding, Int53 } from "@iov/encoding";
 import { ReadonlyDate } from "readonly-date";
 import { As } from "type-tagger";
-
-import { Encoding, Int53 } from "@iov/encoding";
 
 export type Base64String = string & As<"base64">;
 export type HexString = string & As<"hex">;

--- a/packages/iov-tendermint-rpc/src/rpcclients/httpclient.spec.ts
+++ b/packages/iov-tendermint-rpc/src/rpcclients/httpclient.spec.ts
@@ -1,7 +1,6 @@
 import { defaultInstance } from "../config.spec";
 import { createJsonRpcRequest } from "../jsonrpc";
 import { Method } from "../requests";
-
 import { HttpClient } from "./httpclient";
 
 function skipTests(): boolean {

--- a/packages/iov-tendermint-rpc/src/rpcclients/httpclient.ts
+++ b/packages/iov-tendermint-rpc/src/rpcclients/httpclient.ts
@@ -1,11 +1,10 @@
-import axios from "axios";
-
 import {
   isJsonRpcErrorResponse,
   JsonRpcRequest,
   JsonRpcSuccessResponse,
   parseJsonRpcResponse2,
 } from "@iov/jsonrpc";
+import axios from "axios";
 
 import { hasProtocol, RpcClient } from "./rpcclient";
 

--- a/packages/iov-tendermint-rpc/src/rpcclients/rpcclient.spec.ts
+++ b/packages/iov-tendermint-rpc/src/rpcclients/rpcclient.spec.ts
@@ -1,7 +1,6 @@
 import { defaultInstance } from "../config.spec";
 import { createJsonRpcRequest } from "../jsonrpc";
 import { Method } from "../requests";
-
 import { HttpClient } from "./httpclient";
 import { instanceOfRpcStreamingClient } from "./rpcclient";
 import { WebsocketClient } from "./websocketclient";

--- a/packages/iov-tendermint-rpc/src/rpcclients/rpcclient.ts
+++ b/packages/iov-tendermint-rpc/src/rpcclients/rpcclient.ts
@@ -1,6 +1,5 @@
-import { Stream } from "xstream";
-
 import { JsonRpcRequest, JsonRpcSuccessResponse } from "@iov/jsonrpc";
+import { Stream } from "xstream";
 
 /**
  * An event emitted from Tendermint after subscribing via RPC.

--- a/packages/iov-tendermint-rpc/src/rpcclients/websocketclient.spec.ts
+++ b/packages/iov-tendermint-rpc/src/rpcclients/websocketclient.spec.ts
@@ -1,12 +1,10 @@
-import { Stream } from "xstream";
-
 import { toListPromise } from "@iov/stream";
+import { Stream } from "xstream";
 
 import { defaultInstance } from "../config.spec";
 import { Integer } from "../encodings";
 import { createJsonRpcRequest } from "../jsonrpc";
 import { Method } from "../requests";
-
 import { SubscriptionEvent } from "./rpcclient";
 import { WebsocketClient } from "./websocketclient";
 

--- a/packages/iov-tendermint-rpc/src/rpcclients/websocketclient.ts
+++ b/packages/iov-tendermint-rpc/src/rpcclients/websocketclient.ts
@@ -1,6 +1,4 @@
 /* tslint:disable:readonly-keyword readonly-array no-object-mutation */
-import { Listener, Producer, Stream, Subscription } from "xstream";
-
 import {
   isJsonRpcErrorResponse,
   JsonRpcId,
@@ -11,6 +9,7 @@ import {
 } from "@iov/jsonrpc";
 import { ConnectionStatus, ReconnectingSocket, SocketWrapperMessageEvent } from "@iov/socket";
 import { firstEvent } from "@iov/stream";
+import { Listener, Producer, Stream, Subscription } from "xstream";
 
 import { hasProtocol, RpcStreamingClient, SubscriptionEvent } from "./rpcclient";
 

--- a/packages/iov-tendermint-rpc/src/v0-29/hasher.spec.ts
+++ b/packages/iov-tendermint-rpc/src/v0-29/hasher.spec.ts
@@ -1,7 +1,6 @@
 import { Encoding } from "@iov/encoding";
 
 import { TxBytes } from "../types";
-
 import { hashTx } from "./hasher";
 
 describe("Hasher", () => {

--- a/packages/iov-tendermint-rpc/src/v0-31/hasher.spec.ts
+++ b/packages/iov-tendermint-rpc/src/v0-31/hasher.spec.ts
@@ -1,7 +1,6 @@
 import { Encoding } from "@iov/encoding";
 
 import { TxBytes } from "../types";
-
 import { hashTx } from "./hasher";
 
 describe("Hasher", () => {

--- a/packages/iov-tendermint-rpc/types/rpcclients/rpcclient.d.ts
+++ b/packages/iov-tendermint-rpc/types/rpcclients/rpcclient.d.ts
@@ -1,5 +1,5 @@
-import { Stream } from "xstream";
 import { JsonRpcRequest, JsonRpcSuccessResponse } from "@iov/jsonrpc";
+import { Stream } from "xstream";
 /**
  * An event emitted from Tendermint after subscribing via RPC.
  *

--- a/packages/iov-tendermint-rpc/types/rpcclients/websocketclient.d.ts
+++ b/packages/iov-tendermint-rpc/types/rpcclients/websocketclient.d.ts
@@ -1,5 +1,5 @@
-import { Stream } from "xstream";
 import { JsonRpcId, JsonRpcRequest, JsonRpcResponse, JsonRpcSuccessResponse } from "@iov/jsonrpc";
+import { Stream } from "xstream";
 import { RpcStreamingClient, SubscriptionEvent } from "./rpcclient";
 export declare class WebsocketClient implements RpcStreamingClient {
     private readonly url;

--- a/tslint.json
+++ b/tslint.json
@@ -30,6 +30,7 @@
     "no-var-keyword": true,
     "object-literal-shorthand": [true, "never"],
     "object-literal-sort-keys": false,
+    "ordered-imports": false,
     "prefer-const": true,
     "promise-function-async": true,
     "readonly-array": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2672,6 +2672,13 @@ eslint-plugin-prettier@^3.1.0:
   dependencies:
     prettier-linter-helpers "^1.0.0"
 
+eslint-plugin-simple-import-sort@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-4.0.0.tgz#048736c170b9b43f0a8c3ef85ba53881c389f3ff"
+  integrity sha512-QsxOMrXhhqvSiTmZafPc/lvSET9lhblaO2kaaSbFo1FVU/AW9mFQDXadiHJ5OqG6i0N6+Qd+RZ95iQbkg4p+0w==
+  dependencies:
+    validate-npm-package-name "^3.0.0"
+
 eslint-scope@^4.0.0, eslint-scope@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-4.0.3.tgz#ca03833310f6889a3264781aa82e63eb9cfe7848"


### PR DESCRIPTION
With this merged, imports are sorted automatically as part of the eslint autofix step. For me this saves a lot of time that is usually needed to manually sort imports.