### PR TITLE
Upgrade libsodium-wrappers and adapt code

### DIFF
--- a/packages/iov-crypto/package.json
+++ b/packages/iov-crypto/package.json
@@ -35,13 +35,13 @@
     "bn.js": "^4.11.8",
     "elliptic": "^6.4.0",
     "js-sha3": "^0.8.0",
-    "libsodium-wrappers": "^0.7.4",
+    "libsodium-wrappers": "^0.7.5",
     "pbkdf2": "^3.0.16",
     "sha.js": "^2.4.11",
     "type-tagger": "^1.0.0",
     "unorm": "^1.5.0"
   },
   "devDependencies": {
-    "@types/libsodium-wrappers": "^0.7.3"
+    "@types/libsodium-wrappers": "^0.7.5"
   }
 }

--- a/packages/iov-crypto/src/libsodium.spec.ts
+++ b/packages/iov-crypto/src/libsodium.spec.ts
@@ -503,23 +503,26 @@ describe("Libsodium", () => {
         const corruptedCiphertext = ciphertext.map((x, i) =>
           i === 0 ? x ^ 0x01 : x,
         ) as Xchacha20poly1305IetfCiphertext;
-        await Xchacha20poly1305Ietf.decrypt(corruptedCiphertext, key, nonce)
-          .then(() => fail("promise must not resolve"))
-          .catch(error => expect(error.message).toContain("invalid usage"));
+        await Xchacha20poly1305Ietf.decrypt(corruptedCiphertext, key, nonce).then(
+          () => fail("promise must not resolve"),
+          error => expect(error.message).toMatch(/ciphertext cannot be decrypted using that key/i),
+        );
       }
       {
         // corrupted key
         const corruptedKey = key.map((x, i) => (i === 0 ? x ^ 0x01 : x)) as Xchacha20poly1305IetfKey;
-        await Xchacha20poly1305Ietf.decrypt(ciphertext, corruptedKey, nonce)
-          .then(() => fail("promise must not resolve"))
-          .catch(error => expect(error.message).toContain("invalid usage"));
+        await Xchacha20poly1305Ietf.decrypt(ciphertext, corruptedKey, nonce).then(
+          () => fail("promise must not resolve"),
+          error => expect(error.message).toMatch(/ciphertext cannot be decrypted using that key/i),
+        );
       }
       {
         // corrupted nonce
         const corruptedNonce = nonce.map((x, i) => (i === 0 ? x ^ 0x01 : x)) as Xchacha20poly1305IetfNonce;
-        await Xchacha20poly1305Ietf.decrypt(ciphertext, key, corruptedNonce)
-          .then(() => fail("promise must not resolve"))
-          .catch(error => expect(error.message).toContain("invalid usage"));
+        await Xchacha20poly1305Ietf.decrypt(ciphertext, key, corruptedNonce).then(
+          () => fail("promise must not resolve"),
+          error => expect(error.message).toMatch(/ciphertext cannot be decrypted using that key/i),
+        );
       }
     });
 

--- a/packages/iov-keycontrol/src/userprofile.spec.ts
+++ b/packages/iov-keycontrol/src/userprofile.spec.ts
@@ -124,9 +124,10 @@ describe("UserProfile", () => {
       await original.storeIn(db, defaultEncryptionPassword);
 
       const otherEncryptionPassword = "something wrong";
-      await UserProfile.loadFrom(db, otherEncryptionPassword)
-        .then(() => fail("loading must not succeed"))
-        .catch(error => expect(error).toMatch(/invalid usage/));
+      await UserProfile.loadFrom(db, otherEncryptionPassword).then(
+        () => fail("loading must not succeed"),
+        error => expect(error).toMatch(/ciphertext cannot be decrypted using that key/i),
+      );
 
       await db.close();
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -853,7 +853,7 @@
     "@types/events" "*"
     "@types/node" "*"
 
-"@types/libsodium-wrappers@^0.7.3":
+"@types/libsodium-wrappers@^0.7.5":
   version "0.7.5"
   resolved "https://registry.yarnpkg.com/@types/libsodium-wrappers/-/libsodium-wrappers-0.7.5.tgz#3cdda11ebf6b70bf40cfa2c483d7622897277bc4"
   integrity sha512-CfxNQj3+fUwGhV20/yRoiMRjLN6+3cDRAjN2eQ0XKgq/IBhvROsbWxPa34JIiMKGdfHKy92OaMnViyoWw2Nrkg==
@@ -4238,17 +4238,17 @@ libnpmpublish@^1.1.1:
     semver "^5.5.1"
     ssri "^6.0.1"
 
-libsodium-wrappers@^0.7.4:
-  version "0.7.4"
-  resolved "https://registry.yarnpkg.com/libsodium-wrappers/-/libsodium-wrappers-0.7.4.tgz#cdb3ce6553e4864c0a68070c4313583489bd765d"
-  integrity sha512-axKkW01L0q+urLeE7UMSZKWwk4LrRbi6s5pjKBAvbgDBYnsSaolK1oN/Syilm1dqJFkJQNi6qodwOp8dzSoc9Q==
+libsodium-wrappers@^0.7.5:
+  version "0.7.5"
+  resolved "https://registry.yarnpkg.com/libsodium-wrappers/-/libsodium-wrappers-0.7.5.tgz#a880a99250edecead36a336b9d9eb7192ca405b4"
+  integrity sha512-QE9Q+FxLLGdJRiJTuC2GB3LEHZeHX/VcbMQeNPdAixEKo86JPy6bOWND1XmMLu0tjWUu0xIY0YpJYQApxIZwbQ==
   dependencies:
-    libsodium "0.7.4"
+    libsodium "0.7.5"
 
-libsodium@0.7.4:
-  version "0.7.4"
-  resolved "https://registry.yarnpkg.com/libsodium/-/libsodium-0.7.4.tgz#a5bccd65e3a13b34147ea109be3c65d89f90b074"
-  integrity sha512-fTU3vUdrxQzhPAAjmTSqKk4LzYbR0OtcYjp1P92AlH50JIxXZFEIXWh1yryCmU6RLGfwS2IzBdZjbmpYf/TlyQ==
+libsodium@0.7.5:
+  version "0.7.5"
+  resolved "https://registry.yarnpkg.com/libsodium/-/libsodium-0.7.5.tgz#a45a0a88a6f7a39291b053447908a76570138e09"
+  integrity sha512-0YVU2QJc5sDR5HHkGCaliYImS7pGeXi11fiOfm4DirBd96PJVZIn3LJa06ZOFjLNsWkL3UbNjYhLRUOABPL9vw==
 
 load-json-file@^1.0.0:
   version "1.1.0"


### PR DESCRIPTION
The default error message from libsodium is much better now and there is not much room for improvement, since we cannot detect what was wrong (ciphertext, key or nonce).

Closes #250


