### PR TITLE
Support DistributeFunds proposal type

### DIFF
--- a/packages/iov-bns-governance/src/committees.ts
+++ b/packages/iov-bns-governance/src/committees.ts
@@ -1,3 +1,4 @@
+import { Address } from "@iov/bcp";
 import { As } from "type-tagger";
 
 export type CommitteeId = number & As<"committee">;
@@ -22,4 +23,9 @@ export const committeeIds: { readonly [chainId: string]: CommitteeIds } = {
 export const guaranteeFundEscrowIds: { readonly [chainId: string]: Uint8Array } = {
   // TODO: Constants to be finalised once the guarantee funds are set up in the actual genesis blocks. E.g.:
   // testnet: Encoding.fromHex("abcd"),
+};
+
+export const rewardFundAddresses: { readonly [chainId: string]: Address } = {
+  // TODO: Constants to be finalised once the reward funds are set up in the actual deployments. E.g.:
+  // testnet: "tiov1111111111111111111111111111111111111111" as Address,
 };

--- a/packages/iov-bns-governance/src/governor.spec.ts
+++ b/packages/iov-bns-governance/src/governor.spec.ts
@@ -1,7 +1,8 @@
 /* eslint-disable @typescript-eslint/camelcase */
-import { Address, Algorithm, PubkeyBytes, TokenTicker } from "@iov/bcp";
+import { Address, Algorithm, isBlockInfoPending, PubkeyBytes, TokenTicker } from "@iov/bcp";
 import { ActionKind, bnsCodec, BnsConnection, VoteOption } from "@iov/bns";
-import { Encoding } from "@iov/encoding";
+import { Random } from "@iov/crypto";
+import { Bech32, Encoding } from "@iov/encoding";
 import { Ed25519HdWallet, HdPaths, UserProfile } from "@iov/keycontrol";
 import { ReadonlyDate } from "readonly-date";
 
@@ -20,10 +21,13 @@ function pendingWithoutBnsd(): void {
 // This account has money in the genesis file (see scripts/bnsd/README.md).
 const faucetMnemonic = "degree tackle suggest window test behind mesh extra cover prepare oak script";
 const faucetPath = HdPaths.iov(0);
-const bnsdUrl = "http://localhost:23456";
+const bnsdUrl = "ws://localhost:23456";
 const guaranteeFundEscrowId = Encoding.fromHex("88008800");
+const rewardFundAddress = "tiov15nuhg3l8ma2mdmcdvgy7hme20v3xy5mkxcezea" as Address;
 
-async function getGovernorOptions(path = faucetPath): Promise<GovernorOptions> {
+async function getGovernorOptions(
+  path = faucetPath,
+): Promise<GovernorOptions & { readonly profile: UserProfile }> {
   const connection = await BnsConnection.establish(bnsdUrl);
   const chainId = await connection.chainId();
   const profile = new UserProfile();
@@ -33,6 +37,8 @@ async function getGovernorOptions(path = faucetPath): Promise<GovernorOptions> {
     connection: connection,
     identity: identity,
     guaranteeFundEscrowId: guaranteeFundEscrowId,
+    rewardFundAddress: rewardFundAddress,
+    profile: profile,
   };
 }
 
@@ -455,8 +461,96 @@ describe("Governor", () => {
           },
         },
       });
-
       options.connection.disconnect();
+    });
+
+    it("works for DistributeFunds", async () => {
+      pendingWithoutBnsd();
+      const options = await getGovernorOptions();
+      const cleanRewardFundAddress = Bech32.encode("tiov", await Random.getBytes(20)) as Address;
+      const governor = new Governor({
+        ...options,
+        rewardFundAddress: cleanRewardFundAddress,
+      });
+      const { connection, identity, profile } = options;
+
+      const sendTx = await connection.withDefaultFee({
+        kind: "bcp/send",
+        creator: identity,
+        sender: bnsCodec.identityToAddress(identity),
+        recipient: cleanRewardFundAddress,
+        amount: {
+          // 999000000000 + fee
+          quantity: "999010000000",
+          fractionalDigits: 9,
+          tokenTicker: "CASH" as TokenTicker,
+        },
+      });
+      const nonce = await connection.getNonce({ pubkey: identity.pubkey });
+      const signed = await profile.signTransaction(sendTx, bnsCodec, nonce);
+      const response = await connection.postTx(bnsCodec.bytesToPost(signed));
+      await response.blockInfo.waitFor(info => !isBlockInfoPending(info));
+
+      const tx = await governor.buildCreateProposalTx({
+        type: ProposalType.DistributeFunds,
+        title: "Distribute funds",
+        description: "Proposal to distribute funds",
+        startTime: new ReadonlyDate(1562164525898),
+        electionRuleId: 1,
+        recipients: [
+          {
+            address: "tiov222222222222222222222222222222222222222" as Address,
+            weight: 2,
+          },
+          {
+            address: "tiov555555555555555555555555555555555555555" as Address,
+            weight: 5,
+          },
+        ],
+      });
+      expect(tx).toEqual({
+        kind: "bns/create_proposal",
+        creator: identity,
+        title: "Distribute funds",
+        action: {
+          kind: ActionKind.ExecuteProposalBatch,
+          messages: [
+            {
+              kind: ActionKind.Send,
+              sender: cleanRewardFundAddress,
+              recipient: "tiov222222222222222222222222222222222222222" as Address,
+              amount: {
+                quantity: "285428571428",
+                fractionalDigits: 9,
+                tokenTicker: "CASH" as TokenTicker,
+              },
+            },
+            {
+              kind: ActionKind.Send,
+              sender: cleanRewardFundAddress,
+              recipient: "tiov555555555555555555555555555555555555555" as Address,
+              amount: {
+                quantity: "713571428571",
+                fractionalDigits: 9,
+                tokenTicker: "CASH" as TokenTicker,
+              },
+            },
+          ],
+        },
+        description: "Proposal to distribute funds",
+        electionRuleId: 1,
+        startTime: 1562164525,
+        author: bnsCodec.identityToAddress(identity),
+        fee: {
+          tokens: {
+            quantity: "10000000",
+            fractionalDigits: 9,
+            tokenTicker: "CASH" as TokenTicker,
+          },
+        },
+      });
+
+      connection.disconnect();
     });
   });
 

--- a/packages/iov-bns-governance/src/governor.spec.ts
+++ b/packages/iov-bns-governance/src/governor.spec.ts
@@ -480,8 +480,7 @@ describe("Governor", () => {
         sender: bnsCodec.identityToAddress(identity),
         recipient: cleanRewardFundAddress,
         amount: {
-          // 999000000000 + fee
-          quantity: "999010000000",
+          quantity: "999000000000",
           fractionalDigits: 9,
           tokenTicker: "CASH" as TokenTicker,
         },

--- a/packages/iov-bns-governance/src/governor.ts
+++ b/packages/iov-bns-governance/src/governor.ts
@@ -164,21 +164,10 @@ export class Governor {
         if (!fundTotal) {
           throw new Error("Guarantee fund has no CASH balance");
         }
-
-        const tx = {
-          ...commonProperties,
-          action: {
-            kind: ActionKind.ExecuteProposalBatch,
-            messages: [],
-          },
-        };
-        const feeQuote = await this.connection.getFeeQuote(tx);
-        if (!feeQuote.tokens) throw new Error("Received fee quote of unexpected type");
-        const fundTotalMinusFee = new BN(fundTotal.quantity).sub(new BN(feeQuote.tokens.quantity));
         const totalWeight = options.recipients.reduce((total, { weight }) => total + weight, 0);
 
         return this.connection.withDefaultFee({
-          ...tx,
+          ...commonProperties,
           action: {
             kind: ActionKind.ExecuteProposalBatch,
             messages: options.recipients.map(({ address, weight }) => ({
@@ -186,7 +175,7 @@ export class Governor {
               sender: rewardFundAddress,
               recipient: address,
               amount: {
-                quantity: fundTotalMinusFee
+                quantity: new BN(fundTotal.quantity)
                   .muln(weight)
                   .divn(totalWeight)
                   .toString(),

--- a/packages/iov-bns-governance/types/committees.d.ts
+++ b/packages/iov-bns-governance/types/committees.d.ts
@@ -1,3 +1,4 @@
+import { Address } from "@iov/bcp";
 import { As } from "type-tagger";
 export declare type CommitteeId = number & As<"committee">;
 export interface CommitteeIds {
@@ -11,4 +12,7 @@ export declare const committeeIds: {
 };
 export declare const guaranteeFundEscrowIds: {
     readonly [chainId: string]: Uint8Array;
+};
+export declare const rewardFundAddresses: {
+    readonly [chainId: string]: Address;
 };

--- a/packages/iov-bns-governance/types/governor.d.ts
+++ b/packages/iov-bns-governance/types/governor.d.ts
@@ -1,17 +1,19 @@
-import { Identity, WithCreator } from "@iov/bcp";
+import { Address, Identity, WithCreator } from "@iov/bcp";
 import { BnsConnection, CreateProposalTx, ElectionRule, Electorate, Proposal, VoteOption, VoteTx } from "@iov/bns";
 import { ProposalOptions } from "./proposals";
 export interface GovernorOptions {
     readonly connection: BnsConnection;
     readonly identity: Identity;
     readonly guaranteeFundEscrowId: Uint8Array;
+    readonly rewardFundAddress: Address;
 }
 export declare class Governor {
     private readonly connection;
     private readonly identity;
     private readonly address;
     private readonly guaranteeFundEscrowId;
-    constructor({ connection, identity, guaranteeFundEscrowId }: GovernorOptions);
+    private readonly rewardFundAddress;
+    constructor({ connection, identity, guaranteeFundEscrowId, rewardFundAddress }: GovernorOptions);
     getElectorates(): Promise<readonly Electorate[]>;
     getElectionRules(electorateId: number): Promise<readonly ElectionRule[]>;
     getProposals(): Promise<readonly Proposal[]>;

--- a/packages/iov-bns-governance/types/governor.d.ts
+++ b/packages/iov-bns-governance/types/governor.d.ts
@@ -4,15 +4,15 @@ import { ProposalOptions } from "./proposals";
 export interface GovernorOptions {
     readonly connection: BnsConnection;
     readonly identity: Identity;
-    readonly guaranteeFundEscrowId: Uint8Array;
-    readonly rewardFundAddress: Address;
+    readonly guaranteeFundEscrowId?: Uint8Array;
+    readonly rewardFundAddress?: Address;
 }
 export declare class Governor {
     private readonly connection;
     private readonly identity;
     private readonly address;
-    private readonly guaranteeFundEscrowId;
-    private readonly rewardFundAddress;
+    private readonly guaranteeFundEscrowId?;
+    private readonly rewardFundAddress?;
     constructor({ connection, identity, guaranteeFundEscrowId, rewardFundAddress }: GovernorOptions);
     getElectorates(): Promise<readonly Electorate[]>;
     getElectionRules(electorateId: number): Promise<readonly ElectionRule[]>;

--- a/packages/iov-bns/src/decode.spec.ts
+++ b/packages/iov-bns/src/decode.spec.ts
@@ -674,6 +674,78 @@ describe("Decode", () => {
         expect(parsed.author).toEqual("tiov1qqgjyv6y24n80zyeqqgjyv6y24n80zyed9d6mt");
       });
 
+      it("works with ExecuteProposalBatch action with array of Send actions", () => {
+        const transactionMessage: codecImpl.bnsd.ITx = {
+          govCreateProposalMsg: {
+            title: "This will happen next",
+            rawOption: codecImpl.bnsd.ProposalOptions.encode({
+              executeProposalBatchMsg: {
+                messages: [
+                  {
+                    sendMsg: {
+                      source: fromHex("6e1114f57410d8e7bcd910a568c9196efc1479e4"),
+                      destination: fromHex("b1ca7e78f74423ae01da3b51e676934d9105f282"),
+                      amount: {
+                        whole: 1,
+                        fractional: 1,
+                        ticker: "CASH",
+                      },
+                      memo: "say hi",
+                    },
+                  },
+                  {
+                    sendMsg: {
+                      source: fromHex("b1ca7e78f74423ae01da3b51e676934d9105f282"),
+                      destination: fromHex("6e1114f57410d8e7bcd910a568c9196efc1479e4"),
+                      amount: {
+                        whole: 3,
+                        fractional: 3,
+                        ticker: "MASH",
+                      },
+                    },
+                  },
+                ],
+              },
+            }).finish(),
+            description: "foo bar",
+            electionRuleId: fromHex("bbccddbbff"),
+            startTime: 42424242,
+            author: fromHex("0011223344556677889900112233445566778899"),
+          },
+        };
+        const parsed = parseMsg(defaultBaseTx, transactionMessage);
+        if (!isCreateProposalTx(parsed)) {
+          throw new Error("unexpected transaction kind");
+        }
+        expect(parsed.title).toEqual("This will happen next");
+        expect(parsed.action).toEqual({
+          kind: ActionKind.ExecuteProposalBatch,
+          messages: [
+            {
+              kind: ActionKind.Send,
+              sender: defaultSender,
+              recipient: defaultRecipient,
+              amount: defaultAmount,
+              memo: "say hi",
+            },
+            {
+              kind: ActionKind.Send,
+              sender: defaultRecipient,
+              recipient: defaultSender,
+              amount: {
+                quantity: "3000000003",
+                fractionalDigits: 9,
+                tokenTicker: "MASH" as TokenTicker,
+              },
+            },
+          ],
+        });
+        expect(parsed.description).toEqual("foo bar");
+        expect(parsed.electionRuleId).toEqual(806595967999);
+        expect(parsed.startTime).toEqual(42424242);
+        expect(parsed.author).toEqual("tiov1qqgjyv6y24n80zyeqqgjyv6y24n80zyed9d6mt");
+      });
+
       it("works with ReleaseGuaranteeFunds action", () => {
         const transactionMessage: codecImpl.bnsd.ITx = {
           govCreateProposalMsg: {

--- a/packages/iov-bns/src/encode.spec.ts
+++ b/packages/iov-bns/src/encode.spec.ts
@@ -555,6 +555,78 @@ describe("Encode", () => {
         });
       });
 
+      it("works with ExecuteProposalBatch action with array of Send actions", () => {
+        const createProposal: CreateProposalTx & WithCreator = {
+          kind: "bns/create_proposal",
+          creator: defaultCreator,
+          title: "Why not try this?",
+          action: {
+            kind: ActionKind.ExecuteProposalBatch,
+            messages: [
+              {
+                kind: ActionKind.Send,
+                sender: defaultSender,
+                recipient: defaultRecipient,
+                amount: defaultAmount,
+                memo: "say hi",
+              },
+              {
+                kind: ActionKind.Send,
+                sender: defaultRecipient,
+                recipient: defaultSender,
+                amount: {
+                  quantity: "3000000003",
+                  fractionalDigits: 9,
+                  tokenTicker: "MASH" as TokenTicker,
+                },
+              },
+            ],
+          },
+          description: "foo bar",
+          electionRuleId: 4822531585417728,
+          startTime: 1122334455,
+          author: defaultSender,
+        };
+        const msg = buildMsg(createProposal).govCreateProposalMsg!;
+        expect(msg).toEqual({
+          metadata: { schema: 1 },
+          title: "Why not try this?",
+          rawOption: codecImpl.bnsd.ProposalOptions.encode({
+            executeProposalBatchMsg: {
+              messages: [
+                {
+                  sendMsg: {
+                    source: fromHex("6e1114f57410d8e7bcd910a568c9196efc1479e4"),
+                    destination: fromHex("b1ca7e78f74423ae01da3b51e676934d9105f282"),
+                    amount: {
+                      whole: 1,
+                      fractional: 1,
+                      ticker: "CASH",
+                    },
+                    memo: "say hi",
+                  },
+                },
+                {
+                  sendMsg: {
+                    source: fromHex("b1ca7e78f74423ae01da3b51e676934d9105f282"),
+                    destination: fromHex("6e1114f57410d8e7bcd910a568c9196efc1479e4"),
+                    amount: {
+                      whole: 3,
+                      fractional: 3,
+                      ticker: "MASH",
+                    },
+                  },
+                },
+              ],
+            },
+          }).finish(),
+          description: "foo bar",
+          electionRuleId: fromHex("0011221122112200"),
+          startTime: 1122334455,
+          author: fromHex("6e1114f57410d8e7bcd910a568c9196efc1479e4"),
+        });
+      });
+
       it("works with ReleaseEscrow action", () => {
         const createProposal: CreateProposalTx & WithCreator = {
           kind: "bns/create_proposal",

--- a/packages/iov-bns/src/types.ts
+++ b/packages/iov-bns/src/types.ts
@@ -120,6 +120,7 @@ export enum ActionKind {
   CreateTextResolution = "gov_create_text_resolution",
   ExecuteProposalBatch = "execute_proposal_batch",
   ReleaseEscrow = "escrow_release",
+  Send = "cash_send",
   SetValidators = "validators_apply_diff",
   UpdateElectionRule = "gov_update_election_rule",
   UpdateElectorate = "gov_update_electorate",
@@ -160,6 +161,18 @@ export function isReleaseEscrow(action: ProposalAction): action is ReleaseEscrow
   return action.kind === ActionKind.ReleaseEscrow;
 }
 
+export interface Send {
+  readonly kind: ActionKind.Send;
+  readonly sender: Address;
+  readonly recipient: Address;
+  readonly amount: Amount;
+  readonly memo?: string;
+}
+
+export function isSend(action: ProposalAction): action is Send {
+  return action.kind === ActionKind.Send;
+}
+
 export interface SetValidators {
   readonly kind: ActionKind.SetValidators;
   readonly validatorUpdates: Validators;
@@ -195,6 +208,7 @@ export type ProposalAction =
   | CreateTextResolution
   | ExecuteProposalBatch
   | ReleaseEscrow
+  | Send
   | SetValidators
   | UpdateElectorate
   | UpdateElectionRule;

--- a/packages/iov-bns/src/types.ts
+++ b/packages/iov-bns/src/types.ts
@@ -118,6 +118,7 @@ export enum VoteOption {
 
 export enum ActionKind {
   CreateTextResolution = "create_text_resolution",
+  ExecuteProposalBatch = "execute_proposal_batch",
   ReleaseEscrow = "release_escrow ",
   SetValidators = "set_validators",
   UpdateElectionRule = "update_election_rule",
@@ -138,6 +139,15 @@ export interface CreateTextResolution {
 
 export function isCreateTextResolution(action: ProposalAction): action is CreateTextResolution {
   return action.kind === ActionKind.CreateTextResolution;
+}
+
+export interface ExecuteProposalBatch {
+  readonly kind: ActionKind.ExecuteProposalBatch;
+  readonly messages: readonly ProposalAction[];
+}
+
+export function isExecuteProposalBatch(action: ProposalAction): action is ExecuteProposalBatch {
+  return action.kind === ActionKind.ExecuteProposalBatch;
 }
 
 export interface ReleaseEscrow {
@@ -183,6 +193,7 @@ export function isUpdateElectorate(action: ProposalAction): action is UpdateElec
 /** The action to be executed when the proposal is accepted */
 export type ProposalAction =
   | CreateTextResolution
+  | ExecuteProposalBatch
   | ReleaseEscrow
   | SetValidators
   | UpdateElectorate

--- a/packages/iov-bns/src/types.ts
+++ b/packages/iov-bns/src/types.ts
@@ -117,12 +117,12 @@ export enum VoteOption {
 }
 
 export enum ActionKind {
-  CreateTextResolution = "create_text_resolution",
+  CreateTextResolution = "gov_create_text_resolution",
   ExecuteProposalBatch = "execute_proposal_batch",
-  ReleaseEscrow = "release_escrow ",
-  SetValidators = "set_validators",
-  UpdateElectionRule = "update_election_rule",
-  UpdateElectorate = "update_electorate",
+  ReleaseEscrow = "escrow_release",
+  SetValidators = "validators_apply_diff",
+  UpdateElectionRule = "gov_update_election_rule",
+  UpdateElectorate = "gov_update_electorate",
 }
 
 export interface TallyResult {

--- a/packages/iov-bns/types/types.d.ts
+++ b/packages/iov-bns/types/types.d.ts
@@ -85,6 +85,7 @@ export declare enum ActionKind {
     CreateTextResolution = "gov_create_text_resolution",
     ExecuteProposalBatch = "execute_proposal_batch",
     ReleaseEscrow = "escrow_release",
+    Send = "cash_send",
     SetValidators = "validators_apply_diff",
     UpdateElectionRule = "gov_update_election_rule",
     UpdateElectorate = "gov_update_electorate"
@@ -111,6 +112,14 @@ export interface ReleaseEscrow {
     readonly amount: Amount;
 }
 export declare function isReleaseEscrow(action: ProposalAction): action is ReleaseEscrow;
+export interface Send {
+    readonly kind: ActionKind.Send;
+    readonly sender: Address;
+    readonly recipient: Address;
+    readonly amount: Amount;
+    readonly memo?: string;
+}
+export declare function isSend(action: ProposalAction): action is Send;
 export interface SetValidators {
     readonly kind: ActionKind.SetValidators;
     readonly validatorUpdates: Validators;
@@ -130,7 +139,7 @@ export interface UpdateElectorate {
 }
 export declare function isUpdateElectorate(action: ProposalAction): action is UpdateElectorate;
 /** The action to be executed when the proposal is accepted */
-export declare type ProposalAction = CreateTextResolution | ExecuteProposalBatch | ReleaseEscrow | SetValidators | UpdateElectorate | UpdateElectionRule;
+export declare type ProposalAction = CreateTextResolution | ExecuteProposalBatch | ReleaseEscrow | Send | SetValidators | UpdateElectorate | UpdateElectionRule;
 export interface Proposal {
     readonly id: number;
     readonly title: string;

--- a/packages/iov-bns/types/types.d.ts
+++ b/packages/iov-bns/types/types.d.ts
@@ -83,6 +83,7 @@ export declare enum VoteOption {
 }
 export declare enum ActionKind {
     CreateTextResolution = "create_text_resolution",
+    ExecuteProposalBatch = "execute_proposal_batch",
     ReleaseEscrow = "release_escrow ",
     SetValidators = "set_validators",
     UpdateElectionRule = "update_election_rule",
@@ -99,6 +100,11 @@ export interface CreateTextResolution {
     readonly resolution: string;
 }
 export declare function isCreateTextResolution(action: ProposalAction): action is CreateTextResolution;
+export interface ExecuteProposalBatch {
+    readonly kind: ActionKind.ExecuteProposalBatch;
+    readonly messages: readonly ProposalAction[];
+}
+export declare function isExecuteProposalBatch(action: ProposalAction): action is ExecuteProposalBatch;
 export interface ReleaseEscrow {
     readonly kind: ActionKind.ReleaseEscrow;
     readonly escrowId: Uint8Array;
@@ -124,7 +130,7 @@ export interface UpdateElectorate {
 }
 export declare function isUpdateElectorate(action: ProposalAction): action is UpdateElectorate;
 /** The action to be executed when the proposal is accepted */
-export declare type ProposalAction = CreateTextResolution | ReleaseEscrow | SetValidators | UpdateElectorate | UpdateElectionRule;
+export declare type ProposalAction = CreateTextResolution | ExecuteProposalBatch | ReleaseEscrow | SetValidators | UpdateElectorate | UpdateElectionRule;
 export interface Proposal {
     readonly id: number;
     readonly title: string;

--- a/packages/iov-bns/types/types.d.ts
+++ b/packages/iov-bns/types/types.d.ts
@@ -82,12 +82,12 @@ export declare enum VoteOption {
     Abstain = 2
 }
 export declare enum ActionKind {
-    CreateTextResolution = "create_text_resolution",
+    CreateTextResolution = "gov_create_text_resolution",
     ExecuteProposalBatch = "execute_proposal_batch",
-    ReleaseEscrow = "release_escrow ",
-    SetValidators = "set_validators",
-    UpdateElectionRule = "update_election_rule",
-    UpdateElectorate = "update_electorate"
+    ReleaseEscrow = "escrow_release",
+    SetValidators = "validators_apply_diff",
+    UpdateElectionRule = "gov_update_election_rule",
+    UpdateElectorate = "gov_update_electorate"
 }
 export interface TallyResult {
     readonly totalYes: number;


### PR DESCRIPTION
Part of #1112

Some things I'm unclear about:
1. How the funds are actually authorised to be released from the account - is it a special case handled by the backend governance implementation?
1. Once the funds have been divided according to the weightings, what should happen to the remainder? The current approach leaves them in the account.
1. Whether the fee quote can be assumed to be correct when passing an empty array of messages for the batch proposal execution and filling in the messages later. Or in general how the fee works: is it one fee for the whole batch or one per message? Is there even a fee for this particular action?