### PR TITLE
Use "iov-" prefix for IOV's chains

### DIFF
--- a/docs/chain-ids.md
+++ b/docs/chain-ids.md
@@ -43,7 +43,7 @@ request.
 
 | Chain ID             | Description                                                                                                                             | Example                                                                 |
 | -------------------- | --------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
-| `bns-%s`             | A BNS chain by IOV with the network name in `%s`                                                                                        | `bns-hugnet` for the Hugnet testnet                                     |
+| `iov-%s`             | An IOV chain with the network name in `%s`                                                                                              | `iov-lovenet` for the Lovenet testnet                                   |
 | `ethereum-eip155-%d` | An Ethereum chain with the chain ID from [EIP155](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-155.md) in the placeholder `%d` | `ethereum-eip155-1` for Ethereum mainnet, `ethereum-eip155-5` for Görli |
 | `lisk-%s`            | A Lisk chain with a 10 digit prefix of the nethash in `%s`                                                                              | `lisk-da3ed6a454` for the Lisk testnet                                  |
 | `rise-%s`            | A RISE chain with a 10 digit prefix of the nethash in `%s`                                                                              | `rise-296dc9a4d1` for the RISE testnet                                  |

--- a/packages/iov-bns/src/decode.spec.ts
+++ b/packages/iov-bns/src/decode.spec.ts
@@ -70,7 +70,7 @@ describe("Decode", () => {
         },
       ],
     };
-    const decoded = decodeUsernameNft(nft, "bns-testchain" as ChainId);
+    const decoded = decodeUsernameNft(nft, "iov-testchain" as ChainId);
     expect(decoded.id).toEqual("alice");
     expect(decoded.owner).toEqual(Bech32.encode("tiov", fromHex("0e95c039ef14ee329d0e09d84f909cf9eb5ef472")));
     expect(decoded.targets.length).toEqual(1);
@@ -364,7 +364,7 @@ describe("Decode", () => {
     const defaultBaseTx: UnsignedTransaction = {
       kind: "", // this should be overriden by parseMsg
       creator: {
-        chainId: "bns-chain" as ChainId,
+        chainId: "iov-chain" as ChainId,
         pubkey: {
           algo: Algorithm.Ed25519,
           data: fromHex("aabbccdd") as PubkeyBytes,

--- a/packages/iov-multichain/src/jsonrpcsigningserver.spec.ts
+++ b/packages/iov-multichain/src/jsonrpcsigningserver.spec.ts
@@ -52,7 +52,7 @@ async function randomBnsAddress(): Promise<Address> {
 }
 
 const bnsdUrl = "ws://localhost:23456";
-const bnsChainId = "local-bns-devnet";
+const bnsChainId = "local-iov-devnet";
 const bnsdFaucetMnemonic = "degree tackle suggest window test behind mesh extra cover prepare oak script";
 const bnsdFaucetPath = HdPaths.iov(0);
 const ethereumUrl = "http://localhost:8545";

--- a/packages/iov-multichain/src/signingservice.spec.ts
+++ b/packages/iov-multichain/src/signingservice.spec.ts
@@ -88,7 +88,7 @@ function makeSimpleMessagingConnection(
 
 describe("signingservice.worker", () => {
   const bnsdUrl = "ws://localhost:23456";
-  const bnsChainId = "local-bns-devnet";
+  const bnsChainId = "local-iov-devnet";
 
   const signingserviceKarmaUrl = "/base/dist/web/signingservice.worker.js";
   // time to wait until service is initialized and connected to chain

--- a/scripts/bnsd/bnsd_init.sh
+++ b/scripts/bnsd/bnsd_init.sh
@@ -29,7 +29,7 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 APP_STATE=$(<"$SCRIPT_DIR/genesis_app_state.json")
 # shellcheck disable=SC2002
 cat "${BNSD_DIR}/config/genesis.json.orig" \
-  | jq '.chain_id = "local-bns-devnet"' \
+  | jq '.chain_id = "local-iov-devnet"' \
   | jq ". + {\"app_state\" : $APP_STATE}" \
   > "${BNSD_DIR}/config/genesis.json"
 


### PR DESCRIPTION
Closes #1150

The chain ID of real networks is copied 1:1 from the chain ID in Tendermint genesis and will be replaced by `iov-*` starting with the next testnet (https://github.com/iov-one/ops/issues/186)  