### PR TITLE
Add getVotes method to Governor/BnsConnection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.16.2
 
+- @iov/bns: Add `getVotes` by voter address method to `BnsConnection` class.
+- @iov/bns-governance: Add `getVotes` method to `Governor` class.
 - @iov/crypto: Add `EnglishMnemonic.wordlist`.
 
 ## 0.16.1

--- a/packages/iov-bns-governance/src/governor.ts
+++ b/packages/iov-bns-governance/src/governor.ts
@@ -7,6 +7,7 @@ import {
   ElectionRule,
   Electorate,
   Proposal,
+  Vote,
   VoteOption,
   VoteTx,
 } from "@iov/bns";
@@ -79,6 +80,10 @@ export class Governor {
       const electorateId = new BN(electorate.id).toNumber();
       return electorates.some(({ id }) => id === electorateId);
     });
+  }
+
+  public async getVotes(): Promise<readonly Vote[]> {
+    return this.connection.getVotes(this.address);
   }
 
   public async buildCreateProposalTx(options: ProposalOptions): Promise<CreateProposalTx & WithCreator> {

--- a/packages/iov-bns-governance/types/governor.d.ts
+++ b/packages/iov-bns-governance/types/governor.d.ts
@@ -5,6 +5,7 @@ import {
   ElectionRule,
   Electorate,
   Proposal,
+  Vote,
   VoteOption,
   VoteTx,
 } from "@iov/bns";
@@ -26,6 +27,7 @@ export declare class Governor {
   getElectionRules(electorateId: number): Promise<readonly ElectionRule[]>;
   getElectionRuleById(electionRuleId: number): Promise<ElectionRule>;
   getProposals(): Promise<readonly Proposal[]>;
+  getVotes(): Promise<readonly Vote[]>;
   buildCreateProposalTx(options: ProposalOptions): Promise<CreateProposalTx & WithCreator>;
   buildVoteTx(proposalId: number, selection: VoteOption): Promise<VoteTx & WithCreator>;
 }

--- a/packages/iov-bns/src/bnsconnection.ts
+++ b/packages/iov-bns/src/bnsconnection.ts
@@ -1,6 +1,7 @@
 import {
   Account,
   AccountQuery,
+  Address,
   AddressQuery,
   Algorithm,
   Amount,
@@ -62,6 +63,7 @@ import {
   decodeToken,
   decodeUserData,
   decodeUsernameNft,
+  decodeVote,
 } from "./decode";
 import * as codecImpl from "./generated/codecimpl";
 import { bnsSwapQueryTag } from "./tags";
@@ -79,6 +81,7 @@ import {
   Proposal,
   Result,
   Validator,
+  Vote,
 } from "./types";
 import {
   addressPrefix,
@@ -684,6 +687,14 @@ export class BnsConnection implements AtomicSwapConnection {
     const parser = createParser(codecImpl.gov.Proposal, "proposal:");
     const proposals = results.map(parser).map(proposal => decodeProposal(this.prefix, proposal));
     return proposals;
+  }
+
+  public async getVotes(voter: Address): Promise<readonly Vote[]> {
+    const { data } = decodeBnsAddress(voter);
+    const { results } = await this.query("/votes/electors?prefix", data);
+    const parser = createParser(codecImpl.gov.Vote, "vote:");
+    const votes = results.map(parser).map(vote => decodeVote(this.prefix, vote));
+    return votes;
   }
 
   public async getUsernames(query: BnsUsernamesQuery): Promise<readonly BnsUsernameNft[]> {

--- a/packages/iov-bns/src/bnsconnection.ts
+++ b/packages/iov-bns/src/bnsconnection.ts
@@ -81,6 +81,7 @@ import {
   Validator,
 } from "./types";
 import {
+  addressPrefix,
   buildQueryString,
   conditionToAddress,
   decodeBnsAddress,
@@ -227,6 +228,10 @@ export class BnsConnection implements AtomicSwapConnection {
   private readonly context: Context;
   // tslint:disable-next-line: readonly-keyword
   private tokensCache: readonly Token[] | undefined;
+
+  private get prefix(): "iov" | "tiov" {
+    return addressPrefix(this.chainId());
+  }
 
   /**
    * Private constructor to hide package private types from the public interface
@@ -663,21 +668,21 @@ export class BnsConnection implements AtomicSwapConnection {
   public async getElectorates(): Promise<readonly Electorate[]> {
     const results = (await this.query("/electorates?prefix", new Uint8Array([]))).results;
     const parser = createParser(codecImpl.gov.Electorate, "electorate:");
-    const electorates = results.map(parser).map(electorate => decodeElectorate("tiov", electorate));
+    const electorates = results.map(parser).map(electorate => decodeElectorate(this.prefix, electorate));
     return electorates;
   }
 
   public async getElectionRules(): Promise<readonly ElectionRule[]> {
     const results = (await this.query("/electionrules?prefix", new Uint8Array([]))).results;
     const parser = createParser(codecImpl.gov.ElectionRule, "electnrule:");
-    const rules = results.map(parser).map(rule => decodeElectionRule("tiov", rule));
+    const rules = results.map(parser).map(rule => decodeElectionRule(this.prefix, rule));
     return rules;
   }
 
   public async getProposals(): Promise<readonly Proposal[]> {
     const results = (await this.query("/proposals?prefix", new Uint8Array([]))).results;
     const parser = createParser(codecImpl.gov.Proposal, "proposal:");
-    const proposals = results.map(parser).map(rule => decodeProposal("tiov", rule));
+    const proposals = results.map(parser).map(rule => decodeProposal(this.prefix, rule));
     return proposals;
   }
 

--- a/packages/iov-bns/src/bnsconnection.ts
+++ b/packages/iov-bns/src/bnsconnection.ts
@@ -682,7 +682,7 @@ export class BnsConnection implements AtomicSwapConnection {
   public async getProposals(): Promise<readonly Proposal[]> {
     const results = (await this.query("/proposals?prefix", new Uint8Array([]))).results;
     const parser = createParser(codecImpl.gov.Proposal, "proposal:");
-    const proposals = results.map(parser).map(rule => decodeProposal(this.prefix, rule));
+    const proposals = results.map(parser).map(proposal => decodeProposal(this.prefix, proposal));
     return proposals;
   }
 

--- a/packages/iov-bns/src/index.ts
+++ b/packages/iov-bns/src/index.ts
@@ -39,6 +39,7 @@ export {
   VoteOption,
   CreateProposalTx,
   isCreateProposalTx,
+  Vote,
   VoteTx,
   isVoteTx,
   // Proposals

--- a/packages/iov-bns/src/types.ts
+++ b/packages/iov-bns/src/types.ts
@@ -48,6 +48,10 @@ export interface ElectorProperties {
   readonly weight: number;
 }
 
+export interface Elector extends ElectorProperties {
+  readonly address: Address;
+}
+
 /** An unordered map from elector address to remaining properies */
 export interface Electors {
   readonly [index: string]: ElectorProperties;
@@ -239,6 +243,12 @@ export interface Proposal {
   readonly status: ProposalStatus;
   readonly result: ProposalResult;
   readonly executorResult: ProposalExecutorResult;
+}
+
+export interface Vote {
+  readonly proposalId: number;
+  readonly elector: Elector;
+  readonly selection: VoteOption;
 }
 
 // username NFT

--- a/packages/iov-bns/types/bnsconnection.d.ts
+++ b/packages/iov-bns/types/bnsconnection.d.ts
@@ -52,6 +52,7 @@ export declare class BnsConnection implements AtomicSwapConnection {
   private readonly chainData;
   private readonly context;
   private tokensCache;
+  private readonly prefix;
   /**
    * Private constructor to hide package private types from the public interface
    *

--- a/packages/iov-bns/types/bnsconnection.d.ts
+++ b/packages/iov-bns/types/bnsconnection.d.ts
@@ -1,6 +1,7 @@
 import {
   Account,
   AccountQuery,
+  Address,
   AddressQuery,
   Amount,
   AtomicSwap,
@@ -33,6 +34,7 @@ import {
   Proposal,
   Result,
   Validator,
+  Vote,
 } from "./types";
 export interface QueryResponse {
   readonly height?: number;
@@ -114,6 +116,7 @@ export declare class BnsConnection implements AtomicSwapConnection {
   getElectorates(): Promise<readonly Electorate[]>;
   getElectionRules(): Promise<readonly ElectionRule[]>;
   getProposals(): Promise<readonly Proposal[]>;
+  getVotes(voter: Address): Promise<readonly Vote[]>;
   getUsernames(query: BnsUsernamesQuery): Promise<readonly BnsUsernameNft[]>;
   getFeeQuote(transaction: UnsignedTransaction): Promise<Fee>;
   withDefaultFee<T extends UnsignedTransaction>(transaction: T): Promise<T>;

--- a/packages/iov-bns/types/decode.d.ts
+++ b/packages/iov-bns/types/decode.d.ts
@@ -20,6 +20,7 @@ import {
   Participant,
   PrivkeyBundle,
   Proposal,
+  Vote,
 } from "./types";
 /**
  * Decodes a protobuf int field (int32/uint32/int64/uint64) into a JavaScript
@@ -60,5 +61,6 @@ export declare function decodeProposal(
   prefix: "iov" | "tiov",
   proposal: codecImpl.gov.IProposal & Keyed,
 ): Proposal;
+export declare function decodeVote(prefix: "iov" | "tiov", vote: codecImpl.gov.IVote & Keyed): Vote;
 export declare function parseMsg(base: UnsignedTransaction, tx: codecImpl.bnsd.ITx): UnsignedTransaction;
 export declare function parseTx(tx: codecImpl.bnsd.ITx, chainId: ChainId): SignedTransaction;

--- a/packages/iov-bns/types/index.d.ts
+++ b/packages/iov-bns/types/index.d.ts
@@ -36,6 +36,7 @@ export {
   VoteOption,
   CreateProposalTx,
   isCreateProposalTx,
+  Vote,
   VoteTx,
   isVoteTx,
   ProposalAction,

--- a/packages/iov-bns/types/types.d.ts
+++ b/packages/iov-bns/types/types.d.ts
@@ -34,6 +34,9 @@ export interface ElectorProperties {
   /** The voting weight of this elector. Max value is 65535 (2^16-1). */
   readonly weight: number;
 }
+export interface Elector extends ElectorProperties {
+  readonly address: Address;
+}
 /** An unordered map from elector address to remaining properies */
 export interface Electors {
   readonly [index: string]: ElectorProperties;
@@ -185,6 +188,11 @@ export interface Proposal {
   readonly status: ProposalStatus;
   readonly result: ProposalResult;
   readonly executorResult: ProposalExecutorResult;
+}
+export interface Vote {
+  readonly proposalId: number;
+  readonly elector: Elector;
+  readonly selection: VoteOption;
 }
 export interface ChainAddressPair {
   readonly chainId: ChainId;


### PR DESCRIPTION
Closes #1184 

Necessary for https://github.com/iov-one/ponferrada/issues/479

I added a unit test in `bns-governance` but not `bns` because we had more infrastructure there for creating/voting on proposals.