### PR TITLE
Export pubkeyToAddress from @iov/bns 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 0.17.0
 
+- @iov/bns: Export `pubkeyToAddress` for address generation with prefix instead
+  of chain ID.
+
 Breaking changes
 
 - @iov/jsonrpc: Remove deprecated types: `jsonRpcCodeInternalError`,

--- a/packages/iov-bns/src/index.ts
+++ b/packages/iov-bns/src/index.ts
@@ -55,3 +55,4 @@ export {
   BnsTx,
   isBnsTx,
 } from "./types";
+export { pubkeyToAddress } from "./util";

--- a/packages/iov-bns/src/util.spec.ts
+++ b/packages/iov-bns/src/util.spec.ts
@@ -1,7 +1,7 @@
 import { Address, ChainId, TransactionId } from "@iov/bcp";
 import { Encoding } from "@iov/encoding";
 
-import { address, pubJson } from "./testdata.spec";
+import * as testdata from "./testdata.spec";
 import {
   addressPrefix,
   arraysEqual,
@@ -27,8 +27,8 @@ describe("Util", () => {
   });
 
   it("has working identityToAddress", () => {
-    const calculatedAddress = identityToAddress({ chainId: "testnet123" as ChainId, pubkey: pubJson });
-    expect(calculatedAddress).toEqual(address);
+    const address = identityToAddress({ chainId: "testnet123" as ChainId, pubkey: testdata.pubJson });
+    expect(address).toEqual(testdata.address);
   });
 
   it("verify array comparison", () => {

--- a/packages/iov-bns/src/util.spec.ts
+++ b/packages/iov-bns/src/util.spec.ts
@@ -1,4 +1,4 @@
-import { Address, ChainId, TransactionId } from "@iov/bcp";
+import { Address, Algorithm, ChainId, PubkeyBundle, PubkeyBytes, TransactionId } from "@iov/bcp";
 import { Encoding } from "@iov/encoding";
 
 import * as testdata from "./testdata.spec";
@@ -11,6 +11,7 @@ import {
   identityToAddress,
   isHashIdentifier,
   isValidAddress,
+  pubkeyToAddress,
 } from "./util";
 
 const { fromHex, toAscii, toHex, toUtf8 } = Encoding;
@@ -23,6 +24,23 @@ describe("Util", () => {
 
     it("works for mainnet", () => {
       expect(addressPrefix("iov-mainnet" as ChainId)).toEqual("iov");
+    });
+  });
+
+  describe("pubkeyToAddress", () => {
+    it("is compatible to weave test data", () => {
+      const address = pubkeyToAddress(testdata.pubJson, "tiov");
+      expect(address).toEqual(testdata.address);
+    });
+
+    it("throws when pubkey is not Ed25519", () => {
+      const secpPubkey: PubkeyBundle = {
+        algo: Algorithm.Secp256k1,
+        data: fromHex(
+          "044bc2a31265153f07e70e0bab08724e6b85e217f8cd628ceb62974247bb493382ce28cab79ad7119ee1ad3ebcdb98a16805211530ecc6cfefa1b88e6dff99232a",
+        ) as PubkeyBytes,
+      };
+      expect(() => pubkeyToAddress(secpPubkey, "tiov")).toThrowError(/Public key must be Ed25519/i);
     });
   });
 

--- a/packages/iov-bns/src/util.ts
+++ b/packages/iov-bns/src/util.ts
@@ -58,7 +58,8 @@ function keyToIdentifier(key: PubkeyBundle): Uint8Array {
 }
 
 /**
- * Creates an IOV address from a given Ed25519 pubkey and a prefix that represents the network
+ * Creates an IOV address from a given Ed25519 pubkey and
+ * a prefix that represents the network kind (i.e. mainnet or testnet)
  */
 export function pubkeyToAddress(pubkey: PubkeyBundle, prefix: "iov" | "tiov"): Address {
   if (pubkey.algo !== Algorithm.Ed25519) {

--- a/packages/iov-bns/src/util.ts
+++ b/packages/iov-bns/src/util.ts
@@ -57,10 +57,17 @@ function keyToIdentifier(key: PubkeyBundle): Uint8Array {
   return Uint8Array.from([...algoToPrefix(key.algo), ...key.data]);
 }
 
+/**
+ * Creates an IOV address from a given Ed25519 pubkey and a prefix that represents the network
+ */
+export function pubkeyToAddress(pubkey: PubkeyBundle, prefix: "iov" | "tiov"): Address {
+  const bytes = new Sha256(keyToIdentifier(pubkey)).digest().slice(0, 20);
+  return encodeBnsAddress(prefix, bytes);
+}
+
 export function identityToAddress(identity: Identity): Address {
   const prefix = addressPrefix(identity.chainId);
-  const bytes = new Sha256(keyToIdentifier(identity.pubkey)).digest().slice(0, 20);
-  return encodeBnsAddress(prefix, bytes);
+  return pubkeyToAddress(identity.pubkey, prefix);
 }
 
 // TODO: this maps to weave code... maybe we change a bit??

--- a/packages/iov-bns/src/util.ts
+++ b/packages/iov-bns/src/util.ts
@@ -61,6 +61,10 @@ function keyToIdentifier(key: PubkeyBundle): Uint8Array {
  * Creates an IOV address from a given Ed25519 pubkey and a prefix that represents the network
  */
 export function pubkeyToAddress(pubkey: PubkeyBundle, prefix: "iov" | "tiov"): Address {
+  if (pubkey.algo !== Algorithm.Ed25519) {
+    throw new Error("Public key must be Ed25519");
+  }
+
   const bytes = new Sha256(keyToIdentifier(pubkey)).digest().slice(0, 20);
   return encodeBnsAddress(prefix, bytes);
 }

--- a/packages/iov-bns/types/index.d.ts
+++ b/packages/iov-bns/types/index.d.ts
@@ -50,3 +50,4 @@ export {
   BnsTx,
   isBnsTx,
 } from "./types";
+export { pubkeyToAddress } from "./util";

--- a/packages/iov-bns/types/util.d.ts
+++ b/packages/iov-bns/types/util.d.ts
@@ -5,6 +5,7 @@ import {
   Hash,
   Identity,
   Nonce,
+  PubkeyBundle,
   SignableBytes,
   SwapAbortTransaction,
   SwapClaimTransaction,
@@ -26,6 +27,10 @@ export declare function decodeBnsAddress(
   readonly prefix: string;
   readonly data: Uint8Array;
 };
+/**
+ * Creates an IOV address from a given Ed25519 pubkey and a prefix that represents the network
+ */
+export declare function pubkeyToAddress(pubkey: PubkeyBundle, prefix: "iov" | "tiov"): Address;
 export declare function identityToAddress(identity: Identity): Address;
 export declare type Condition = Uint8Array & As<"Condition">;
 export declare function swapCondition(swap: SwapData): Condition;

--- a/packages/iov-bns/types/util.d.ts
+++ b/packages/iov-bns/types/util.d.ts
@@ -28,7 +28,8 @@ export declare function decodeBnsAddress(
   readonly data: Uint8Array;
 };
 /**
- * Creates an IOV address from a given Ed25519 pubkey and a prefix that represents the network
+ * Creates an IOV address from a given Ed25519 pubkey and
+ * a prefix that represents the network kind (i.e. mainnet or testnet)
  */
 export declare function pubkeyToAddress(pubkey: PubkeyBundle, prefix: "iov" | "tiov"): Address;
 export declare function identityToAddress(identity: Identity): Address;


### PR DESCRIPTION
This allows address generation in the IOV Address Generator as well as the Token Finder without using a fake testnet chain ID.