### PR TITLE
Add basic README to jsonrpc package

### DIFF
--- a/packages/iov-jsonrpc/README.md
+++ b/packages/iov-jsonrpc/README.md
@@ -1,0 +1,12 @@
+# @iov/jsonrpc
+
+[![npm version](https://img.shields.io/npm/v/@iov/jsonrpc.svg)](https://www.npmjs.com/package/@iov/jsonrpc)
+
+This package provides a light framework for implementing a [JSON-RPC 2.0 API](https://www.jsonrpc.org/specification).
+
+## License
+
+This package is part of the IOV-Core repository, licensed under the Apache
+License 2.0 (see
+[NOTICE](https://github.com/iov-one/iov-core/blob/master/NOTICE) and
+[LICENSE](https://github.com/iov-one/iov-core/blob/master/LICENSE)).


### PR DESCRIPTION
Closes #1195

I assume we’ll do a more thorough job of filling out documentation before launch, but this will mean that at least the npm page doesn’t say it found no README.