### PR TITLE
Support multisig txs in BNS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.17.1
 
+- @iov/bns: Add `MultisignatureTx` type and `isMultisignatureTx` helper function
+  to BNS.
 - @iov/bns-governance: Add `TreasurySend` proposal type and export
   `TreasurySendOptions`.
 - @iov/bns-governance: Support `TreasurySend` proposals in

--- a/packages/iov-bns/src/encode.spec.ts
+++ b/packages/iov-bns/src/encode.spec.ts
@@ -272,7 +272,7 @@ describe("Encode", () => {
       expect(msg.ref!.length).toEqual(0);
     });
 
-    it("throws for SendTransaction with mismatched sender and creator", () => {
+    it("works for SendTransaction with mismatched sender and creator", () => {
       const transaction: SendTransaction & WithCreator = {
         kind: "bcp/send",
         creator: defaultCreator,
@@ -285,7 +285,14 @@ describe("Encode", () => {
         recipient: defaultRecipient,
         memo: "abc",
       };
-      expect(() => buildMsg(transaction)).toThrowError(/sender and creator do not match/i);
+      const msg = buildMsg(transaction).cashSendMsg!;
+      expect(msg.source).toEqual(fromHex("b1ca7e78f74423ae01da3b51e676934d9105f282"));
+      expect(msg.destination).toEqual(fromHex("b1ca7e78f74423ae01da3b51e676934d9105f282"));
+      expect(msg.memo).toEqual("abc");
+      expect(msg.amount!.whole).toEqual(1);
+      expect(msg.amount!.fractional).toEqual(1);
+      expect(msg.amount!.ticker).toEqual("CASH");
+      expect(msg.ref!.length).toEqual(0);
     });
 
     // Usernames

--- a/packages/iov-bns/src/index.ts
+++ b/packages/iov-bns/src/index.ts
@@ -21,6 +21,8 @@ export {
   isCreateMultisignatureTx,
   UpdateMultisignatureTx,
   isUpdateMultisignatureTx,
+  MultisignatureTx,
+  isMultisignatureTx,
   // Governance
   ValidatorProperties,
   Validators,

--- a/packages/iov-bns/src/integrationtests/multisignature.spec.ts
+++ b/packages/iov-bns/src/integrationtests/multisignature.spec.ts
@@ -1,0 +1,281 @@
+import {
+  Address,
+  Amount,
+  ChainId,
+  Identity,
+  isBlockInfoPending,
+  isBlockInfoSucceeded,
+  SendTransaction,
+  SignedTransaction,
+  TokenTicker,
+  UnsignedTransaction,
+  WithCreator,
+} from "@iov/bcp";
+import { Slip10RawIndex } from "@iov/crypto";
+import { Ed25519HdWallet, HdPaths, UserProfile } from "@iov/keycontrol";
+import BN from "bn.js";
+
+import { bnsCodec } from "../bnscodec";
+import { BnsConnection } from "../bnsconnection";
+import { CreateMultisignatureTx, MultisignatureTx, Participant } from "../types";
+import { conditionToAddress, multisignatureCondition } from "../util";
+
+const CASH = "CASH" as TokenTicker;
+const bnsUrl = "ws://localhost:23456";
+const chainId = "local-iov-devnet" as ChainId;
+// Address: tiov1xwvnaxahzcszkvmk362m7vndjkzumv8ufmzy3m
+const aliceMnemonic = "host century wave huge seed boost success right brave general orphan lion";
+// Address: tiov1qrw95py2x7fzjw25euuqlj6dq6t0jahe7rh8wp
+const bobMnemonic = "dad kiss slogan offer outer bomb usual dream awkward jeans enlist mansion";
+const defaultFeeAmount = 10000000;
+
+async function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function tendermintSearchIndexUpdated(): Promise<void> {
+  // Tendermint needs some time before a committed transaction is found in search
+  return sleep(50);
+}
+
+function pendingWithoutBnsd(): void {
+  if (!process.env.BNSD_ENABLED) {
+    pending("Set BNSD_ENABLED to enable bnsd-based tests");
+  }
+}
+
+interface ActorData {
+  readonly profile: UserProfile;
+  readonly connection: BnsConnection;
+  readonly identity: Identity;
+}
+
+class Actor {
+  public static async create(mnemonic: string, hdPath: readonly Slip10RawIndex[]): Promise<Actor> {
+    const profile = new UserProfile();
+    const wallet = profile.addWallet(Ed25519HdWallet.fromMnemonic(mnemonic));
+
+    const connection = await BnsConnection.establish(bnsUrl);
+
+    const identity = await profile.createIdentity(wallet.id, connection.chainId(), hdPath);
+
+    return new Actor({
+      profile: profile,
+      connection: connection,
+      identity: identity,
+    });
+  }
+
+  public get address(): Address {
+    return bnsCodec.identityToAddress(this.identity);
+  }
+
+  private readonly connection: BnsConnection;
+  private readonly profile: UserProfile;
+  private readonly identity: Identity;
+
+  public constructor(data: ActorData) {
+    this.profile = data.profile;
+    this.connection = data.connection;
+    this.identity = data.identity;
+  }
+
+  public async getBalance(address: Address): Promise<BN> {
+    const account = await this.connection.getAccount({ address: address });
+    const balance = account ? account.balance : [];
+    const amount = balance.find(row => row.tokenTicker === CASH);
+    return new BN(amount ? amount.quantity : 0);
+  }
+
+  public async signTransaction(transaction: UnsignedTransaction): Promise<SignedTransaction> {
+    const nonce = await this.connection.getNonce({ pubkey: this.identity.pubkey });
+    return this.profile.signTransaction(transaction, bnsCodec, nonce);
+  }
+
+  public async appendSignature(signedTransaction: SignedTransaction): Promise<SignedTransaction> {
+    const nonce = await this.connection.getNonce({ pubkey: this.identity.pubkey });
+    return this.profile.appendSignature(this.identity, signedTransaction, bnsCodec, nonce);
+  }
+
+  public async postTransaction(signedTransaction: SignedTransaction): Promise<Uint8Array | undefined> {
+    const txBytes = bnsCodec.bytesToPost(signedTransaction);
+    const post = await this.connection.postTx(txBytes);
+    const blockInfo = await post.blockInfo.waitFor(info => !isBlockInfoPending(info));
+    if (!isBlockInfoSucceeded(blockInfo)) {
+      throw new Error("Transaction failed");
+    }
+    await tendermintSearchIndexUpdated();
+    return blockInfo.result;
+  }
+
+  public async signAndPost(transaction: UnsignedTransaction): Promise<Uint8Array | undefined> {
+    const signed = await this.signTransaction(transaction);
+    return this.postTransaction(signed);
+  }
+
+  public async sendCash(recipient: Address, quantity: string): Promise<Uint8Array | undefined> {
+    const tx = await this.connection.withDefaultFee<SendTransaction & WithCreator>({
+      kind: "bcp/send",
+      creator: this.identity,
+      sender: this.address,
+      recipient: recipient,
+      amount: {
+        quantity: quantity,
+        fractionalDigits: 9,
+        tokenTicker: CASH,
+      },
+    });
+
+    return this.signAndPost(tx);
+  }
+
+  public async createMultisignatureContract(
+    participants: readonly Participant[],
+    activationThreshold: number,
+    adminThreshold: number,
+  ): Promise<Uint8Array> {
+    const tx = await this.connection.withDefaultFee<CreateMultisignatureTx & WithCreator>({
+      kind: "bns/create_multisignature_contract",
+      creator: this.identity,
+      participants: participants,
+      activationThreshold: activationThreshold,
+      adminThreshold: adminThreshold,
+    });
+    const result = await this.signAndPost(tx);
+    if (result === undefined) {
+      throw new Error("Created a multisignature contract but received no ID back");
+    }
+    return result;
+  }
+
+  public async createSendTransaction(
+    multisignatureId: Uint8Array,
+    sender: Address,
+    recipient: Address,
+    amount: Amount,
+  ): Promise<SendTransaction & WithCreator> {
+    return this.connection.withDefaultFee<SendTransaction & WithCreator & MultisignatureTx>({
+      kind: "bcp/send",
+      multisig: [multisignatureId],
+      creator: this.identity,
+      sender: sender,
+      recipient: recipient,
+      amount: amount,
+    });
+  }
+}
+
+describe("Multisignature wallets", () => {
+  it("does not send funds with insufficient signatures", async () => {
+    pendingWithoutBnsd();
+
+    const alice = await Actor.create(aliceMnemonic, HdPaths.iov(0));
+    const bob = await Actor.create(bobMnemonic, HdPaths.iov(0));
+
+    // Create multisignature contract
+    const participants: readonly Participant[] = [
+      {
+        address: alice.address,
+        weight: 1,
+      },
+      {
+        address: bob.address,
+        weight: 1,
+      },
+    ];
+    const activationThreshold = 2;
+    const adminThreshold = 2;
+    const multisignatureId = await alice.createMultisignatureContract(
+      participants,
+      activationThreshold,
+      adminThreshold,
+    );
+
+    const condition = multisignatureCondition(multisignatureId);
+    const multisignatureAddress = conditionToAddress(chainId, condition);
+
+    // Fund multisignature account
+    await alice.sendCash(multisignatureAddress, "1234567890");
+    const multisignatureBalanceBefore = await alice.getBalance(multisignatureAddress);
+
+    // Create send tx
+    const amount = {
+      quantity: "123",
+      fractionalDigits: 9,
+      tokenTicker: CASH,
+    };
+    const sendTx = await alice.createSendTransaction(
+      multisignatureId,
+      multisignatureAddress,
+      alice.address,
+      amount,
+    );
+    try {
+      await alice.signAndPost(sendTx);
+      fail("Expected transaction to fail with insufficient signatures");
+    } catch (err) {
+      expect(err).toMatch(/weight is not enough to activate/i);
+    }
+
+    // Balance should be unchanged
+    const multisignatureBalanceAfter = await alice.getBalance(multisignatureAddress);
+    expect(multisignatureBalanceAfter).toEqual(multisignatureBalanceBefore);
+  });
+
+  it("sends funds with sufficient signatures", async () => {
+    pendingWithoutBnsd();
+
+    const alice = await Actor.create(aliceMnemonic, HdPaths.iov(0));
+    const bob = await Actor.create(bobMnemonic, HdPaths.iov(0));
+
+    // Create multisignature contract
+    const participants: readonly Participant[] = [
+      {
+        address: alice.address,
+        weight: 1,
+      },
+      {
+        address: bob.address,
+        weight: 1,
+      },
+    ];
+    const activationThreshold = 2;
+    const adminThreshold = 2;
+    const multisignatureId = await alice.createMultisignatureContract(
+      participants,
+      activationThreshold,
+      adminThreshold,
+    );
+
+    const condition = multisignatureCondition(multisignatureId);
+    const multisignatureAddress = conditionToAddress(chainId, condition);
+
+    // Fund multisignature account
+    await alice.sendCash(multisignatureAddress, "1234567890");
+    const multisignatureBalanceBefore = await alice.getBalance(multisignatureAddress);
+
+    // Create send tx
+    const amount = {
+      quantity: "123",
+      fractionalDigits: 9,
+      tokenTicker: CASH,
+    };
+    const sendTx = await alice.createSendTransaction(
+      multisignatureId,
+      multisignatureAddress,
+      alice.address,
+      amount,
+    );
+    const signedByAlice = await alice.signTransaction(sendTx);
+    const signedByBob = await bob.appendSignature(signedByAlice);
+
+    await alice.postTransaction(signedByBob);
+
+    // Balance should be updated
+    const multisignatureBalanceAfter = await alice.getBalance(multisignatureAddress);
+    expect(multisignatureBalanceAfter.lt(multisignatureBalanceBefore)).toEqual(true);
+    expect(
+      multisignatureBalanceBefore.sub(multisignatureBalanceAfter).eq(new BN(123 + defaultFeeAmount)),
+    ).toEqual(true);
+  });
+});

--- a/packages/iov-bns/src/types.ts
+++ b/packages/iov-bns/src/types.ts
@@ -15,6 +15,7 @@ import {
   SwapOfferTransaction,
   TimestampTimeout,
 } from "@iov/bcp";
+import { isUint8Array } from "@iov/encoding";
 import { As } from "type-tagger";
 
 // config (those are not used outside of @iov/bns)
@@ -486,4 +487,12 @@ export function isBnsTx(transaction: LightTransaction): transaction is BnsTx {
   }
 
   return transaction.kind.startsWith("bns/");
+}
+
+export interface MultisignatureTx extends LightTransaction {
+  readonly multisig: readonly Uint8Array[];
+}
+
+export function isMultisignatureTx(transaction: LightTransaction): transaction is MultisignatureTx {
+  return Array.isArray((transaction as any).multisig) && (transaction as any).multisig.every(isUint8Array);
 }

--- a/packages/iov-bns/src/util.ts
+++ b/packages/iov-bns/src/util.ts
@@ -102,6 +102,10 @@ export function swapCondition(swap: SwapData): Condition {
   return buildCondition("aswap", "pre_hash", weaveSwapId);
 }
 
+export function multisignatureCondition(multisignatureId: Uint8Array): Condition {
+  return buildCondition("multisig", "usage", multisignatureId);
+}
+
 export function conditionToAddress(chainId: ChainId, cond: Condition): Address {
   const prefix = addressPrefix(chainId);
   const bytes = new Sha256(cond).digest().slice(0, 20);

--- a/packages/iov-bns/src/util.ts
+++ b/packages/iov-bns/src/util.ts
@@ -106,9 +106,13 @@ export function multisignatureCondition(multisignatureId: Uint8Array): Condition
   return buildCondition("multisig", "usage", multisignatureId);
 }
 
+export function conditionToWeaveAddress(cond: Condition): Uint8Array {
+  return new Sha256(cond).digest().slice(0, 20);
+}
+
 export function conditionToAddress(chainId: ChainId, cond: Condition): Address {
   const prefix = addressPrefix(chainId);
-  const bytes = new Sha256(cond).digest().slice(0, 20);
+  const bytes = conditionToWeaveAddress(cond);
   return encodeBnsAddress(prefix, bytes);
 }
 

--- a/packages/iov-bns/types/index.d.ts
+++ b/packages/iov-bns/types/index.d.ts
@@ -19,6 +19,8 @@ export {
   isCreateMultisignatureTx,
   UpdateMultisignatureTx,
   isUpdateMultisignatureTx,
+  MultisignatureTx,
+  isMultisignatureTx,
   ValidatorProperties,
   Validators,
   ActionKind,

--- a/packages/iov-bns/types/types.d.ts
+++ b/packages/iov-bns/types/types.d.ts
@@ -340,3 +340,7 @@ export declare type BnsTx =
   | CreateProposalTx
   | VoteTx;
 export declare function isBnsTx(transaction: LightTransaction): transaction is BnsTx;
+export interface MultisignatureTx extends LightTransaction {
+  readonly multisig: readonly Uint8Array[];
+}
+export declare function isMultisignatureTx(transaction: LightTransaction): transaction is MultisignatureTx;

--- a/packages/iov-bns/types/util.d.ts
+++ b/packages/iov-bns/types/util.d.ts
@@ -37,6 +37,7 @@ export declare function identityToAddress(identity: Identity): Address;
 export declare type Condition = Uint8Array & As<"Condition">;
 export declare function swapCondition(swap: SwapData): Condition;
 export declare function multisignatureCondition(multisignatureId: Uint8Array): Condition;
+export declare function conditionToWeaveAddress(cond: Condition): Uint8Array;
 export declare function conditionToAddress(chainId: ChainId, cond: Condition): Address;
 export declare function isValidAddress(address: string): boolean;
 export declare function appendSignBytes(bz: Uint8Array, chainId: ChainId, nonce: Nonce): SignableBytes;

--- a/packages/iov-bns/types/util.d.ts
+++ b/packages/iov-bns/types/util.d.ts
@@ -36,6 +36,7 @@ export declare function pubkeyToAddress(pubkey: PubkeyBundle, prefix: IovBech32P
 export declare function identityToAddress(identity: Identity): Address;
 export declare type Condition = Uint8Array & As<"Condition">;
 export declare function swapCondition(swap: SwapData): Condition;
+export declare function multisignatureCondition(multisignatureId: Uint8Array): Condition;
 export declare function conditionToAddress(chainId: ChainId, cond: Condition): Address;
 export declare function isValidAddress(address: string): boolean;
 export declare function appendSignBytes(bz: Uint8Array, chainId: ChainId, nonce: Nonce): SignableBytes;


### PR DESCRIPTION
Closes #1119

I'm not clear on the ramifications of my changes to `encode.ts`. I also didn't know who should pay the fee in the event that more than one multisignature contract is referenced (probably quite an unusual situation anyway so we may not even want to support it client-side).