### PR TITLE
Add missing decode tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 - @iov/bns: Validate pubkey length when encoding.
 - @iov/bns: Export escrow transaction types.
 - @iov/bns: Export proposal action checkers.
+- @iov/bns: Fixed a bug where memo fields of swap offer transactions were not
+  parsed during decoding.
 - @iov/bns-governance: `Governor.getElectionRules` now returns an empty array
   instead of throwing if no election rules are found.
 

--- a/packages/iov-bns/src/decode.spec.ts
+++ b/packages/iov-bns/src/decode.spec.ts
@@ -523,6 +523,7 @@ describe("Decode", () => {
               ticker: "CASH",
             },
           ],
+          memo: "some memo",
         },
       };
       const parsed = parseMsg(defaultBaseTx, transactionMessage);
@@ -533,6 +534,7 @@ describe("Decode", () => {
       expect(parsed.recipient).toEqual(defaultRecipient);
       expect(parsed.timeout).toEqual(defaultTimeout);
       expect(parsed.hash).toEqual(defaultHash);
+      expect(parsed.memo).toEqual("some memo");
     });
 
     it("works for SwapClaimTransaction", () => {

--- a/packages/iov-bns/src/decode.spec.ts
+++ b/packages/iov-bns/src/decode.spec.ts
@@ -3,9 +3,15 @@ import {
   Algorithm,
   Amount,
   ChainId,
+  Hash,
   isSendTransaction,
+  isSwapAbortTransaction,
+  isSwapClaimTransaction,
+  isSwapOfferTransaction,
   Nonce,
+  Preimage,
   PubkeyBytes,
+  SwapIdBytes,
   TokenTicker,
   UnsignedTransaction,
 } from "@iov/bcp";
@@ -467,6 +473,14 @@ describe("Decode", () => {
       fractionalDigits: 9,
       tokenTicker: "CASH" as TokenTicker,
     };
+    const defaultSwapId = {
+      data: fromHex("aabbccdd") as SwapIdBytes,
+    };
+    const defaultPreimage = fromHex("22334455") as Preimage;
+    const defaultHash = fromHex("0033669900336699003366990033669900336699003366990033669900336699") as Hash;
+    const defaultTimeout = {
+      timestamp: 1568814406426,
+    };
 
     // Token sends
 
@@ -495,7 +509,59 @@ describe("Decode", () => {
 
     // Atomic swaps
 
-    // TODO: add missing tests here
+    it("works for SwapOfferTransaction", () => {
+      const transactionMessage: codecImpl.bnsd.ITx = {
+        aswapCreateMsg: {
+          source: fromHex("6e1114f57410d8e7bcd910a568c9196efc1479e4"),
+          destination: fromHex("b1ca7e78f74423ae01da3b51e676934d9105f282"),
+          preimageHash: defaultHash,
+          timeout: defaultTimeout.timestamp,
+          amount: [
+            {
+              whole: 1,
+              fractional: 1,
+              ticker: "CASH",
+            },
+          ],
+        },
+      };
+      const parsed = parseMsg(defaultBaseTx, transactionMessage);
+      if (!isSwapOfferTransaction(parsed)) {
+        throw new Error("unexpected transaction kind");
+      }
+      expect(parsed.amounts).toEqual([defaultAmount]);
+      expect(parsed.recipient).toEqual(defaultRecipient);
+      expect(parsed.timeout).toEqual(defaultTimeout);
+      expect(parsed.hash).toEqual(defaultHash);
+    });
+
+    it("works for SwapClaimTransaction", () => {
+      const transactionMessage: codecImpl.bnsd.ITx = {
+        aswapReleaseMsg: {
+          swapId: defaultSwapId.data,
+          preimage: defaultPreimage,
+        },
+      };
+      const parsed = parseMsg(defaultBaseTx, transactionMessage);
+      if (!isSwapClaimTransaction(parsed)) {
+        throw new Error("unexpected transaction kind");
+      }
+      expect(parsed.preimage).toEqual(defaultPreimage);
+      expect(parsed.swapId).toEqual(defaultSwapId);
+    });
+
+    it("works for SwapAbortTransaction", () => {
+      const transactionMessage: codecImpl.bnsd.ITx = {
+        aswapReturnMsg: {
+          swapId: defaultSwapId.data,
+        },
+      };
+      const parsed = parseMsg(defaultBaseTx, transactionMessage);
+      if (!isSwapAbortTransaction(parsed)) {
+        throw new Error("unexpected transaction kind");
+      }
+      expect(parsed.swapId).toEqual(defaultSwapId);
+    });
 
     // Usernames
 

--- a/packages/iov-bns/src/decode.spec.ts
+++ b/packages/iov-bns/src/decode.spec.ts
@@ -470,7 +470,28 @@ describe("Decode", () => {
 
     // Token sends
 
-    // TODO: add missing tests here
+    it("works for SendTransaction", () => {
+      const transactionMessage: codecImpl.bnsd.ITx = {
+        cashSendMsg: {
+          source: fromHex("6e1114f57410d8e7bcd910a568c9196efc1479e4"),
+          destination: fromHex("b1ca7e78f74423ae01da3b51e676934d9105f282"),
+          amount: {
+            whole: 1,
+            fractional: 1,
+            ticker: "CASH",
+          },
+          memo: "some memo",
+        },
+      };
+      const parsed = parseMsg(defaultBaseTx, transactionMessage);
+      if (!isSendTransaction(parsed)) {
+        throw new Error("unexpected transaction kind");
+      }
+      expect(parsed.amount).toEqual(defaultAmount);
+      expect(parsed.sender).toEqual(defaultSender);
+      expect(parsed.recipient).toEqual(defaultRecipient);
+      expect(parsed.memo).toEqual("some memo");
+    });
 
     // Atomic swaps
 

--- a/packages/iov-bns/src/decode.ts
+++ b/packages/iov-bns/src/decode.ts
@@ -490,14 +490,15 @@ function parseSwapOfferTx(
     throw new Error("Hash must be 32 bytes (sha256)");
   }
   const prefix = addressPrefix(base.creator.chainId);
-  return {
+  const parsed = {
     ...base,
-    kind: "bcp/swap_offer",
+    kind: "bcp/swap_offer" as const,
     hash: hash as Hash,
     recipient: encodeBnsAddress(prefix, ensure(msg.destination, "destination")),
     timeout: { timestamp: asIntegerNumber(ensure(msg.timeout, "timeout")) },
     amounts: (msg.amount || []).map(decodeAmount),
   };
+  return msg.memo ? { ...parsed, memo: msg.memo } : parsed;
 }
 
 function parseSwapClaimTx(


### PR DESCRIPTION
Closes #1217

Also fixes a bug in `parseSwapOfferTx` which did not previously parse the memo field.