### PR TITLE
Add Decimal class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
   parsed during decoding.
 - @iov/bns-governance: `Governor.getElectionRules` now returns an empty array
   instead of throwing if no election rules are found.
+- @iov/encoding: Add `Decimal` class.
 
 ## 0.17.6
 

--- a/packages/iov-encoding/src/decimal.spec.ts
+++ b/packages/iov-encoding/src/decimal.spec.ts
@@ -85,6 +85,12 @@ describe("Decimal", () => {
       expect(Decimal.fromUserInput("", 2).atomics).toEqual("0");
       expect(Decimal.fromUserInput("", 3).atomics).toEqual("0");
     });
+
+    it("accepts american notation with skipped leading zero", () => {
+      expect(Decimal.fromUserInput(".1", 3).atomics).toEqual("100");
+      expect(Decimal.fromUserInput(".12", 3).atomics).toEqual("120");
+      expect(Decimal.fromUserInput(".123", 3).atomics).toEqual("123");
+    });
   });
 
   describe("toString", () => {

--- a/packages/iov-encoding/src/decimal.spec.ts
+++ b/packages/iov-encoding/src/decimal.spec.ts
@@ -13,6 +13,11 @@ describe("Decimal", () => {
     it("throws for more than one separators", () => {
       expect(() => Decimal.fromUserInput("1.3.5", 5)).toThrowError(/more than one separator found/i);
       expect(() => Decimal.fromUserInput("1..3", 5)).toThrowError(/more than one separator found/i);
+      expect(() => Decimal.fromUserInput("..", 5)).toThrowError(/more than one separator found/i);
+    });
+
+    it("throws for separator only", () => {
+      expect(() => Decimal.fromUserInput(".", 5)).toThrowError(/fractional part missing/i);
     });
 
     it("throws for more fractional digits than supported", () => {

--- a/packages/iov-encoding/src/decimal.spec.ts
+++ b/packages/iov-encoding/src/decimal.spec.ts
@@ -1,0 +1,89 @@
+import { Decimal } from "./decimal";
+
+describe("Decimal", () => {
+  describe("fromUserInput", () => {
+    it("throws helpful error message for invalid characters", () => {
+      expect(() => Decimal.fromUserInput(" 13", 5)).toThrowError(/invalid character at position 1/i);
+      expect(() => Decimal.fromUserInput("1,3", 5)).toThrowError(/invalid character at position 2/i);
+      expect(() => Decimal.fromUserInput("13-", 5)).toThrowError(/invalid character at position 3/i);
+      expect(() => Decimal.fromUserInput("13/", 5)).toThrowError(/invalid character at position 3/i);
+      expect(() => Decimal.fromUserInput("13\\", 5)).toThrowError(/invalid character at position 3/i);
+    });
+
+    it("throws for more than one separators", () => {
+      expect(() => Decimal.fromUserInput("1.3.5", 5)).toThrowError(/more than one separator found/i);
+      expect(() => Decimal.fromUserInput("1..3", 5)).toThrowError(/more than one separator found/i);
+    });
+
+    it("throws for more fractional digits than supported", () => {
+      expect(() => Decimal.fromUserInput("44.123456", 5)).toThrowError(
+        /got more fractional digits than supported/i,
+      );
+      expect(() => Decimal.fromUserInput("44.1", 0)).toThrowError(
+        /got more fractional digits than supported/i,
+      );
+    });
+
+    it("throws for fractional digits that are not non-negative integers", () => {
+      // no integer
+      expect(() => Decimal.fromUserInput("1", Number.NaN)).toThrowError(
+        /fractional digits is not an integer/i,
+      );
+      expect(() => Decimal.fromUserInput("1", Number.POSITIVE_INFINITY)).toThrowError(
+        /fractional digits is not an integer/i,
+      );
+      expect(() => Decimal.fromUserInput("1", Number.NEGATIVE_INFINITY)).toThrowError(
+        /fractional digits is not an integer/i,
+      );
+      expect(() => Decimal.fromUserInput("1", 1.78945544484)).toThrowError(
+        /fractional digits is not an integer/i,
+      );
+
+      // negative
+      expect(() => Decimal.fromUserInput("1", -1)).toThrowError(/fractional digits must not be negative/i);
+      expect(() => Decimal.fromUserInput("1", Number.MIN_SAFE_INTEGER)).toThrowError(
+        /fractional digits must not be negative/i,
+      );
+    });
+
+    it("returns correct value", () => {
+      expect(Decimal.fromUserInput("44", 0).getQuantity()).toEqual("44");
+      expect(Decimal.fromUserInput("44", 1).getQuantity()).toEqual("440");
+      expect(Decimal.fromUserInput("44", 2).getQuantity()).toEqual("4400");
+      expect(Decimal.fromUserInput("44", 3).getQuantity()).toEqual("44000");
+
+      expect(Decimal.fromUserInput("44.2", 1).getQuantity()).toEqual("442");
+      expect(Decimal.fromUserInput("44.2", 2).getQuantity()).toEqual("4420");
+      expect(Decimal.fromUserInput("44.2", 3).getQuantity()).toEqual("44200");
+
+      expect(Decimal.fromUserInput("44.1", 6).getQuantity()).toEqual("44100000");
+      expect(Decimal.fromUserInput("44.12", 6).getQuantity()).toEqual("44120000");
+      expect(Decimal.fromUserInput("44.123", 6).getQuantity()).toEqual("44123000");
+      expect(Decimal.fromUserInput("44.1234", 6).getQuantity()).toEqual("44123400");
+      expect(Decimal.fromUserInput("44.12345", 6).getQuantity()).toEqual("44123450");
+      expect(Decimal.fromUserInput("44.123456", 6).getQuantity()).toEqual("44123456");
+    });
+
+    it("cuts leading zeros", () => {
+      expect(Decimal.fromUserInput("4", 2).getQuantity()).toEqual("400");
+      expect(Decimal.fromUserInput("04", 2).getQuantity()).toEqual("400");
+      expect(Decimal.fromUserInput("004", 2).getQuantity()).toEqual("400");
+    });
+
+    it("cuts tailing zeros", () => {
+      expect(Decimal.fromUserInput("4.12", 5).getQuantity()).toEqual("412000");
+      expect(Decimal.fromUserInput("4.120", 5).getQuantity()).toEqual("412000");
+      expect(Decimal.fromUserInput("4.1200", 5).getQuantity()).toEqual("412000");
+      expect(Decimal.fromUserInput("4.12000", 5).getQuantity()).toEqual("412000");
+      expect(Decimal.fromUserInput("4.120000", 5).getQuantity()).toEqual("412000");
+      expect(Decimal.fromUserInput("4.1200000", 5).getQuantity()).toEqual("412000");
+    });
+
+    it("interpretes the empty string as zero", () => {
+      expect(Decimal.fromUserInput("", 0).getQuantity()).toEqual("0");
+      expect(Decimal.fromUserInput("", 1).getQuantity()).toEqual("0");
+      expect(Decimal.fromUserInput("", 2).getQuantity()).toEqual("0");
+      expect(Decimal.fromUserInput("", 3).getQuantity()).toEqual("0");
+    });
+  });
+});

--- a/packages/iov-encoding/src/decimal.spec.ts
+++ b/packages/iov-encoding/src/decimal.spec.ts
@@ -86,4 +86,30 @@ describe("Decimal", () => {
       expect(Decimal.fromUserInput("", 3).atomics).toEqual("0");
     });
   });
+
+  describe("toString", () => {
+    it("displays no decimal point for full numbers", () => {
+      expect(Decimal.fromUserInput("44", 0).toString()).toEqual("44");
+      expect(Decimal.fromUserInput("44", 1).toString()).toEqual("44");
+      expect(Decimal.fromUserInput("44", 2).toString()).toEqual("44");
+
+      expect(Decimal.fromUserInput("44", 2).toString()).toEqual("44");
+      expect(Decimal.fromUserInput("44.0", 2).toString()).toEqual("44");
+      expect(Decimal.fromUserInput("44.00", 2).toString()).toEqual("44");
+      expect(Decimal.fromUserInput("44.000", 2).toString()).toEqual("44");
+    });
+
+    it("only shows significant digits", () => {
+      expect(Decimal.fromUserInput("44.1", 2).toString()).toEqual("44.1");
+      expect(Decimal.fromUserInput("44.10", 2).toString()).toEqual("44.1");
+      expect(Decimal.fromUserInput("44.100", 2).toString()).toEqual("44.1");
+    });
+
+    it("fills up leading zeros", () => {
+      expect(Decimal.fromAtomics("3", 0).toString()).toEqual("3");
+      expect(Decimal.fromAtomics("3", 1).toString()).toEqual("0.3");
+      expect(Decimal.fromAtomics("3", 2).toString()).toEqual("0.03");
+      expect(Decimal.fromAtomics("3", 3).toString()).toEqual("0.003");
+    });
+  });
 });

--- a/packages/iov-encoding/src/decimal.spec.ts
+++ b/packages/iov-encoding/src/decimal.spec.ts
@@ -10,7 +10,7 @@ describe("Decimal", () => {
       expect(() => Decimal.fromUserInput("13\\", 5)).toThrowError(/invalid character at position 3/i);
     });
 
-    it("throws for more than one separators", () => {
+    it("throws for more than one separator", () => {
       expect(() => Decimal.fromUserInput("1.3.5", 5)).toThrowError(/more than one separator found/i);
       expect(() => Decimal.fromUserInput("1..3", 5)).toThrowError(/more than one separator found/i);
       expect(() => Decimal.fromUserInput("..", 5)).toThrowError(/more than one separator found/i);
@@ -84,7 +84,7 @@ describe("Decimal", () => {
       expect(Decimal.fromUserInput("4.1200000", 5).atomics).toEqual("412000");
     });
 
-    it("interpretes the empty string as zero", () => {
+    it("interprets the empty string as zero", () => {
       expect(Decimal.fromUserInput("", 0).atomics).toEqual("0");
       expect(Decimal.fromUserInput("", 1).atomics).toEqual("0");
       expect(Decimal.fromUserInput("", 2).atomics).toEqual("0");

--- a/packages/iov-encoding/src/decimal.spec.ts
+++ b/packages/iov-encoding/src/decimal.spec.ts
@@ -1,6 +1,37 @@
 import { Decimal } from "./decimal";
 
 describe("Decimal", () => {
+  describe("fromAtomics", () => {
+    it("leads to correct atomics value", () => {
+      expect(Decimal.fromAtomics("1", 0).atomics).toEqual("1");
+      expect(Decimal.fromAtomics("1", 1).atomics).toEqual("1");
+      expect(Decimal.fromAtomics("1", 2).atomics).toEqual("1");
+
+      expect(Decimal.fromAtomics("1", 5).atomics).toEqual("1");
+      expect(Decimal.fromAtomics("2", 5).atomics).toEqual("2");
+      expect(Decimal.fromAtomics("3", 5).atomics).toEqual("3");
+      expect(Decimal.fromAtomics("10", 5).atomics).toEqual("10");
+      expect(Decimal.fromAtomics("20", 5).atomics).toEqual("20");
+      expect(Decimal.fromAtomics("30", 5).atomics).toEqual("30");
+      expect(Decimal.fromAtomics("100000000000000000000000", 5).atomics).toEqual("100000000000000000000000");
+      expect(Decimal.fromAtomics("200000000000000000000000", 5).atomics).toEqual("200000000000000000000000");
+      expect(Decimal.fromAtomics("300000000000000000000000", 5).atomics).toEqual("300000000000000000000000");
+
+      expect(Decimal.fromAtomics("44", 5).atomics).toEqual("44");
+      expect(Decimal.fromAtomics("044", 5).atomics).toEqual("44");
+      expect(Decimal.fromAtomics("0044", 5).atomics).toEqual("44");
+      expect(Decimal.fromAtomics("00044", 5).atomics).toEqual("44");
+    });
+
+    it("reads fractional digits correctly", () => {
+      expect(Decimal.fromAtomics("44", 0).toString()).toEqual("44");
+      expect(Decimal.fromAtomics("44", 1).toString()).toEqual("4.4");
+      expect(Decimal.fromAtomics("44", 2).toString()).toEqual("0.44");
+      expect(Decimal.fromAtomics("44", 3).toString()).toEqual("0.044");
+      expect(Decimal.fromAtomics("44", 4).toString()).toEqual("0.0044");
+    });
+  });
+
   describe("fromUserInput", () => {
     it("throws helpful error message for invalid characters", () => {
       expect(() => Decimal.fromUserInput(" 13", 5)).toThrowError(/invalid character at position 1/i);

--- a/packages/iov-encoding/src/decimal.spec.ts
+++ b/packages/iov-encoding/src/decimal.spec.ts
@@ -47,43 +47,43 @@ describe("Decimal", () => {
     });
 
     it("returns correct value", () => {
-      expect(Decimal.fromUserInput("44", 0).getQuantity()).toEqual("44");
-      expect(Decimal.fromUserInput("44", 1).getQuantity()).toEqual("440");
-      expect(Decimal.fromUserInput("44", 2).getQuantity()).toEqual("4400");
-      expect(Decimal.fromUserInput("44", 3).getQuantity()).toEqual("44000");
+      expect(Decimal.fromUserInput("44", 0).atomics).toEqual("44");
+      expect(Decimal.fromUserInput("44", 1).atomics).toEqual("440");
+      expect(Decimal.fromUserInput("44", 2).atomics).toEqual("4400");
+      expect(Decimal.fromUserInput("44", 3).atomics).toEqual("44000");
 
-      expect(Decimal.fromUserInput("44.2", 1).getQuantity()).toEqual("442");
-      expect(Decimal.fromUserInput("44.2", 2).getQuantity()).toEqual("4420");
-      expect(Decimal.fromUserInput("44.2", 3).getQuantity()).toEqual("44200");
+      expect(Decimal.fromUserInput("44.2", 1).atomics).toEqual("442");
+      expect(Decimal.fromUserInput("44.2", 2).atomics).toEqual("4420");
+      expect(Decimal.fromUserInput("44.2", 3).atomics).toEqual("44200");
 
-      expect(Decimal.fromUserInput("44.1", 6).getQuantity()).toEqual("44100000");
-      expect(Decimal.fromUserInput("44.12", 6).getQuantity()).toEqual("44120000");
-      expect(Decimal.fromUserInput("44.123", 6).getQuantity()).toEqual("44123000");
-      expect(Decimal.fromUserInput("44.1234", 6).getQuantity()).toEqual("44123400");
-      expect(Decimal.fromUserInput("44.12345", 6).getQuantity()).toEqual("44123450");
-      expect(Decimal.fromUserInput("44.123456", 6).getQuantity()).toEqual("44123456");
+      expect(Decimal.fromUserInput("44.1", 6).atomics).toEqual("44100000");
+      expect(Decimal.fromUserInput("44.12", 6).atomics).toEqual("44120000");
+      expect(Decimal.fromUserInput("44.123", 6).atomics).toEqual("44123000");
+      expect(Decimal.fromUserInput("44.1234", 6).atomics).toEqual("44123400");
+      expect(Decimal.fromUserInput("44.12345", 6).atomics).toEqual("44123450");
+      expect(Decimal.fromUserInput("44.123456", 6).atomics).toEqual("44123456");
     });
 
     it("cuts leading zeros", () => {
-      expect(Decimal.fromUserInput("4", 2).getQuantity()).toEqual("400");
-      expect(Decimal.fromUserInput("04", 2).getQuantity()).toEqual("400");
-      expect(Decimal.fromUserInput("004", 2).getQuantity()).toEqual("400");
+      expect(Decimal.fromUserInput("4", 2).atomics).toEqual("400");
+      expect(Decimal.fromUserInput("04", 2).atomics).toEqual("400");
+      expect(Decimal.fromUserInput("004", 2).atomics).toEqual("400");
     });
 
     it("cuts tailing zeros", () => {
-      expect(Decimal.fromUserInput("4.12", 5).getQuantity()).toEqual("412000");
-      expect(Decimal.fromUserInput("4.120", 5).getQuantity()).toEqual("412000");
-      expect(Decimal.fromUserInput("4.1200", 5).getQuantity()).toEqual("412000");
-      expect(Decimal.fromUserInput("4.12000", 5).getQuantity()).toEqual("412000");
-      expect(Decimal.fromUserInput("4.120000", 5).getQuantity()).toEqual("412000");
-      expect(Decimal.fromUserInput("4.1200000", 5).getQuantity()).toEqual("412000");
+      expect(Decimal.fromUserInput("4.12", 5).atomics).toEqual("412000");
+      expect(Decimal.fromUserInput("4.120", 5).atomics).toEqual("412000");
+      expect(Decimal.fromUserInput("4.1200", 5).atomics).toEqual("412000");
+      expect(Decimal.fromUserInput("4.12000", 5).atomics).toEqual("412000");
+      expect(Decimal.fromUserInput("4.120000", 5).atomics).toEqual("412000");
+      expect(Decimal.fromUserInput("4.1200000", 5).atomics).toEqual("412000");
     });
 
     it("interpretes the empty string as zero", () => {
-      expect(Decimal.fromUserInput("", 0).getQuantity()).toEqual("0");
-      expect(Decimal.fromUserInput("", 1).getQuantity()).toEqual("0");
-      expect(Decimal.fromUserInput("", 2).getQuantity()).toEqual("0");
-      expect(Decimal.fromUserInput("", 3).getQuantity()).toEqual("0");
+      expect(Decimal.fromUserInput("", 0).atomics).toEqual("0");
+      expect(Decimal.fromUserInput("", 1).atomics).toEqual("0");
+      expect(Decimal.fromUserInput("", 2).atomics).toEqual("0");
+      expect(Decimal.fromUserInput("", 3).atomics).toEqual("0");
     });
   });
 });

--- a/packages/iov-encoding/src/decimal.ts
+++ b/packages/iov-encoding/src/decimal.ts
@@ -16,11 +16,28 @@ export class Decimal {
       }
     }
 
-    const parts = input.split(".");
-    if (parts.length > 2) throw new Error("More than one separator found");
+    let whole: string;
+    let fractional: string;
 
-    const whole = parts[0] || "";
-    const fractional = (parts[1] || "").replace(/0+$/, "");
+    if (input.search(/\./) === -1) {
+      // integer format, no separator
+      whole = input;
+      fractional = "";
+    } else {
+      const parts = input.split(".");
+      switch (parts.length) {
+        case 0:
+        case 1:
+          throw new Error("Less than two elements in split result. This must not happen here.");
+        case 2:
+          if (!parts[1]) throw new Error("Fractional part missing");
+          whole = parts[0];
+          fractional = parts[1].replace(/0+$/, "");
+          break;
+        default:
+          throw new Error("More than one separator found");
+      }
+    }
 
     if (fractional.length > fractionalDigits) {
       throw new Error("Got more fractional digits than supported");

--- a/packages/iov-encoding/src/decimal.ts
+++ b/packages/iov-encoding/src/decimal.ts
@@ -7,8 +7,7 @@ import BN from "bn.js";
  */
 export class Decimal {
   public static fromUserInput(input: string, fractionalDigits: number): Decimal {
-    if (!Number.isInteger(fractionalDigits)) throw new Error("Fractional digits is not an integer");
-    if (fractionalDigits < 0) throw new Error("Fractional digits must not be negative");
+    Decimal.verifyFractionalDigits(fractionalDigits);
 
     const badCharacter = input.match(/[^0-9.]/);
     if (badCharacter) {
@@ -49,9 +48,13 @@ export class Decimal {
   }
 
   public static fromAtomics(atomics: string, fractionalDigits: number): Decimal {
+    Decimal.verifyFractionalDigits(fractionalDigits);
+    return new Decimal(atomics, fractionalDigits);
+  }
+
+  private static verifyFractionalDigits(fractionalDigits: number): void {
     if (!Number.isInteger(fractionalDigits)) throw new Error("Fractional digits is not an integer");
     if (fractionalDigits < 0) throw new Error("Fractional digits must not be negative");
-    return new Decimal(atomics, fractionalDigits);
   }
 
   public get atomics(): string {

--- a/packages/iov-encoding/src/decimal.ts
+++ b/packages/iov-encoding/src/decimal.ts
@@ -31,6 +31,12 @@ export class Decimal {
     return new Decimal(quantity, fractionalDigits);
   }
 
+  public static fromAtomics(atomics: string, fractionalDigits: number): Decimal {
+    if (!Number.isInteger(fractionalDigits)) throw new Error("Fractional digits is not an integer");
+    if (fractionalDigits < 0) throw new Error("Fractional digits must not be negative");
+    return new Decimal(atomics, fractionalDigits);
+  }
+
   public get atomics(): string {
     return this.data.atomics.toString();
   }
@@ -45,5 +51,19 @@ export class Decimal {
       atomics: new BN(atomics),
       fractionalDigits: fractionalDigits,
     };
+  }
+
+  public toString(): string {
+    const factor = new BN(10).pow(new BN(this.data.fractionalDigits));
+    const whole = this.data.atomics.div(factor);
+    const fractional = this.data.atomics.mod(factor);
+
+    if (fractional.isZero()) {
+      return whole.toString();
+    } else {
+      const fullFractionalPart = fractional.toString().padStart(this.data.fractionalDigits, "0");
+      const trimmedFractionalPart = fullFractionalPart.replace(/0+$/, "");
+      return `${whole.toString()}.${trimmedFractionalPart}`;
+    }
   }
 }

--- a/packages/iov-encoding/src/decimal.ts
+++ b/packages/iov-encoding/src/decimal.ts
@@ -31,15 +31,19 @@ export class Decimal {
     return new Decimal(quantity, fractionalDigits);
   }
 
-  private readonly quantity: BN;
-  private readonly fractionalDigits: number;
-
-  private constructor(quantity: string, fractionalDigits: number) {
-    this.quantity = new BN(quantity);
-    this.fractionalDigits = fractionalDigits;
+  public get atomics(): string {
+    return this.data.atomics.toString();
   }
 
-  public getQuantity(): string {
-    return this.quantity.toString();
+  private readonly data: {
+    readonly atomics: BN;
+    readonly fractionalDigits: number;
+  };
+
+  private constructor(atomics: string, fractionalDigits: number) {
+    this.data = {
+      atomics: new BN(atomics),
+      fractionalDigits: fractionalDigits,
+    };
   }
 }

--- a/packages/iov-encoding/src/decimal.ts
+++ b/packages/iov-encoding/src/decimal.ts
@@ -10,10 +10,10 @@ export class Decimal {
     if (!Number.isInteger(fractionalDigits)) throw new Error("Fractional digits is not an integer");
     if (fractionalDigits < 0) throw new Error("Fractional digits must not be negative");
 
-    for (let index = 0; index < input.length; index++) {
-      if (!input[index].match(/^[0-9.]$/)) {
-        throw new Error(`Invalid character at position ${index + 1}`);
-      }
+    const badCharacter = input.match(/[^0-9.]/);
+    if (badCharacter) {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      throw new Error(`Invalid character at position ${badCharacter.index! + 1}`);
     }
 
     let whole: string;

--- a/packages/iov-encoding/src/decimal.ts
+++ b/packages/iov-encoding/src/decimal.ts
@@ -28,7 +28,7 @@ export class Decimal {
       switch (parts.length) {
         case 0:
         case 1:
-          throw new Error("Less than two elements in split result. This must not happen here.");
+          throw new Error("Fewer than two elements in split result. This must not happen here.");
         case 2:
           if (!parts[1]) throw new Error("Fractional part missing");
           whole = parts[0];

--- a/packages/iov-encoding/src/decimal.ts
+++ b/packages/iov-encoding/src/decimal.ts
@@ -1,0 +1,45 @@
+import BN from "bn.js";
+
+/**
+ * A type for arbitrary precision, non-negative decimals.
+ *
+ * Instances of this class are immutable.
+ */
+export class Decimal {
+  public static fromUserInput(input: string, fractionalDigits: number): Decimal {
+    if (!Number.isInteger(fractionalDigits)) throw new Error("Fractional digits is not an integer");
+    if (fractionalDigits < 0) throw new Error("Fractional digits must not be negative");
+
+    for (let index = 0; index < input.length; index++) {
+      if (!input[index].match(/^[0-9.]$/)) {
+        throw new Error(`Invalid character at position ${index + 1}`);
+      }
+    }
+
+    const parts = input.split(".");
+    if (parts.length > 2) throw new Error("More than one separator found");
+
+    const whole = parts[0] || "";
+    const fractional = (parts[1] || "").replace(/0+$/, "");
+
+    if (fractional.length > fractionalDigits) {
+      throw new Error("Got more fractional digits than supported");
+    }
+
+    const quantity = `${whole}${fractional.padEnd(fractionalDigits, "0")}`;
+
+    return new Decimal(quantity, fractionalDigits);
+  }
+
+  private readonly quantity: BN;
+  private readonly fractionalDigits: number;
+
+  private constructor(quantity: string, fractionalDigits: number) {
+    this.quantity = new BN(quantity);
+    this.fractionalDigits = fractionalDigits;
+  }
+
+  public getQuantity(): string {
+    return this.quantity.toString();
+  }
+}

--- a/packages/iov-encoding/src/index.ts
+++ b/packages/iov-encoding/src/index.ts
@@ -1,4 +1,5 @@
 export { Bech32 } from "./bech32";
+export { Decimal } from "./decimal";
 export { Encoding } from "./encoding";
 export { Int53, Uint32, Uint53, Uint64 } from "./integers";
 export {

--- a/packages/iov-encoding/types/decimal.d.ts
+++ b/packages/iov-encoding/types/decimal.d.ts
@@ -1,0 +1,12 @@
+/**
+ * A type for arbitrary precision, non-negative decimals.
+ *
+ * Instances of this class are immutable.
+ */
+export declare class Decimal {
+  static fromUserInput(input: string, fractionalDigits: number): Decimal;
+  private readonly quantity;
+  private readonly fractionalDigits;
+  private constructor();
+  getQuantity(): string;
+}

--- a/packages/iov-encoding/types/decimal.d.ts
+++ b/packages/iov-encoding/types/decimal.d.ts
@@ -6,6 +6,7 @@
 export declare class Decimal {
   static fromUserInput(input: string, fractionalDigits: number): Decimal;
   static fromAtomics(atomics: string, fractionalDigits: number): Decimal;
+  private static verifyFractionalDigits;
   readonly atomics: string;
   private readonly data;
   private constructor();

--- a/packages/iov-encoding/types/decimal.d.ts
+++ b/packages/iov-encoding/types/decimal.d.ts
@@ -5,8 +5,7 @@
  */
 export declare class Decimal {
   static fromUserInput(input: string, fractionalDigits: number): Decimal;
-  private readonly quantity;
-  private readonly fractionalDigits;
+  readonly atomics: string;
+  private readonly data;
   private constructor();
-  getQuantity(): string;
 }

--- a/packages/iov-encoding/types/decimal.d.ts
+++ b/packages/iov-encoding/types/decimal.d.ts
@@ -5,7 +5,9 @@
  */
 export declare class Decimal {
   static fromUserInput(input: string, fractionalDigits: number): Decimal;
+  static fromAtomics(atomics: string, fractionalDigits: number): Decimal;
   readonly atomics: string;
   private readonly data;
   private constructor();
+  toString(): string;
 }

--- a/packages/iov-encoding/types/index.d.ts
+++ b/packages/iov-encoding/types/index.d.ts
@@ -1,4 +1,5 @@
 export { Bech32 } from "./bech32";
+export { Decimal } from "./decimal";
 export { Encoding } from "./encoding";
 export { Int53, Uint32, Uint53, Uint64 } from "./integers";
 export {


### PR DESCRIPTION
We are implementing too many of this functionality again and again in caller projects like ponferrada, the Token finder, the multisignature tool, the faucet, including code like

```ts
// This produces a human readable format of the amount, value and token ticker
export function amountToString(amount: Amount): string {
  const { tokenTicker } = amount;
  const value = amountToNumber(amount);

  return `${value} ${tokenTicker}`;
}
```

where we rely on the bahaviour of an IEEE 754 float, which cannot express all amounts precisely.

The basic functionality included here allows converting our IOV-Core amounts to human readable numbers like:

```ts
export function amountToString(amount: Amount): string {
  const { quantity, fractionalDigits, tokenTicker } = amount;
  return `${Decimal.fromAtomics(quantity, fractionalDigits).toString()} ${tokenTicker}`;
}
```

and reading user input into amounts.