### PR TITLE
Calculate BlockId from Tendermint header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 ## 1.0.0
 
+- @iov/bns: Populate the correct block ID in `BnsConnection.watchBlockHeaders`.
 - @iov/encoding: Add `Uint32.toBytesLittleEndian`.
+- @iov/tendermint-rpc: Add `hashBlock` to `Adaptor` type and implement for
+  `v0-31`.
+- @iov/tendermint-rpc: Add `ReadonlyDateWithNanoseconds` and `Version` types.
+- @iov/tendermint-rpc: Fill out `Header` type with missing fields and use new
+  `ReadonlyDateWithNanoseconds` type for `time` field.
 
 Breaking changes
 

--- a/packages/iov-bns/src/bnsconnection.spec.ts
+++ b/packages/iov-bns/src/bnsconnection.spec.ts
@@ -490,15 +490,15 @@ describe("BnsConnection", () => {
       const headerFromGet = await connection.getBlockHeader(lastHeight);
 
       // first header
+      expect(headers[0].id).not.toEqual(headerFromGet.id);
       expect(headers[0].height).toEqual(headerFromGet.height - 1);
-      // expect(headers[0].id).not.toEqual(headerFromGet.id);
       expect(headers[0].transactionCount).toBeGreaterThanOrEqual(0);
       expect(headers[0].time.getTime()).toBeGreaterThan(headerFromGet.time.getTime() - blockTime - 200);
       expect(headers[0].time.getTime()).toBeLessThan(headerFromGet.time.getTime() - blockTime + 200);
 
       // second header
+      expect(headers[1].id).toEqual(headerFromGet.id);
       expect(headers[1].height).toEqual(headerFromGet.height);
-      // expect(headers[1].id).toEqual(headerFromGet.id);
       expect(headers[1].transactionCount).toEqual(headerFromGet.transactionCount);
       expect(headers[1].time).toEqual(headerFromGet.time);
 

--- a/packages/iov-bns/src/bnsconnection.ts
+++ b/packages/iov-bns/src/bnsconnection.ts
@@ -47,7 +47,7 @@ import {
 } from "@iov/bcp";
 import { Encoding, Uint53 } from "@iov/encoding";
 import { concat, DefaultValueProducer, dropDuplicates, fromListPromise, ValueAndUpdates } from "@iov/stream";
-import { broadcastTxSyncSuccess, Client as TendermintClient } from "@iov/tendermint-rpc";
+import { broadcastTxSyncSuccess, Client as TendermintClient, v0_31 } from "@iov/tendermint-rpc";
 import equal from "fast-deep-equal";
 import { Stream, Subscription } from "xstream";
 
@@ -618,15 +618,10 @@ export class BnsConnection implements AtomicSwapConnection {
   }
 
   public watchBlockHeaders(): Stream<BlockHeader> {
-    // TODO: ID unavailable because
-    // - we cannot trivially calculate it https://github.com/iov-one/iov-core/issues/618 and
-    // - want to avoid an extra query to the node which causes issues when trying to send to a disconnected socket
-    // Leave it a dummy as long as no application strictly requires the ID
-    const dummyBlockId = "block ID not implemented for Tendermint" as BlockId;
-
     return this.tmClient.subscribeNewBlockHeader().map(tmHeader => {
+      const blockId = Encoding.toHex(v0_31.hashBlock(tmHeader)).toUpperCase() as BlockId;
       return {
-        id: dummyBlockId,
+        id: blockId,
         height: tmHeader.height,
         time: tmHeader.time,
         transactionCount: tmHeader.numTxs,

--- a/packages/iov-tendermint-rpc/src/adaptor.ts
+++ b/packages/iov-tendermint-rpc/src/adaptor.ts
@@ -3,12 +3,13 @@ import { JsonRpcRequest, JsonRpcSuccessResponse } from "@iov/jsonrpc";
 import * as requests from "./requests";
 import * as responses from "./responses";
 import { SubscriptionEvent } from "./rpcclients";
-import { TxBytes, TxHash } from "./types";
+import { BlockHash, TxBytes, TxHash } from "./types";
 
 export interface Adaptor {
   readonly params: Params;
   readonly responses: Responses;
   readonly hashTx: (tx: TxBytes) => TxHash;
+  readonly hashBlock: (header: responses.Header) => BlockHash;
 }
 
 // Encoder is a generic that matches all methods of Params

--- a/packages/iov-tendermint-rpc/src/encodings.spec.ts
+++ b/packages/iov-tendermint-rpc/src/encodings.spec.ts
@@ -1,0 +1,91 @@
+import { ReadonlyDate } from "readonly-date";
+
+import { encodeBlockId, encodeBytes, encodeInt, encodeString, encodeTime, encodeVersion } from "./encodings";
+
+describe("encodings", () => {
+  describe("encodeString", () => {
+    it("works", () => {
+      expect(encodeString("")).toEqual(Uint8Array.from([0]));
+      const str = "hello iov";
+      expect(encodeString(str)).toEqual(
+        Uint8Array.from([str.length, 0x68, 0x65, 0x6c, 0x6c, 0x6f, 0x20, 0x69, 0x6f, 0x76]),
+      );
+    });
+  });
+
+  describe("encodeInt", () => {
+    it("works", () => {
+      expect(encodeInt(0)).toEqual(Uint8Array.from([0]));
+      expect(encodeInt(1)).toEqual(Uint8Array.from([1]));
+      expect(encodeInt(127)).toEqual(Uint8Array.from([127]));
+      expect(encodeInt(128)).toEqual(Uint8Array.from([128, 1]));
+      expect(encodeInt(255)).toEqual(Uint8Array.from([255, 1]));
+      expect(encodeInt(256)).toEqual(Uint8Array.from([128, 2]));
+    });
+  });
+
+  describe("encodeTime", () => {
+    it("works", () => {
+      const readonlyDateWithNanoseconds = new ReadonlyDate(1464109200);
+      // tslint:disable-next-line:no-object-mutation
+      (readonlyDateWithNanoseconds as any).nanoseconds = 666666;
+      expect(encodeTime(readonlyDateWithNanoseconds)).toEqual(
+        Uint8Array.from([0x08, 173, 174, 89, 0x10, 170, 220, 215, 95]),
+      );
+    });
+  });
+
+  describe("encodeBytes", () => {
+    it("works", () => {
+      expect(encodeBytes(Uint8Array.from([]))).toEqual(Uint8Array.from([]));
+      const uint8Array = Uint8Array.from([1, 2, 3, 4, 5, 6, 7]);
+      expect(encodeBytes(uint8Array)).toEqual(Uint8Array.from([uint8Array.length, 1, 2, 3, 4, 5, 6, 7]));
+    });
+  });
+
+  describe("encodeVersion", () => {
+    it("works", () => {
+      const version = {
+        block: 666666,
+        app: 200,
+      };
+      expect(encodeVersion(version)).toEqual(Uint8Array.from([0x08, 170, 216, 40, 0x10, 200, 1]));
+    });
+  });
+
+  describe("encodeBlockId", () => {
+    it("works", () => {
+      const blockId = {
+        hash: Uint8Array.from([1, 2, 3, 4, 5, 6, 7]),
+        parts: {
+          total: 88,
+          hash: Uint8Array.from([8, 9, 10, 11, 12]),
+        },
+      };
+      expect(encodeBlockId(blockId)).toEqual(
+        Uint8Array.from([
+          0x0a,
+          blockId.hash.length,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          0x12,
+          9,
+          0x08,
+          88,
+          0x12,
+          5,
+          8,
+          9,
+          10,
+          11,
+          12,
+        ]),
+      );
+    });
+  });
+});

--- a/packages/iov-tendermint-rpc/src/encodings.ts
+++ b/packages/iov-tendermint-rpc/src/encodings.ts
@@ -1,6 +1,9 @@
 import { Encoding, Int53 } from "@iov/encoding";
-import { ReadonlyDate } from "readonly-date";
 import { As } from "type-tagger";
+
+import { BlockId, ReadonlyDateWithNanoseconds, Version } from "./responses";
+
+const { toUtf8 } = Encoding;
 
 export type Base64String = string & As<"base64">;
 export type HexString = string & As<"hex">;
@@ -156,8 +159,13 @@ export class Base64 {
 }
 
 export class DateTime {
-  public static decode(dateTimeString: DateTimeString): ReadonlyDate {
-    return Encoding.fromRfc3339(dateTimeString);
+  public static decode(dateTimeString: DateTimeString): ReadonlyDateWithNanoseconds {
+    const readonlyDate = Encoding.fromRfc3339(dateTimeString);
+    const nanosecondsMatch = dateTimeString.match(/\.(\d+)Z$/);
+    const nanoseconds = nanosecondsMatch ? nanosecondsMatch[1].slice(3) : "";
+    // tslint:disable-next-line:no-object-mutation
+    (readonlyDate as any).nanoseconds = parseInt(nanoseconds.padEnd(6, "0"), 10);
+    return readonlyDate as ReadonlyDateWithNanoseconds;
   }
 }
 
@@ -169,4 +177,57 @@ export class Hex {
   public static decode(hexString: HexString): Uint8Array {
     return Encoding.fromHex(hexString);
   }
+}
+
+// Encodings needed for hashing block headers
+// Several of these functions are inspired by https://github.com/nomic-io/js-tendermint/blob/tendermint-0.30/src/
+
+// See https://github.com/tendermint/go-amino/blob/v0.15.0/encoder.go#L193-L195
+export function encodeString(s: string): Uint8Array {
+  const utf8 = toUtf8(s);
+  return Uint8Array.from([utf8.length, ...utf8]);
+}
+
+// See https://github.com/tendermint/go-amino/blob/v0.15.0/encoder.go#L79-L87
+export function encodeInt(n: number): Uint8Array {
+  // tslint:disable-next-line:no-bitwise
+  return n >= 0x80 ? Uint8Array.from([(n & 0xff) | 0x80, ...encodeInt(n >> 7)]) : Uint8Array.from([n & 0xff]);
+}
+
+// See https://github.com/tendermint/go-amino/blob/v0.15.0/encoder.go#L134-L178
+export function encodeTime(time: ReadonlyDateWithNanoseconds): Uint8Array {
+  const milliseconds = time.getTime();
+  const seconds = Math.floor(milliseconds / 1000);
+  const secondsArray = seconds ? [0x08, ...encodeInt(seconds)] : new Uint8Array();
+  const nanoseconds = (time.nanoseconds || 0) + (milliseconds % 1000) * 1e6;
+  const nanosecondsArray = nanoseconds ? [0x10, ...encodeInt(nanoseconds)] : new Uint8Array();
+  return Uint8Array.from([...secondsArray, ...nanosecondsArray]);
+}
+
+// See https://github.com/tendermint/go-amino/blob/v0.15.0/encoder.go#L180-L187
+export function encodeBytes(bytes: Uint8Array): Uint8Array {
+  // Since we're only dealing with short byte arrays we don't need a full VarBuffer implementation yet
+  if (bytes.length >= 0x80) throw new Error("Not implemented for byte arrays of length 128 or more");
+  return bytes.length ? Uint8Array.from([bytes.length, ...bytes]) : new Uint8Array();
+}
+
+export function encodeVersion(version: Version): Uint8Array {
+  const blockArray = version.block ? Uint8Array.from([0x08, ...encodeInt(version.block)]) : new Uint8Array();
+  const appArray = version.app ? Uint8Array.from([0x10, ...encodeInt(version.app)]) : new Uint8Array();
+  return Uint8Array.from([...blockArray, ...appArray]);
+}
+
+export function encodeBlockId(blockId: BlockId): Uint8Array {
+  return Uint8Array.from([
+    0x0a,
+    blockId.hash.length,
+    ...blockId.hash,
+    0x12,
+    blockId.parts.hash.length + 4,
+    0x08,
+    blockId.parts.total,
+    0x12,
+    blockId.parts.hash.length,
+    ...blockId.parts.hash,
+  ]);
 }

--- a/packages/iov-tendermint-rpc/src/responses.ts
+++ b/packages/iov-tendermint-rpc/src/responses.ts
@@ -235,13 +235,18 @@ export interface Version {
   readonly app: number;
 }
 
+export interface ReadonlyDateWithNanoseconds extends ReadonlyDate {
+  /* Nanoseconds after the time stored in a vanilla ReadonlyDate (millisecond granularity) */
+  readonly nanoseconds?: number;
+}
+
 // https://github.com/tendermint/tendermint/blob/v0.31.8/docs/spec/blockchain/blockchain.md
 export interface Header {
   // basic block info
   readonly version: Version;
   readonly chainId: string;
   readonly height: number;
-  readonly time: ReadonlyDate;
+  readonly time: ReadonlyDateWithNanoseconds;
   readonly numTxs: number;
   readonly totalTxs: number;
 

--- a/packages/iov-tendermint-rpc/src/responses.ts
+++ b/packages/iov-tendermint-rpc/src/responses.ts
@@ -230,25 +230,38 @@ export interface Vote {
   readonly signature: ValidatorSignature;
 }
 
+export interface Version {
+  readonly block: number;
+  readonly app: number;
+}
+
+// https://github.com/tendermint/tendermint/blob/v0.31.8/docs/spec/blockchain/blockchain.md
 export interface Header {
+  // basic block info
+  readonly version: Version;
   readonly chainId: string;
   readonly height: number;
   readonly time: ReadonlyDate;
   readonly numTxs: number;
-  readonly lastBlockId: BlockId;
   readonly totalTxs: number;
 
-  // merkle roots for proofs
-  readonly appHash: Uint8Array;
-  readonly consensusHash: Uint8Array;
-  /** empty when number of transaction is 0 */
-  readonly dataHash: Uint8Array;
-  /** this can be empty */
-  readonly evidenceHash: Uint8Array;
+  // prev block info
+  readonly lastBlockId: BlockId;
+
+  // hashes of block data
   readonly lastCommitHash: Uint8Array;
-  /** this can be empty */
-  readonly lastResultsHash: Uint8Array;
+  readonly dataHash: Uint8Array; // empty when number of transaction is 0
+
+  // hashes from the app output from the prev block
   readonly validatorsHash: Uint8Array;
+  readonly nextValidatorsHash: Uint8Array;
+  readonly consensusHash: Uint8Array;
+  readonly appHash: Uint8Array;
+  readonly lastResultsHash: Uint8Array;
+
+  // consensus info
+  readonly evidenceHash: Uint8Array;
+  readonly proposerAddress: Uint8Array;
 }
 
 export interface NodeInfo {

--- a/packages/iov-tendermint-rpc/src/types.ts
+++ b/packages/iov-tendermint-rpc/src/types.ts
@@ -3,6 +3,11 @@
 
 import { As } from "type-tagger";
 
+/**
+ * Merkle root
+ */
+export type BlockHash = Uint8Array & As<"block-hash">;
+
 /** Raw transaction bytes */
 export type TxBytes = Uint8Array & As<"tx-bytes">;
 

--- a/packages/iov-tendermint-rpc/src/v0-31/hasher.spec.ts
+++ b/packages/iov-tendermint-rpc/src/v0-31/hasher.spec.ts
@@ -1,14 +1,100 @@
 import { Encoding } from "@iov/encoding";
+import { ReadonlyDate } from "readonly-date";
 
+import { ReadonlyDateWithNanoseconds } from "../responses";
 import { TxBytes } from "../types";
-import { hashTx } from "./hasher";
+import { hashBlock, hashTx } from "./hasher";
+
+const { fromHex, fromBase64 } = Encoding;
 
 describe("Hasher", () => {
   it("creates transaction hash equal to local test", () => {
     // This was taken from a result from /tx_search of some random test transaction
     // curl "http://localhost:11127/tx_search?query=\"tx.hash='5CB2CF94A1097A4BC19258BC2353C3E76102B6D528458BE45C855DC5563C1DB2'\""
-    const txId = Encoding.fromHex("5CB2CF94A1097A4BC19258BC2353C3E76102B6D528458BE45C855DC5563C1DB2");
-    const txData = Encoding.fromBase64("YUpxZDY2NURaUDMxPWd2TzBPdnNrVWFWYg==") as TxBytes;
+    const txId = fromHex("5CB2CF94A1097A4BC19258BC2353C3E76102B6D528458BE45C855DC5563C1DB2");
+    const txData = fromBase64("YUpxZDY2NURaUDMxPWd2TzBPdnNrVWFWYg==") as TxBytes;
     expect(hashTx(txData)).toEqual(txId);
+  });
+
+  it("creates block hash equal to local test for empty block", () => {
+    // This was taken from a result from /block of some random empty block
+    // curl "http://localhost:11131/block"
+    const blockId = fromHex("5B5D3F7E77A4BD6CB6067947E478BC3BD493DD24A981535F0ADEBDAAA0498480");
+    const time = new ReadonlyDate("2019-09-19T10:41:24.898178746Z");
+    // tslint:disable-next-line:no-object-mutation
+    (time as any).nanoseconds = 178746;
+    const blockData = {
+      version: {
+        block: 10,
+        app: 1,
+      },
+      chainId: "test-chain-RRlV24",
+      height: 2195,
+      time: time as ReadonlyDateWithNanoseconds,
+      numTxs: 0,
+      totalTxs: 20,
+
+      lastBlockId: {
+        hash: fromHex("1D38C4FE5C1D8C3CC1F47602BF107C9B269BA7DA3514DEDF958F5A33AB75C06B"),
+        parts: {
+          total: 1,
+          hash: fromHex("C441341B7D846DDA6AF72F83DF68C9AF93665FE5280B136CA29C7411D280DAEC"),
+        },
+      },
+
+      lastCommitHash: fromHex("0C5EEF7AE1275337BFAA173F57799AA90830E74AFF3FB03D1F579DA37BCAEAB1"),
+      dataHash: fromHex(""),
+
+      validatorsHash: fromHex("44D7D0BE3C70B58DA87696102E3A52E5C9FA98A717E56D02987DA8CAE86F03F4"),
+      nextValidatorsHash: fromHex("44D7D0BE3C70B58DA87696102E3A52E5C9FA98A717E56D02987DA8CAE86F03F4"),
+      consensusHash: fromHex("048091BC7DDC283F77BFBF91D73C44DA58C3DF8A9CBC867405D8B7F3DAADA22F"),
+      appHash: fromHex("2800000000000000"),
+      lastResultsHash: fromHex(""),
+
+      evidenceHash: fromHex(""),
+      proposerAddress: fromHex("057B8C349E591579EDFCC0E5D5402E3076E99675"),
+    };
+    expect(hashBlock(blockData)).toEqual(blockId);
+  });
+
+  it("creates block hash equal to local test for block with a transaction", () => {
+    // This was taken from a result from /block of some random block with a transaction
+    // curl "http://localhost:11131/block?height=5940"
+    const blockId = fromHex("1C4777AFBBA49E15D031A830E62E7BE986823938732B872C02B8A3D16BD3163B");
+    const time = new ReadonlyDate("2019-09-24T10:51:28.240847497Z");
+    // tslint:disable-next-line:no-object-mutation
+    (time as any).nanoseconds = 847497;
+    const blockData = {
+      version: {
+        block: 10,
+        app: 1,
+      },
+      chainId: "test-chain-lY9FO6",
+      height: 5940,
+      time: time as ReadonlyDateWithNanoseconds,
+      numTxs: 1,
+      totalTxs: 61,
+
+      lastBlockId: {
+        hash: fromHex("D2983E6AEEFC55E0A46565CD2274CCD21CB013F5602B0C35A423A99D1120DB13"),
+        parts: {
+          total: 1,
+          hash: fromHex("AA55D7F92AD3A9CFDA8C5E45F95B03AEF9FB38AB984FD762E5CE20791324369D"),
+        },
+      },
+
+      lastCommitHash: fromHex("5DBFFDBE41878AEB947176D3E0B0DC70850B0A61F8B709ED132FEA59664DFCE5"),
+      dataHash: fromHex("90FE1A62418F68B411915EEF6792B134693D9D0148432BA661D91213B0CCD15A"),
+
+      validatorsHash: fromHex("0A4647900ED90CC605E851BBB4946D7B9D1830F293BC87F3CE16AEFF4E4C77E2"),
+      nextValidatorsHash: fromHex("0A4647900ED90CC605E851BBB4946D7B9D1830F293BC87F3CE16AEFF4E4C77E2"),
+      consensusHash: fromHex("048091BC7DDC283F77BFBF91D73C44DA58C3DF8A9CBC867405D8B7F3DAADA22F"),
+      appHash: fromHex("7800000000000000"),
+      lastResultsHash: fromHex("6E340B9CFFB37A989CA544E6BB780A2C78901D3FB33738768511A30617AFA01D"),
+
+      evidenceHash: fromHex(""),
+      proposerAddress: fromHex("6BCBB90987613FE15D3DEFA4920E9F98425698FF"),
+    };
+    expect(hashBlock(blockData)).toEqual(blockId);
   });
 });

--- a/packages/iov-tendermint-rpc/src/v0-31/hasher.ts
+++ b/packages/iov-tendermint-rpc/src/v0-31/hasher.ts
@@ -1,10 +1,71 @@
 import { Sha256 } from "@iov/crypto";
 
-import { TxBytes, TxHash } from "../types";
+import { encodeBlockId, encodeBytes, encodeInt, encodeString, encodeTime, encodeVersion } from "../encodings";
+import { Header } from "../responses";
+import { BlockHash, TxBytes, TxHash } from "../types";
 
 // hash is sha256
 // https://github.com/tendermint/tendermint/blob/master/UPGRADING.md#v0260
 export function hashTx(tx: TxBytes): TxHash {
   const hash = new Sha256(tx).digest();
   return hash as TxHash;
+}
+
+function getSplitPoint(n: number): number {
+  if (n < 1) throw new Error("Cannot split an empty tree");
+  const largestPowerOf2 = 2 ** Math.floor(Math.log2(n));
+  return largestPowerOf2 < n ? largestPowerOf2 : largestPowerOf2 / 2;
+}
+
+function hashLeaf(leaf: Uint8Array): Uint8Array {
+  const hash = new Sha256(Uint8Array.from([0]));
+  hash.update(leaf);
+  return hash.digest();
+}
+
+function hashInner(left: Uint8Array, right: Uint8Array): Uint8Array {
+  const hash = new Sha256(Uint8Array.from([1]));
+  hash.update(left);
+  hash.update(right);
+  return hash.digest();
+}
+
+// See https://github.com/tendermint/tendermint/blob/v0.31.8/docs/spec/blockchain/encoding.md#merkleroot
+// Note: the hashes input may not actually be hashes, especially before a recursive call
+function hashTree(hashes: readonly Uint8Array[]): Uint8Array {
+  switch (hashes.length) {
+    case 0:
+      throw new Error("Cannot hash empty tree");
+    case 1:
+      return hashLeaf(hashes[0]);
+    default: {
+      const slicePoint = getSplitPoint(hashes.length);
+      const left = hashTree(hashes.slice(0, slicePoint));
+      const right = hashTree(hashes.slice(slicePoint));
+      return hashInner(left, right);
+    }
+  }
+}
+
+export function hashBlock(header: Header): BlockHash {
+  const encodedFields: readonly Uint8Array[] = [
+    encodeVersion(header.version),
+    encodeString(header.chainId),
+    encodeInt(header.height),
+    encodeTime(header.time),
+    encodeInt(header.numTxs),
+    encodeInt(header.totalTxs),
+    encodeBlockId(header.lastBlockId),
+
+    encodeBytes(header.lastCommitHash),
+    encodeBytes(header.dataHash),
+    encodeBytes(header.validatorsHash),
+    encodeBytes(header.nextValidatorsHash),
+    encodeBytes(header.consensusHash),
+    encodeBytes(header.appHash),
+    encodeBytes(header.lastResultsHash),
+    encodeBytes(header.evidenceHash),
+    encodeBytes(header.proposerAddress),
+  ];
+  return hashTree(encodedFields) as BlockHash;
 }

--- a/packages/iov-tendermint-rpc/src/v0-31/index.ts
+++ b/packages/iov-tendermint-rpc/src/v0-31/index.ts
@@ -1,5 +1,5 @@
 import { Adaptor } from "../adaptor";
-import { hashTx } from "./hasher";
+import { hashBlock, hashTx } from "./hasher";
 import { Params } from "./requests";
 import { Responses } from "./responses";
 
@@ -8,7 +8,5 @@ export const v0_31: Adaptor = {
   params: Params,
   responses: Responses,
   hashTx: hashTx,
-  hashBlock: () => {
-    throw new Error("Not implemented");
-  },
+  hashBlock: hashBlock,
 };

--- a/packages/iov-tendermint-rpc/src/v0-31/index.ts
+++ b/packages/iov-tendermint-rpc/src/v0-31/index.ts
@@ -8,4 +8,7 @@ export const v0_31: Adaptor = {
   params: Params,
   responses: Responses,
   hashTx: hashTx,
+  hashBlock: () => {
+    throw new Error("Not implemented");
+  },
 };

--- a/packages/iov-tendermint-rpc/src/v0-31/responses.ts
+++ b/packages/iov-tendermint-rpc/src/v0-31/responses.ts
@@ -235,40 +235,63 @@ function decodeBlockId(data: RpcBlockId): responses.BlockId {
   };
 }
 
+interface RpcBlockVersion {
+  readonly block: IntegerString;
+  readonly app: IntegerString;
+}
+
+function decodeBlockVersion(data: RpcBlockVersion): responses.Version {
+  return {
+    block: Integer.parse(data.block),
+    app: Integer.parse(data.app),
+  };
+}
+
 interface RpcHeader {
+  readonly version: RpcBlockVersion;
   readonly chain_id: string;
   readonly height: IntegerString;
   readonly time: DateTimeString;
   readonly num_txs: IntegerString;
-  readonly last_block_id: RpcBlockId;
   readonly total_txs: IntegerString;
 
-  // merkle roots for proofs
-  readonly app_hash: HexString;
-  readonly consensus_hash: HexString;
-  readonly data_hash: HexString;
-  readonly evidence_hash: HexString;
+  readonly last_block_id: RpcBlockId;
+
   readonly last_commit_hash: HexString;
-  readonly last_results_hash: HexString;
+  readonly data_hash: HexString;
+
   readonly validators_hash: HexString;
+  readonly next_validators_hash: HexString;
+  readonly consensus_hash: HexString;
+  readonly app_hash: HexString;
+  readonly last_results_hash: HexString;
+
+  readonly evidence_hash: HexString;
+  readonly proposer_address: HexString;
 }
 
 function decodeHeader(data: RpcHeader): responses.Header {
   return {
+    version: decodeBlockVersion(data.version),
     chainId: assertNotEmpty(data.chain_id),
     height: Integer.parse(assertNotEmpty(data.height)),
     time: DateTime.decode(assertNotEmpty(data.time)),
     numTxs: Integer.parse(assertNotEmpty(data.num_txs)),
     totalTxs: Integer.parse(assertNotEmpty(data.total_txs)),
+
     lastBlockId: decodeBlockId(data.last_block_id),
 
-    appHash: Encoding.fromHex(assertNotEmpty(data.app_hash)),
-    consensusHash: Encoding.fromHex(assertNotEmpty(data.consensus_hash)),
-    dataHash: Encoding.fromHex(assertSet(data.data_hash)),
-    evidenceHash: Encoding.fromHex(assertSet(data.evidence_hash)),
     lastCommitHash: Encoding.fromHex(assertNotEmpty(data.last_commit_hash)),
-    lastResultsHash: Encoding.fromHex(assertSet(data.last_results_hash)),
+    dataHash: Encoding.fromHex(assertSet(data.data_hash)),
+
     validatorsHash: Encoding.fromHex(assertNotEmpty(data.validators_hash)),
+    nextValidatorsHash: Encoding.fromHex(assertNotEmpty(data.next_validators_hash)),
+    consensusHash: Encoding.fromHex(assertNotEmpty(data.consensus_hash)),
+    appHash: Encoding.fromHex(assertNotEmpty(data.app_hash)),
+    lastResultsHash: Encoding.fromHex(assertSet(data.last_results_hash)),
+
+    evidenceHash: Encoding.fromHex(assertSet(data.evidence_hash)),
+    proposerAddress: Encoding.fromHex(assertNotEmpty(data.proposer_address)),
   };
 }
 

--- a/packages/iov-tendermint-rpc/types/adaptor.d.ts
+++ b/packages/iov-tendermint-rpc/types/adaptor.d.ts
@@ -2,11 +2,12 @@ import { JsonRpcRequest, JsonRpcSuccessResponse } from "@iov/jsonrpc";
 import * as requests from "./requests";
 import * as responses from "./responses";
 import { SubscriptionEvent } from "./rpcclients";
-import { TxBytes, TxHash } from "./types";
+import { BlockHash, TxBytes, TxHash } from "./types";
 export interface Adaptor {
   readonly params: Params;
   readonly responses: Responses;
   readonly hashTx: (tx: TxBytes) => TxHash;
+  readonly hashBlock: (header: responses.Header) => BlockHash;
 }
 export declare type Encoder<T extends requests.Request> = (req: T) => JsonRpcRequest;
 export declare type Decoder<T extends responses.Response> = (res: JsonRpcSuccessResponse) => T;

--- a/packages/iov-tendermint-rpc/types/encodings.d.ts
+++ b/packages/iov-tendermint-rpc/types/encodings.d.ts
@@ -1,5 +1,5 @@
-import { ReadonlyDate } from "readonly-date";
 import { As } from "type-tagger";
+import { BlockId, ReadonlyDateWithNanoseconds, Version } from "./responses";
 export declare type Base64String = string & As<"base64">;
 export declare type HexString = string & As<"hex">;
 export declare type IntegerString = string & As<"integer">;
@@ -60,9 +60,15 @@ export declare class Base64 {
   static decode(base64String: Base64String): Uint8Array;
 }
 export declare class DateTime {
-  static decode(dateTimeString: DateTimeString): ReadonlyDate;
+  static decode(dateTimeString: DateTimeString): ReadonlyDateWithNanoseconds;
 }
 export declare class Hex {
   static encode(data: Uint8Array): HexString;
   static decode(hexString: HexString): Uint8Array;
 }
+export declare function encodeString(s: string): Uint8Array;
+export declare function encodeInt(n: number): Uint8Array;
+export declare function encodeTime(time: ReadonlyDateWithNanoseconds): Uint8Array;
+export declare function encodeBytes(bytes: Uint8Array): Uint8Array;
+export declare function encodeVersion(version: Version): Uint8Array;
+export declare function encodeBlockId(blockId: BlockId): Uint8Array;

--- a/packages/iov-tendermint-rpc/types/responses.d.ts
+++ b/packages/iov-tendermint-rpc/types/responses.d.ts
@@ -184,23 +184,27 @@ export interface Vote {
   readonly blockId: BlockId;
   readonly signature: ValidatorSignature;
 }
+export interface Version {
+  readonly block: number;
+  readonly app: number;
+}
 export interface Header {
+  readonly version: Version;
   readonly chainId: string;
   readonly height: number;
   readonly time: ReadonlyDate;
   readonly numTxs: number;
-  readonly lastBlockId: BlockId;
   readonly totalTxs: number;
-  readonly appHash: Uint8Array;
-  readonly consensusHash: Uint8Array;
-  /** empty when number of transaction is 0 */
-  readonly dataHash: Uint8Array;
-  /** this can be empty */
-  readonly evidenceHash: Uint8Array;
+  readonly lastBlockId: BlockId;
   readonly lastCommitHash: Uint8Array;
-  /** this can be empty */
-  readonly lastResultsHash: Uint8Array;
+  readonly dataHash: Uint8Array;
   readonly validatorsHash: Uint8Array;
+  readonly nextValidatorsHash: Uint8Array;
+  readonly consensusHash: Uint8Array;
+  readonly appHash: Uint8Array;
+  readonly lastResultsHash: Uint8Array;
+  readonly evidenceHash: Uint8Array;
+  readonly proposerAddress: Uint8Array;
 }
 export interface NodeInfo {
   readonly id: Uint8Array;

--- a/packages/iov-tendermint-rpc/types/responses.d.ts
+++ b/packages/iov-tendermint-rpc/types/responses.d.ts
@@ -188,11 +188,14 @@ export interface Version {
   readonly block: number;
   readonly app: number;
 }
+export interface ReadonlyDateWithNanoseconds extends ReadonlyDate {
+  readonly nanoseconds?: number;
+}
 export interface Header {
   readonly version: Version;
   readonly chainId: string;
   readonly height: number;
-  readonly time: ReadonlyDate;
+  readonly time: ReadonlyDateWithNanoseconds;
   readonly numTxs: number;
   readonly totalTxs: number;
   readonly lastBlockId: BlockId;

--- a/packages/iov-tendermint-rpc/types/types.d.ts
+++ b/packages/iov-tendermint-rpc/types/types.d.ts
@@ -1,4 +1,8 @@
 import { As } from "type-tagger";
+/**
+ * Merkle root
+ */
+export declare type BlockHash = Uint8Array & As<"block-hash">;
 /** Raw transaction bytes */
 export declare type TxBytes = Uint8Array & As<"tx-bytes">;
 /**

--- a/packages/iov-tendermint-rpc/types/v0-31/hasher.d.ts
+++ b/packages/iov-tendermint-rpc/types/v0-31/hasher.d.ts
@@ -1,2 +1,4 @@
-import { TxBytes, TxHash } from "../types";
+import { Header } from "../responses";
+import { BlockHash, TxBytes, TxHash } from "../types";
 export declare function hashTx(tx: TxBytes): TxHash;
+export declare function hashBlock(header: Header): BlockHash;


### PR DESCRIPTION
Closes #618

Draft PR to check a few design decisions:
- [x] `ReadonlyDateWithNanoseconds` approach (awkward but fairly simple and avoids breaking change)
- [x] Location of encoding functions
- [x] Assuming small numbers for eg hash lengths so we don’t have to do a full implementation of the `VarBuffer`s etc

Still to do:
- [x] Test cases for encoding functions
- [x] Test case for block with transactions
- [x] Explanation of where certain magic numbers come from/other documentation links
- [x] Attribution to nomic-io for inspiration behind many functions?
- [x] Actually use the function in bnsconnection.ts
- [x] ~~Copy and paste to v0.29~~ [Just use dummy function since it's going to be removed anyway]
- [x] CHANGELOG entry