### PR TITLE
Remove old data before copying latest docs

### DIFF
--- a/scripts/travis/mode_docs.sh
+++ b/scripts/travis/mode_docs.sh
@@ -43,6 +43,7 @@ if [[ "$TRAVIS_OS_NAME" == "linux" ]] && [[ "$TRAVIS_NODE_VERSION" == "8" ]] && 
     cd "iov-core-docs"
     git checkout gh-pages
     git reset master
+    git clean -xdf
   )
 
   ./scripts/copy_docs.sh


### PR DESCRIPTION
Without this change, new docs override old ones without deleting old data. This results in docs that are long gone, like 

* https://iov-one.github.io/iov-core-docs/latest/iov-ledger-bns/index.html
* https://iov-one.github.io/iov-core-docs/latest/iov-tendermint-types/index.html
* https://iov-one.github.io/iov-core-docs/latest/iov-core/index.html