### PR TITLE
Implement Cosmos connection

### DIFF
--- a/packages/iov-cosmos/karma.conf.js
+++ b/packages/iov-cosmos/karma.conf.js
@@ -43,5 +43,12 @@ module.exports = function(config) {
 
     // Keep brower open for debugging. This is overridden by yarn scripts
     singleRun: false,
+
+    customLaunchers: {
+      ChromeHeadlessInsecure: {
+        base: "ChromeHeadless",
+        flags: ["--disable-web-security"],
+      },
+    },
   });
 };

--- a/packages/iov-cosmos/package.json
+++ b/packages/iov-cosmos/package.json
@@ -46,5 +46,8 @@
     "axios": "^0.19.0",
     "readonly-date": "^1.0.0",
     "xstream": "^11.11.0"
+  },
+  "devDependencies": {
+    "@iov/keycontrol": "^1.0.0"
   }
 }

--- a/packages/iov-cosmos/package.json
+++ b/packages/iov-cosmos/package.json
@@ -32,7 +32,7 @@
     "test-node": "node jasmine-testrunner.js",
     "test-edge": "yarn pack-web && karma start --single-run --browsers Edge",
     "test-firefox": "yarn pack-web && karma start --single-run --browsers Firefox",
-    "test-chrome": "yarn pack-web && karma start --single-run --browsers ChromeHeadless",
+    "test-chrome": "yarn pack-web && karma start --single-run --browsers ChromeHeadlessInsecure",
     "test-safari": "yarn pack-web && karma start --single-run --browsers Safari",
     "test": "yarn build-or-skip && yarn test-node",
     "pack-web": "yarn build-or-skip && webpack --mode development --config webpack.web.config.js"

--- a/packages/iov-cosmos/package.json
+++ b/packages/iov-cosmos/package.json
@@ -41,6 +41,7 @@
     "@iov/bcp": "^1.0.0",
     "@iov/crypto": "^1.0.0",
     "@iov/encoding": "^1.0.0",
+    "@iov/stream": "^1.0.0",
     "@tendermint/amino-js": "^0.6.2",
     "xstream": "^11.11.0"
   }

--- a/packages/iov-cosmos/package.json
+++ b/packages/iov-cosmos/package.json
@@ -44,6 +44,7 @@
     "@iov/stream": "^1.0.0",
     "@tendermint/amino-js": "^0.6.2",
     "axios": "^0.19.0",
+    "readonly-date": "^1.0.0",
     "xstream": "^11.11.0"
   }
 }

--- a/packages/iov-cosmos/package.json
+++ b/packages/iov-cosmos/package.json
@@ -43,6 +43,7 @@
     "@iov/encoding": "^1.0.0",
     "@iov/stream": "^1.0.0",
     "@tendermint/amino-js": "^0.6.2",
+    "axios": "^0.19.0",
     "xstream": "^11.11.0"
   }
 }

--- a/packages/iov-cosmos/src/cosmosconnection.spec.ts
+++ b/packages/iov-cosmos/src/cosmosconnection.spec.ts
@@ -1,6 +1,16 @@
-import { Address, Algorithm, PubkeyBytes } from "@iov/bcp";
+import {
+  Address,
+  Algorithm,
+  ChainId,
+  PubkeyBytes,
+  SendTransaction,
+  TokenTicker,
+  WithCreator,
+} from "@iov/bcp";
 import { Encoding } from "@iov/encoding";
+import { HdPaths, Secp256k1HdWallet, UserProfile } from "@iov/keycontrol";
 
+import { cosmosCodec } from "./cosmoscodec";
 import { CosmosConnection } from "./cosmosconnection";
 
 const { fromBase64 } = Encoding;
@@ -11,15 +21,24 @@ function pendingWithoutCosmos(): void {
   }
 }
 
+async function sleep(ms: number = 5000): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
 describe("CosmosConnection", () => {
+  const vatom = "vatom" as TokenTicker;
   const httpUrl = "http://localhost:1317";
-  const defaultChainId = "testing";
+  const defaultChainId = "testing" as ChainId;
   const defaultEmptyAddress = "cosmos1h806c7khnvmjlywdrkdgk2vrayy2mmvf9rxk2r" as Address;
   const defaultAddress = "cosmos1pkptre7fdkl6gfrzlesjjvhxhlc3r4gmmk8rs6" as Address;
   const defaultPubkey = {
     algo: Algorithm.Secp256k1,
     data: fromBase64("A08EGB7ro1ORuFhjOnZcSgwYlpe0DSFjVNUIkNNQxwKQ") as PubkeyBytes,
   };
+  const faucetMnemonic =
+    "economy stock theory fatal elder harbor betray wasp final emotion task crumble siren bottom lizard educate guess current outdoor pair theory focus wife stone";
+  const faucetPath = HdPaths.cosmos(0);
+  const defaultRecipient = "cosmos1t70qnpr0az8tf7py83m4ue5y89w58lkjmx0yq2" as Address;
 
   describe("establish", () => {
     it("can connect to Cosmos via http", async () => {
@@ -85,6 +104,41 @@ describe("CosmosConnection", () => {
         data: fromBase64("A08EGB7ro1ORuFhjOnZcSgwYlpe0DSFjVNUIkNNQxwKQ"),
       });
       expect(account.balance.length).toEqual(2);
+      connection.disconnect();
+    });
+  });
+
+  describe("integration: postTx and getTx", () => {
+    it("can post and get a transaction", async () => {
+      pendingWithoutCosmos();
+      const connection = await CosmosConnection.establish(httpUrl);
+      const profile = new UserProfile();
+      const wallet = profile.addWallet(Secp256k1HdWallet.fromMnemonic(faucetMnemonic));
+      const faucet = await profile.createIdentity(wallet.id, defaultChainId, faucetPath);
+      const faucetAddress = cosmosCodec.identityToAddress(faucet);
+
+      const unsigned = await connection.withDefaultFee<SendTransaction & WithCreator>({
+        kind: "bcp/send",
+        creator: faucet,
+        sender: faucetAddress,
+        recipient: defaultRecipient,
+        memo: "My first payment",
+        amount: {
+          quantity: "75000",
+          fractionalDigits: 9,
+          tokenTicker: vatom,
+        },
+      });
+      const nonce = await connection.getNonce({ address: faucetAddress });
+      const signed = await profile.signTransaction(unsigned, cosmosCodec, nonce);
+      const postableBytes = cosmosCodec.bytesToPost(signed);
+      const { transactionId } = await connection.postTx(postableBytes);
+
+      await sleep();
+
+      const getResponse = await connection.getTx(transactionId);
+      expect(getResponse).toBeTruthy();
+
       connection.disconnect();
     });
   });

--- a/packages/iov-cosmos/src/cosmosconnection.spec.ts
+++ b/packages/iov-cosmos/src/cosmosconnection.spec.ts
@@ -155,9 +155,7 @@ describe("CosmosConnection", () => {
         toHex(Secp256k1.compressPubkey(unsigned.creator.pubkey.data)),
       );
 
-      // TODO: Enable when Cosmos-SDK supports this
-      // See https://github.com/cosmos/cosmos-sdk/issues/4713
-      // expect(primarySignature.nonce).toEqual(signed.primarySignature.nonce);
+      expect(primarySignature.nonce).toEqual(signed.primarySignature.nonce);
       expect(primarySignature.pubkey.algo).toEqual(signed.primarySignature.pubkey.algo);
       expect(toHex(primarySignature.pubkey.data)).toEqual(
         toHex(Secp256k1.compressPubkey(signed.primarySignature.pubkey.data)),

--- a/packages/iov-cosmos/src/cosmosconnection.spec.ts
+++ b/packages/iov-cosmos/src/cosmosconnection.spec.ts
@@ -1,0 +1,91 @@
+import { Address, Algorithm, PubkeyBytes } from "@iov/bcp";
+import { Encoding } from "@iov/encoding";
+
+import { CosmosConnection } from "./cosmosconnection";
+
+const { fromBase64 } = Encoding;
+
+function pendingWithoutCosmos(): void {
+  if (!process.env.COSMOS_ENABLED) {
+    return pending("Set COSMOS_ENABLED to enable Cosmos node-based tests");
+  }
+}
+
+describe("CosmosConnection", () => {
+  const httpUrl = "http://localhost:1317";
+  const defaultChainId = "testing";
+  const defaultEmptyAddress = "cosmos1h806c7khnvmjlywdrkdgk2vrayy2mmvf9rxk2r" as Address;
+  const defaultAddress = "cosmos1pkptre7fdkl6gfrzlesjjvhxhlc3r4gmmk8rs6" as Address;
+  const defaultPubkey = {
+    algo: Algorithm.Secp256k1,
+    data: fromBase64("A08EGB7ro1ORuFhjOnZcSgwYlpe0DSFjVNUIkNNQxwKQ") as PubkeyBytes,
+  };
+
+  describe("establish", () => {
+    it("can connect to Cosmos via http", async () => {
+      pendingWithoutCosmos();
+      const connection = await CosmosConnection.establish(httpUrl);
+      expect(connection).toBeTruthy();
+      connection.disconnect();
+    });
+  });
+
+  describe("chainId", () => {
+    it("displays the chain ID", async () => {
+      pendingWithoutCosmos();
+      const connection = await CosmosConnection.establish(httpUrl);
+      const chainId = connection.chainId();
+      expect(chainId).toEqual(defaultChainId);
+      connection.disconnect();
+    });
+  });
+
+  describe("height", () => {
+    it("displays the current height", async () => {
+      pendingWithoutCosmos();
+      const connection = await CosmosConnection.establish(httpUrl);
+      const height = await connection.height();
+      expect(height).toBeGreaterThan(0);
+      connection.disconnect();
+    });
+  });
+
+  describe("getAccount", () => {
+    it("gets an empty account by address", async () => {
+      pendingWithoutCosmos();
+      const connection = await CosmosConnection.establish(httpUrl);
+      const account = await connection.getAccount({ address: defaultEmptyAddress });
+      expect(account).toBeUndefined();
+      connection.disconnect();
+    });
+
+    it("gets an account by address", async () => {
+      pendingWithoutCosmos();
+      const connection = await CosmosConnection.establish(httpUrl);
+      const account = await connection.getAccount({ address: defaultAddress });
+      if (account === undefined) {
+        throw new Error("Expected account not to be undefined");
+      }
+      expect(account.address).toEqual(defaultAddress);
+      expect(account.pubkey).toEqual(defaultPubkey);
+      expect(account.balance.length).toEqual(2);
+      connection.disconnect();
+    });
+
+    it("gets an account by pubkey", async () => {
+      pendingWithoutCosmos();
+      const connection = await CosmosConnection.establish(httpUrl);
+      const account = await connection.getAccount({ pubkey: defaultPubkey });
+      if (account === undefined) {
+        throw new Error("Expected account not to be undefined");
+      }
+      expect(account.address).toEqual(defaultAddress);
+      expect(account.pubkey).toEqual({
+        algo: Algorithm.Secp256k1,
+        data: fromBase64("A08EGB7ro1ORuFhjOnZcSgwYlpe0DSFjVNUIkNNQxwKQ"),
+      });
+      expect(account.balance.length).toEqual(2);
+      connection.disconnect();
+    });
+  });
+});

--- a/packages/iov-cosmos/src/cosmosconnection.spec.ts
+++ b/packages/iov-cosmos/src/cosmosconnection.spec.ts
@@ -24,10 +24,6 @@ function pendingWithoutCosmos(): void {
   }
 }
 
-async function sleep(ms: number = 6000): Promise<void> {
-  return new Promise(resolve => setTimeout(resolve, ms));
-}
-
 describe("CosmosConnection", () => {
   const vatom = "vatom" as TokenTicker;
   const httpUrl = "http://localhost:1317";
@@ -136,8 +132,6 @@ describe("CosmosConnection", () => {
       const signed = await profile.signTransaction(unsigned, cosmosCodec, nonce);
       const postableBytes = cosmosCodec.bytesToPost(signed);
       const { transactionId } = await connection.postTx(postableBytes);
-
-      await sleep();
 
       const getResponse = await connection.getTx(transactionId);
       expect(getResponse).toBeTruthy();

--- a/packages/iov-cosmos/src/cosmosconnection.spec.ts
+++ b/packages/iov-cosmos/src/cosmosconnection.spec.ts
@@ -25,7 +25,7 @@ function pendingWithoutCosmos(): void {
 }
 
 describe("CosmosConnection", () => {
-  const vatom = "vatom" as TokenTicker;
+  const atom = "ATOM" as TokenTicker;
   const httpUrl = "http://localhost:1317";
   const defaultChainId = "testing" as ChainId;
   const defaultEmptyAddress = "cosmos1h806c7khnvmjlywdrkdgk2vrayy2mmvf9rxk2r" as Address;
@@ -124,8 +124,8 @@ describe("CosmosConnection", () => {
         memo: "My first payment",
         amount: {
           quantity: "75000",
-          fractionalDigits: 9,
-          tokenTicker: vatom,
+          fractionalDigits: 6,
+          tokenTicker: atom,
         },
       });
       const nonce = await connection.getNonce({ address: faucetAddress });
@@ -184,8 +184,8 @@ describe("CosmosConnection", () => {
         memo: "My first payment",
         amount: {
           quantity: "75000",
-          fractionalDigits: 9,
-          tokenTicker: vatom,
+          fractionalDigits: 6,
+          tokenTicker: atom,
         },
       });
       const nonce = await connection.getNonce({ address: faucetAddress });

--- a/packages/iov-cosmos/src/cosmosconnection.spec.ts
+++ b/packages/iov-cosmos/src/cosmosconnection.spec.ts
@@ -86,7 +86,8 @@ describe("CosmosConnection", () => {
       }
       expect(account.address).toEqual(defaultAddress);
       expect(account.pubkey).toEqual(defaultPubkey);
-      expect(account.balance.length).toEqual(2);
+      // Unsupported coins are filtered out
+      expect(account.balance.length).toEqual(1);
       connection.disconnect();
     });
 
@@ -102,7 +103,8 @@ describe("CosmosConnection", () => {
         algo: Algorithm.Secp256k1,
         data: fromBase64("A08EGB7ro1ORuFhjOnZcSgwYlpe0DSFjVNUIkNNQxwKQ"),
       });
-      expect(account.balance.length).toEqual(2);
+      // Unsupported coins are filtered out
+      expect(account.balance.length).toEqual(1);
       connection.disconnect();
     });
   });

--- a/packages/iov-cosmos/src/cosmosconnection.ts
+++ b/packages/iov-cosmos/src/cosmosconnection.ts
@@ -35,6 +35,8 @@ import { RestClient } from "./restclient";
 
 const { fromBase64 } = Encoding;
 
+const vatom = "vatom" as TokenTicker;
+
 interface ChainData {
   readonly chainId: ChainId;
 }
@@ -157,6 +159,15 @@ export class CosmosConnection implements BlockchainConnection {
   }
 
   public async withDefaultFee<T extends UnsignedTransaction>(tx: T): Promise<T> {
-    throw new Error("not implemented");
+    return {
+      ...tx,
+      fee: {
+        tokens: {
+          quantity: "5000",
+          tokenTicker: vatom,
+        },
+        gasLimit: "200000",
+      },
+    };
   }
 }

--- a/packages/iov-cosmos/src/cosmosconnection.ts
+++ b/packages/iov-cosmos/src/cosmosconnection.ts
@@ -14,6 +14,7 @@ import {
   FailedTransaction,
   Fee,
   isPubkeyQuery,
+  isSendTransaction,
   LightTransaction,
   Nonce,
   PostableBytes,
@@ -192,19 +193,23 @@ export class CosmosConnection implements BlockchainConnection {
   }
 
   public async getFeeQuote(tx: UnsignedTransaction): Promise<Fee> {
-    throw new Error("not implemented");
+    if (!isSendTransaction(tx)) {
+      throw new Error("Received transaction of unsupported kind.");
+    }
+    return {
+      tokens: {
+        fractionalDigits: 9,
+        quantity: "5000",
+        tokenTicker: vatom,
+      },
+      gasLimit: "200000",
+    };
   }
 
   public async withDefaultFee<T extends UnsignedTransaction>(tx: T): Promise<T> {
     return {
       ...tx,
-      fee: {
-        tokens: {
-          quantity: "5000",
-          tokenTicker: vatom,
-        },
-        gasLimit: "200000",
-      },
+      fee: await this.getFeeQuote(tx),
     };
   }
 }

--- a/packages/iov-cosmos/src/cosmosconnection.ts
+++ b/packages/iov-cosmos/src/cosmosconnection.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/camelcase,@typescript-eslint/no-unused-vars */
+/* eslint-disable @typescript-eslint/camelcase */
 import {
   Account,
   AccountQuery,
@@ -103,7 +103,7 @@ export class CosmosConnection implements BlockchainConnection {
     return block_meta.header.height;
   }
 
-  public async getToken(ticker: TokenTicker): Promise<Token | undefined> {
+  public async getToken(_ticker: TokenTicker): Promise<Token | undefined> {
     throw new Error("not implemented");
   }
 
@@ -127,7 +127,7 @@ export class CosmosConnection implements BlockchainConnection {
         };
   }
 
-  public watchAccount(account: AccountQuery): Stream<Account | undefined> {
+  public watchAccount(_account: AccountQuery): Stream<Account | undefined> {
     throw new Error("not implemented");
   }
 
@@ -198,12 +198,14 @@ export class CosmosConnection implements BlockchainConnection {
   }
 
   public listenTx(
-    query: TransactionQuery,
+    _query: TransactionQuery,
   ): Stream<ConfirmedTransaction<LightTransaction> | FailedTransaction> {
     throw new Error("not implemented");
   }
 
-  public liveTx(query: TransactionQuery): Stream<ConfirmedTransaction<LightTransaction> | FailedTransaction> {
+  public liveTx(
+    _query: TransactionQuery,
+  ): Stream<ConfirmedTransaction<LightTransaction> | FailedTransaction> {
     throw new Error("not implemented");
   }
 

--- a/packages/iov-cosmos/src/cosmosconnection.ts
+++ b/packages/iov-cosmos/src/cosmosconnection.ts
@@ -39,7 +39,7 @@ import { RestClient, TxsResponse } from "./restclient";
 
 const { fromBase64 } = Encoding;
 
-const vatom = "vatom" as TokenTicker;
+const atom = "ATOM" as TokenTicker;
 
 interface ChainData {
   readonly chainId: ChainId;
@@ -215,9 +215,9 @@ export class CosmosConnection implements BlockchainConnection {
     }
     return {
       tokens: {
-        fractionalDigits: 9,
+        fractionalDigits: 6,
         quantity: "5000",
-        tokenTicker: vatom,
+        tokenTicker: atom,
       },
       gasLimit: "200000",
     };

--- a/packages/iov-cosmos/src/decode.spec.ts
+++ b/packages/iov-cosmos/src/decode.spec.ts
@@ -12,8 +12,9 @@ import {
   parseFee,
   parseMsg,
   parseTx,
+  parseTxsResponse,
 } from "./decode";
-import { chainId, nonce, signedTxJson } from "./testdata.spec";
+import { chainId, nonce, signedTxJson, txId } from "./testdata.spec";
 import data from "./testdata/cosmoshub.json";
 
 const { fromBase64 } = Encoding;
@@ -146,6 +147,26 @@ describe("decode", () => {
   describe("parseTx", () => {
     it("works", () => {
       expect(parseTx(data.tx, chainId, nonce)).toEqual(signedTxJson);
+    });
+  });
+
+  describe("parseTxsResponse", () => {
+    it("works", () => {
+      const currentHeight = 2923;
+      const txsResponse = {
+        height: "2823",
+        txhash: txId,
+        raw_log: '[{"msg_index":0,"success":true,"log":""}]',
+        tx: data.tx,
+      };
+      const expected = {
+        ...signedTxJson,
+        height: 2823,
+        confirmations: 101,
+        transactionId: txId,
+        log: '[{"msg_index":0,"success":true,"log":""}]',
+      };
+      expect(parseTxsResponse(chainId, currentHeight, nonce, txsResponse)).toEqual(expected);
     });
   });
 });

--- a/packages/iov-cosmos/src/decode.ts
+++ b/packages/iov-cosmos/src/decode.ts
@@ -3,6 +3,7 @@ import {
   Algorithm,
   Amount,
   ChainId,
+  ConfirmedAndSignedTransaction,
   Fee,
   FullSignature,
   Identity,
@@ -13,10 +14,13 @@ import {
   SignatureBytes,
   SignedTransaction,
   TokenTicker,
+  TransactionId,
+  UnsignedTransaction,
 } from "@iov/bcp";
 import { Encoding } from "@iov/encoding";
 import amino from "@tendermint/amino-js";
 
+import { TxsResponse } from "./restclient";
 import { isAminoStdTx } from "./types";
 
 const { fromBase64 } = Encoding;
@@ -117,5 +121,21 @@ export function parseTx(tx: amino.Tx, chainId: ChainId, nonce: Nonce): SignedTra
     transaction: transaction,
     primarySignature: primarySignature,
     otherSignatures: [],
+  };
+}
+
+export function parseTxsResponse(
+  chainId: ChainId,
+  currentHeight: number,
+  nonce: Nonce,
+  response: TxsResponse,
+): ConfirmedAndSignedTransaction<UnsignedTransaction> {
+  const height = parseInt(response.height, 10);
+  return {
+    ...parseTx(response.tx, chainId, nonce),
+    height: height,
+    confirmations: currentHeight - height + 1,
+    transactionId: response.txhash as TransactionId,
+    log: response.raw_log,
   };
 }

--- a/packages/iov-cosmos/src/encode.spec.ts
+++ b/packages/iov-cosmos/src/encode.spec.ts
@@ -24,6 +24,7 @@ import {
 const { fromBase64 } = Encoding;
 
 describe("encode", () => {
+  const atom = "ATOM" as TokenTicker;
   // https://rpc.cosmos.network:26657/tx?hash=0x2268EB5AB730B45F8426078827BB5BB49819CE2B0D74B2C1D191070BADB379F1&prove=true
   const defaultPubkey = {
     algo: Algorithm.Secp256k1,
@@ -36,9 +37,9 @@ describe("encode", () => {
   const defaultSender = "cosmos1h806c7khnvmjlywdrkdgk2vrayy2mmvf9rxk2r" as Address;
   const defaultRecipient = "cosmos1z7g5w84ynmjyg0kqpahdjqpj7yq34v3suckp0e" as Address;
   const defaultAmount: Amount = {
-    fractionalDigits: 0,
+    fractionalDigits: 6,
     quantity: "11657995",
-    tokenTicker: "ATOM" as TokenTicker,
+    tokenTicker: atom,
   };
   const defaultMemo = "hello cosmos hub";
 
@@ -71,9 +72,9 @@ describe("encode", () => {
     it("throws without gas limit", () => {
       const fee = {
         tokens: {
-          fractionalDigits: 0,
+          fractionalDigits: 6,
           quantity: "5000",
-          tokenTicker: "ATOM" as TokenTicker,
+          tokenTicker: atom,
         },
       };
       expect(() => encodeFee(fee)).toThrowError(/cannot encode fee without gas limit/i);
@@ -82,9 +83,9 @@ describe("encode", () => {
     it("encodes a fee", () => {
       const fee = {
         tokens: {
-          fractionalDigits: 0,
+          fractionalDigits: 6,
           quantity: "5000",
-          tokenTicker: "ATOM" as TokenTicker,
+          tokenTicker: atom,
         },
         gasLimit: "200000",
       };
@@ -219,9 +220,9 @@ describe("encode", () => {
         memo: defaultMemo,
         fee: {
           tokens: {
-            fractionalDigits: 0,
+            fractionalDigits: 6,
             quantity: "5000",
-            tokenTicker: "ATOM" as TokenTicker,
+            tokenTicker: atom,
           },
           gasLimit: "200000",
         },
@@ -267,9 +268,9 @@ describe("encode", () => {
           memo: defaultMemo,
           fee: {
             tokens: {
-              fractionalDigits: 0,
+              fractionalDigits: 6,
               quantity: "5000",
-              tokenTicker: "ATOM" as TokenTicker,
+              tokenTicker: atom,
             },
             gasLimit: "200000",
           },

--- a/packages/iov-cosmos/src/index.ts
+++ b/packages/iov-cosmos/src/index.ts
@@ -1,1 +1,3 @@
 export { cosmosCodec, CosmosCodec } from "./cosmoscodec";
+export { CosmosConnection } from "./cosmosconnection";
+export { createCosmosConnector } from "./cosmosconnector";

--- a/packages/iov-cosmos/src/restclient.ts
+++ b/packages/iov-cosmos/src/restclient.ts
@@ -128,8 +128,10 @@ export class RestClient {
     return responseData as BlocksResponse;
   }
 
-  public async authAccounts(address: Address): Promise<AuthAccountsResponse> {
-    const responseData = await this.get(`/auth/accounts/${address}`);
+  public async authAccounts(address: Address, height?: string): Promise<AuthAccountsResponse> {
+    const path =
+      height === undefined ? `/auth/accounts/${address}` : `/auth/accounts/${address}?tx.height=${height}`;
+    const responseData = await this.get(path);
     if ((responseData as any).result.type !== "cosmos-sdk/Account") {
       throw new Error("Unexpected response data format");
     }

--- a/packages/iov-cosmos/src/restclient.ts
+++ b/packages/iov-cosmos/src/restclient.ts
@@ -92,7 +92,11 @@ export class RestClient {
 
   public async get(path: string): Promise<RestClientResponse> {
     const url = this.baseUrl + path;
-    return axios.get(url).then(res => res.data);
+    const { data } = await axios.get(url);
+    if (data === null) {
+      throw new Error("Received null response from server");
+    }
+    return data;
   }
 
   public async post(path: string, params: PostTxsParams): Promise<RestClientResponse> {

--- a/packages/iov-cosmos/src/restclient.ts
+++ b/packages/iov-cosmos/src/restclient.ts
@@ -1,0 +1,86 @@
+import { Address } from "@iov/bcp";
+import amino from "@tendermint/amino-js";
+import axios from "axios";
+
+interface NodeInfo {
+  readonly network: string;
+}
+
+interface NodeInfoResponse {
+  readonly node_info: NodeInfo;
+}
+
+interface BlockMeta {
+  readonly header: {
+    readonly height: number;
+    readonly time: string;
+    readonly num_txs: number;
+  };
+  readonly block_id: {
+    readonly hash: string;
+  };
+}
+
+interface Block {
+  readonly header: {
+    readonly height: number;
+  };
+}
+
+interface BlocksResponse {
+  readonly block_meta: BlockMeta;
+  readonly block: Block;
+}
+
+interface AuthAccountsResponse {
+  readonly result: {
+    readonly value: amino.BaseAccount;
+  };
+}
+
+type RestClientResponse = NodeInfoResponse | BlocksResponse | AuthAccountsResponse;
+
+export class RestClient {
+  private readonly baseUrl: string;
+
+  public constructor(url: string) {
+    this.baseUrl = url;
+  }
+
+  public async get(path: string): Promise<RestClientResponse> {
+    const url = this.baseUrl + path;
+    return axios.request({ url: url, method: "GET" }).then(res => res.data);
+  }
+
+  public async nodeInfo(): Promise<NodeInfoResponse> {
+    const responseData = await this.get("/node_info");
+    if (!(responseData as any).node_info) {
+      throw new Error("Unexpected response data format");
+    }
+    return responseData as NodeInfoResponse;
+  }
+
+  public async blocksLatest(): Promise<BlocksResponse> {
+    const responseData = await this.get("/blocks/latest");
+    if (!(responseData as any).block) {
+      throw new Error("Unexpected response data format");
+    }
+    return responseData as BlocksResponse;
+  }
+
+  public async blocks(height: number): Promise<BlocksResponse> {
+    const responseData = await this.get(`/blocks/${height}`);
+    if (!(responseData as any).block) {
+      throw new Error("Unexpected response data format");
+    }
+    return responseData as BlocksResponse;
+  }
+
+  public async authAccounts(address: Address): Promise<AuthAccountsResponse> {
+    const responseData = await this.get(`/auth/accounts/${address}`);
+    if ((responseData as any).result.type !== "cosmos-sdk/Account") {
+      throw new Error("Unexpected response data format");
+    }
+    return responseData as AuthAccountsResponse;
+  }
+}

--- a/packages/iov-cosmos/src/restclient.ts
+++ b/packages/iov-cosmos/src/restclient.ts
@@ -38,7 +38,7 @@ interface AuthAccountsResponse {
   };
 }
 
-interface TxsResponse {
+export interface TxsResponse {
   readonly height: string;
   readonly txhash: string;
   readonly raw_log: string;

--- a/packages/iov-cosmos/src/restclient.ts
+++ b/packages/iov-cosmos/src/restclient.ts
@@ -2,6 +2,8 @@ import { Address, PostableBytes, TransactionId } from "@iov/bcp";
 import amino, { unmarshalTx } from "@tendermint/amino-js";
 import axios, { AxiosInstance } from "axios";
 
+import { AminoTx } from "./types";
+
 interface NodeInfo {
   readonly network: string;
 }
@@ -42,7 +44,7 @@ export interface TxsResponse {
   readonly height: string;
   readonly txhash: string;
   readonly raw_log: string;
-  readonly tx: amino.Tx;
+  readonly tx: AminoTx;
 }
 
 interface SearchTxsResponse {
@@ -150,6 +152,9 @@ export class RestClient {
 
   public async txsById(id: TransactionId): Promise<TxsResponse> {
     const responseData = await this.get(`/txs/${id}`);
+    if (!(responseData as any).tx) {
+      throw new Error("Unexpected response data format");
+    }
     return responseData as TxsResponse;
   }
 
@@ -160,6 +165,9 @@ export class RestClient {
       mode: this.mode,
     };
     const responseData = await this.post("/txs", params);
+    if (!(responseData as any).txhash) {
+      throw new Error("Unexpected response data format");
+    }
     return responseData as PostTxsResponse;
   }
 }

--- a/packages/iov-cosmos/src/restclient.ts
+++ b/packages/iov-cosmos/src/restclient.ts
@@ -45,6 +45,15 @@ export interface TxsResponse {
   readonly tx: amino.Tx;
 }
 
+interface SearchTxsResponse {
+  readonly total_count: string;
+  readonly count: string;
+  readonly page_number: string;
+  readonly page_total: string;
+  readonly limit: string;
+  readonly txs: readonly TxsResponse[];
+}
+
 interface PostTxsParams {}
 
 interface PostTxsResponse {
@@ -54,7 +63,13 @@ interface PostTxsResponse {
   readonly raw_log?: string;
 }
 
-type RestClientResponse = NodeInfoResponse | BlocksResponse | AuthAccountsResponse | PostTxsResponse;
+type RestClientResponse =
+  | NodeInfoResponse
+  | BlocksResponse
+  | AuthAccountsResponse
+  | TxsResponse
+  | SearchTxsResponse
+  | PostTxsResponse;
 
 type BroadcastMode = "block" | "sync" | "async";
 
@@ -115,6 +130,14 @@ export class RestClient {
       throw new Error("Unexpected response data format");
     }
     return responseData as AuthAccountsResponse;
+  }
+
+  public async txs(query: string): Promise<SearchTxsResponse> {
+    const responseData = await this.get(`/txs?${query}`);
+    if (!(responseData as any).txs) {
+      throw new Error("Unexpected response data format");
+    }
+    return responseData as SearchTxsResponse;
   }
 
   public async txsById(id: TransactionId): Promise<TxsResponse> {

--- a/packages/iov-cosmos/types/cosmosconnection.d.ts
+++ b/packages/iov-cosmos/types/cosmosconnection.d.ts
@@ -31,10 +31,10 @@ export declare class CosmosConnection implements BlockchainConnection {
   disconnect(): void;
   chainId(): ChainId;
   height(): Promise<number>;
-  getToken(ticker: TokenTicker): Promise<Token | undefined>;
+  getToken(_ticker: TokenTicker): Promise<Token | undefined>;
   getAllTokens(): Promise<readonly Token[]>;
   getAccount(query: AccountQuery): Promise<Account | undefined>;
-  watchAccount(account: AccountQuery): Stream<Account | undefined>;
+  watchAccount(_account: AccountQuery): Stream<Account | undefined>;
   getNonce(query: AddressQuery | PubkeyQuery): Promise<Nonce>;
   getNonces(query: AddressQuery | PubkeyQuery, count: number): Promise<readonly Nonce[]>;
   getBlockHeader(height: number): Promise<BlockHeader>;
@@ -44,8 +44,8 @@ export declare class CosmosConnection implements BlockchainConnection {
   searchTx(
     query: TransactionQuery,
   ): Promise<readonly (ConfirmedTransaction<LightTransaction> | FailedTransaction)[]>;
-  listenTx(query: TransactionQuery): Stream<ConfirmedTransaction<LightTransaction> | FailedTransaction>;
-  liveTx(query: TransactionQuery): Stream<ConfirmedTransaction<LightTransaction> | FailedTransaction>;
+  listenTx(_query: TransactionQuery): Stream<ConfirmedTransaction<LightTransaction> | FailedTransaction>;
+  liveTx(_query: TransactionQuery): Stream<ConfirmedTransaction<LightTransaction> | FailedTransaction>;
   getFeeQuote(tx: UnsignedTransaction): Promise<Fee>;
   withDefaultFee<T extends UnsignedTransaction>(tx: T): Promise<T>;
   private parseAndPopulateTxResponse;

--- a/packages/iov-cosmos/types/cosmosconnection.d.ts
+++ b/packages/iov-cosmos/types/cosmosconnection.d.ts
@@ -48,4 +48,5 @@ export declare class CosmosConnection implements BlockchainConnection {
   liveTx(query: TransactionQuery): Stream<ConfirmedTransaction<LightTransaction> | FailedTransaction>;
   getFeeQuote(tx: UnsignedTransaction): Promise<Fee>;
   withDefaultFee<T extends UnsignedTransaction>(tx: T): Promise<T>;
+  private parseAndPopulateTxResponse;
 }

--- a/packages/iov-cosmos/types/cosmosconnection.d.ts
+++ b/packages/iov-cosmos/types/cosmosconnection.d.ts
@@ -23,6 +23,11 @@ import {
 import { Stream } from "xstream";
 export declare class CosmosConnection implements BlockchainConnection {
   static establish(url: string): Promise<CosmosConnection>;
+  private static initialize;
+  private readonly restClient;
+  private readonly chainData;
+  private readonly prefix;
+  private constructor();
   disconnect(): void;
   chainId(): ChainId;
   height(): Promise<number>;

--- a/packages/iov-cosmos/types/cosmosconnection.d.ts
+++ b/packages/iov-cosmos/types/cosmosconnection.d.ts
@@ -26,6 +26,7 @@ export declare class CosmosConnection implements BlockchainConnection {
   private static initialize;
   private readonly restClient;
   private readonly chainData;
+  private readonly supportedTokens;
   private readonly prefix;
   private constructor();
   disconnect(): void;

--- a/packages/iov-cosmos/types/decode.d.ts
+++ b/packages/iov-cosmos/types/decode.d.ts
@@ -1,6 +1,7 @@
 import {
   Amount,
   ChainId,
+  ConfirmedAndSignedTransaction,
   Fee,
   FullSignature,
   Identity,
@@ -9,8 +10,10 @@ import {
   SendTransaction,
   SignatureBytes,
   SignedTransaction,
+  UnsignedTransaction,
 } from "@iov/bcp";
 import amino from "@tendermint/amino-js";
+import { TxsResponse } from "./restclient";
 export declare function decodePubkey(pubkey: amino.PubKey): PubkeyBundle;
 export declare function decodeSignature(signature: string): SignatureBytes;
 export declare function decodeFullSignature(signature: amino.StdSignature, nonce: number): FullSignature;
@@ -19,3 +22,9 @@ export declare function parseMsg(msg: amino.Msg): SendTransaction;
 export declare function parseFee(fee: amino.StdFee): Fee;
 export declare function parseCreator(signature: amino.StdSignature, chainId: ChainId): Identity;
 export declare function parseTx(tx: amino.Tx, chainId: ChainId, nonce: Nonce): SignedTransaction;
+export declare function parseTxsResponse(
+  chainId: ChainId,
+  currentHeight: number,
+  nonce: Nonce,
+  response: TxsResponse,
+): ConfirmedAndSignedTransaction<UnsignedTransaction>;

--- a/packages/iov-cosmos/types/index.d.ts
+++ b/packages/iov-cosmos/types/index.d.ts
@@ -1,1 +1,3 @@
 export { cosmosCodec, CosmosCodec } from "./cosmoscodec";
+export { CosmosConnection } from "./cosmosconnection";
+export { createCosmosConnector } from "./cosmosconnector";

--- a/packages/iov-cosmos/types/restclient.d.ts
+++ b/packages/iov-cosmos/types/restclient.d.ts
@@ -1,5 +1,6 @@
 import { Address, PostableBytes, TransactionId } from "@iov/bcp";
 import amino from "@tendermint/amino-js";
+import { AminoTx } from "./types";
 interface NodeInfo {
   readonly network: string;
 }
@@ -34,7 +35,7 @@ export interface TxsResponse {
   readonly height: string;
   readonly txhash: string;
   readonly raw_log: string;
-  readonly tx: amino.Tx;
+  readonly tx: AminoTx;
 }
 interface SearchTxsResponse {
   readonly total_count: string;

--- a/packages/iov-cosmos/types/restclient.d.ts
+++ b/packages/iov-cosmos/types/restclient.d.ts
@@ -1,4 +1,4 @@
-import { Address } from "@iov/bcp";
+import { Address, PostableBytes, TransactionId } from "@iov/bcp";
 import amino from "@tendermint/amino-js";
 interface NodeInfo {
   readonly network: string;
@@ -30,14 +30,33 @@ interface AuthAccountsResponse {
     readonly value: amino.BaseAccount;
   };
 }
-declare type RestClientResponse = NodeInfoResponse | BlocksResponse | AuthAccountsResponse;
+interface TxsResponse {
+  readonly height: string;
+  readonly txhash: string;
+  readonly raw_log: string;
+  readonly tx: amino.Tx;
+}
+interface PostTxsParams {}
+interface PostTxsResponse {
+  readonly height: string;
+  readonly txhash: string;
+  readonly code?: number;
+  readonly raw_log?: string;
+}
+declare type RestClientResponse = NodeInfoResponse | BlocksResponse | AuthAccountsResponse | PostTxsResponse;
+declare type BroadcastMode = "block" | "sync" | "async";
 export declare class RestClient {
   private readonly baseUrl;
-  constructor(url: string);
+  private readonly postConfig;
+  private readonly mode;
+  constructor(url: string, mode?: BroadcastMode);
   get(path: string): Promise<RestClientResponse>;
+  post(path: string, params: PostTxsParams): Promise<RestClientResponse>;
   nodeInfo(): Promise<NodeInfoResponse>;
   blocksLatest(): Promise<BlocksResponse>;
   blocks(height: number): Promise<BlocksResponse>;
   authAccounts(address: Address): Promise<AuthAccountsResponse>;
+  txsById(id: TransactionId): Promise<TxsResponse>;
+  postTx(tx: PostableBytes): Promise<PostTxsResponse>;
 }
 export {};

--- a/packages/iov-cosmos/types/restclient.d.ts
+++ b/packages/iov-cosmos/types/restclient.d.ts
@@ -60,8 +60,7 @@ declare type RestClientResponse =
   | PostTxsResponse;
 declare type BroadcastMode = "block" | "sync" | "async";
 export declare class RestClient {
-  private readonly baseUrl;
-  private readonly postConfig;
+  private readonly client;
   private readonly mode;
   constructor(url: string, mode?: BroadcastMode);
   get(path: string): Promise<RestClientResponse>;

--- a/packages/iov-cosmos/types/restclient.d.ts
+++ b/packages/iov-cosmos/types/restclient.d.ts
@@ -1,0 +1,43 @@
+import { Address } from "@iov/bcp";
+import amino from "@tendermint/amino-js";
+interface NodeInfo {
+  readonly network: string;
+}
+interface NodeInfoResponse {
+  readonly node_info: NodeInfo;
+}
+interface BlockMeta {
+  readonly header: {
+    readonly height: number;
+    readonly time: string;
+    readonly num_txs: number;
+  };
+  readonly block_id: {
+    readonly hash: string;
+  };
+}
+interface Block {
+  readonly header: {
+    readonly height: number;
+  };
+}
+interface BlocksResponse {
+  readonly block_meta: BlockMeta;
+  readonly block: Block;
+}
+interface AuthAccountsResponse {
+  readonly result: {
+    readonly value: amino.BaseAccount;
+  };
+}
+declare type RestClientResponse = NodeInfoResponse | BlocksResponse | AuthAccountsResponse;
+export declare class RestClient {
+  private readonly baseUrl;
+  constructor(url: string);
+  get(path: string): Promise<RestClientResponse>;
+  nodeInfo(): Promise<NodeInfoResponse>;
+  blocksLatest(): Promise<BlocksResponse>;
+  blocks(height: number): Promise<BlocksResponse>;
+  authAccounts(address: Address): Promise<AuthAccountsResponse>;
+}
+export {};

--- a/packages/iov-cosmos/types/restclient.d.ts
+++ b/packages/iov-cosmos/types/restclient.d.ts
@@ -69,7 +69,7 @@ export declare class RestClient {
   nodeInfo(): Promise<NodeInfoResponse>;
   blocksLatest(): Promise<BlocksResponse>;
   blocks(height: number): Promise<BlocksResponse>;
-  authAccounts(address: Address): Promise<AuthAccountsResponse>;
+  authAccounts(address: Address, height?: string): Promise<AuthAccountsResponse>;
   txs(query: string): Promise<SearchTxsResponse>;
   txsById(id: TransactionId): Promise<TxsResponse>;
   postTx(tx: PostableBytes): Promise<PostTxsResponse>;

--- a/packages/iov-cosmos/types/restclient.d.ts
+++ b/packages/iov-cosmos/types/restclient.d.ts
@@ -30,7 +30,7 @@ interface AuthAccountsResponse {
     readonly value: amino.BaseAccount;
   };
 }
-interface TxsResponse {
+export interface TxsResponse {
   readonly height: string;
   readonly txhash: string;
   readonly raw_log: string;

--- a/packages/iov-cosmos/types/restclient.d.ts
+++ b/packages/iov-cosmos/types/restclient.d.ts
@@ -36,6 +36,14 @@ export interface TxsResponse {
   readonly raw_log: string;
   readonly tx: amino.Tx;
 }
+interface SearchTxsResponse {
+  readonly total_count: string;
+  readonly count: string;
+  readonly page_number: string;
+  readonly page_total: string;
+  readonly limit: string;
+  readonly txs: readonly TxsResponse[];
+}
 interface PostTxsParams {}
 interface PostTxsResponse {
   readonly height: string;
@@ -43,7 +51,13 @@ interface PostTxsResponse {
   readonly code?: number;
   readonly raw_log?: string;
 }
-declare type RestClientResponse = NodeInfoResponse | BlocksResponse | AuthAccountsResponse | PostTxsResponse;
+declare type RestClientResponse =
+  | NodeInfoResponse
+  | BlocksResponse
+  | AuthAccountsResponse
+  | TxsResponse
+  | SearchTxsResponse
+  | PostTxsResponse;
 declare type BroadcastMode = "block" | "sync" | "async";
 export declare class RestClient {
   private readonly baseUrl;
@@ -56,6 +70,7 @@ export declare class RestClient {
   blocksLatest(): Promise<BlocksResponse>;
   blocks(height: number): Promise<BlocksResponse>;
   authAccounts(address: Address): Promise<AuthAccountsResponse>;
+  txs(query: string): Promise<SearchTxsResponse>;
   txsById(id: TransactionId): Promise<TxsResponse>;
   postTx(tx: PostableBytes): Promise<PostTxsResponse>;
 }

--- a/packages/iov-keycontrol/src/hdpaths.spec.ts
+++ b/packages/iov-keycontrol/src/hdpaths.spec.ts
@@ -78,4 +78,23 @@ describe("HdPaths", () => {
       Slip10RawIndex.normal(123),
     ]);
   });
+
+  it("has working Cosmos implementation", () => {
+    // m/44'/118'/0'/0/0
+    expect(HdPaths.cosmos(0)).toEqual([
+      Slip10RawIndex.hardened(44),
+      Slip10RawIndex.hardened(118),
+      Slip10RawIndex.hardened(0),
+      Slip10RawIndex.normal(0),
+      Slip10RawIndex.normal(0),
+    ]);
+    // m/44'/118'/0'/0/123
+    expect(HdPaths.cosmos(123)).toEqual([
+      Slip10RawIndex.hardened(44),
+      Slip10RawIndex.hardened(118),
+      Slip10RawIndex.hardened(0),
+      Slip10RawIndex.normal(0),
+      Slip10RawIndex.normal(123),
+    ]);
+  });
 });

--- a/packages/iov-keycontrol/src/hdpaths.ts
+++ b/packages/iov-keycontrol/src/hdpaths.ts
@@ -94,6 +94,10 @@ export class HdPaths {
     return HdPaths.bip44(HdPaths.coinTypes.eth, 0, 0, account);
   }
 
+  public static cosmos(account: number): readonly Slip10RawIndex[] {
+    return HdPaths.bip44(HdPaths.coinTypes.atom, 0, 0, account);
+  }
+
   private static readonly purposes = {
     bip44: 44,
     iov: 4804438,
@@ -106,6 +110,7 @@ export class HdPaths {
   private static readonly coinTypes = {
     testnet: 1,
     eth: 60,
+    atom: 118,
     iov: 234,
   };
 }

--- a/packages/iov-keycontrol/types/hdpaths.d.ts
+++ b/packages/iov-keycontrol/types/hdpaths.d.ts
@@ -58,6 +58,7 @@ export declare class HdPaths {
    * @param account The account index `a` starting at 0
    */
   static ethereum(account: number): readonly Slip10RawIndex[];
+  static cosmos(account: number): readonly Slip10RawIndex[];
   private static readonly purposes;
   /**
    * Coin types as registered at

--- a/scripts/cosmos/.gaiad/config/genesis.json
+++ b/scripts/cosmos/.gaiad/config/genesis.json
@@ -173,7 +173,7 @@
             "amount": "1000000000"
           },
           {
-            "denom": "vatom",
+            "denom": "uatom",
             "amount": "1000000000"
           }
         ],

--- a/scripts/cosmos/start.sh
+++ b/scripts/cosmos/start.sh
@@ -37,7 +37,7 @@ docker run \
 
 echo "gaiad running and logging into $GAIAD_LOGFILE"
 
-sleep 2
+sleep 10
 
 docker exec "$CONTAINER_NAME" \
   gaiacli rest-server \

--- a/scripts/cosmos/start.sh
+++ b/scripts/cosmos/start.sh
@@ -46,4 +46,4 @@ docker exec "$CONTAINER_NAME" \
   --laddr tcp://0.0.0.0:1317 \
   > "$REST_SERVER_LOGFILE" &
 
-echo "rest server running and logging into $REST_SERVER_LOGFILE"
+echo "rest server running on http://localhost:1317 and logging into $REST_SERVER_LOGFILE"


### PR DESCRIPTION
Part 2 of #1220 
Merge after #1284 

- connection implementation
- very basic REST client (RPC requires Tendermint v0.32)
- Cosmos HD paths

Connection methods not implemented:
- anything requiring streams
- `getToken`/`getAllTokens`: no obvious (documented) way to query for these via the REST API