### PR TITLE
Upgrade libsodium-wrappers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - @iov/bns: Upgrade weave to v0.21.3.
 - @iov/bns: Support SetMsgFee in CreateProposal transactions.
+- @iov/crypto: Upgrade to libsodium-wrappers v0.7.6. This means @iov/cli now
+  supports Node v12.
 
 ## 1.1.0
 

--- a/packages/iov-crypto/package.json
+++ b/packages/iov-crypto/package.json
@@ -50,6 +50,6 @@
     "unorm": "^1.5.0"
   },
   "devDependencies": {
-    "@types/libsodium-wrappers": "^0.7.5"
+    "@types/libsodium-wrappers": "^0.7.6"
   }
 }

--- a/packages/iov-crypto/package.json
+++ b/packages/iov-crypto/package.json
@@ -43,7 +43,7 @@
     "bn.js": "^4.11.8",
     "elliptic": "^6.4.0",
     "js-sha3": "^0.8.0",
-    "libsodium-wrappers": "^0.7.5",
+    "libsodium-wrappers": "^0.7.6",
     "pbkdf2": "^3.0.16",
     "sha.js": "^2.4.11",
     "type-tagger": "^1.0.0",

--- a/packages/iov-crypto/package.json
+++ b/packages/iov-crypto/package.json
@@ -50,6 +50,6 @@
     "unorm": "^1.5.0"
   },
   "devDependencies": {
-    "@types/libsodium-wrappers": "^0.7.6"
+    "@types/libsodium-wrappers": "^0.7.7"
   }
 }

--- a/packages/iov-crypto/src/libsodium.ts
+++ b/packages/iov-crypto/src/libsodium.ts
@@ -99,7 +99,7 @@ export class Xchacha20poly1305Ietf {
   ): Promise<Xchacha20poly1305IetfCiphertext> {
     await sodium.ready;
 
-    const additionalData = undefined;
+    const additionalData = null;
 
     return sodium.crypto_aead_xchacha20poly1305_ietf_encrypt(
       message,
@@ -117,7 +117,7 @@ export class Xchacha20poly1305Ietf {
   ): Promise<Xchacha20poly1305IetfMessage> {
     await sodium.ready;
 
-    const additionalData = undefined;
+    const additionalData = null;
 
     return sodium.crypto_aead_xchacha20poly1305_ietf_decrypt(
       null, // secret nonce: unused and should be null (https://download.libsodium.org/doc/secret-key_cryptography/aead/chacha20-poly1305/xchacha20-poly1305_construction)

--- a/yarn.lock
+++ b/yarn.lock
@@ -960,10 +960,10 @@
     "@types/abstract-leveldown" "*"
     "@types/node" "*"
 
-"@types/libsodium-wrappers@^0.7.5":
-  version "0.7.5"
-  resolved "https://registry.yarnpkg.com/@types/libsodium-wrappers/-/libsodium-wrappers-0.7.5.tgz#3cdda11ebf6b70bf40cfa2c483d7622897277bc4"
-  integrity sha512-CfxNQj3+fUwGhV20/yRoiMRjLN6+3cDRAjN2eQ0XKgq/IBhvROsbWxPa34JIiMKGdfHKy92OaMnViyoWw2Nrkg==
+"@types/libsodium-wrappers@^0.7.6":
+  version "0.7.7"
+  resolved "https://registry.yarnpkg.com/@types/libsodium-wrappers/-/libsodium-wrappers-0.7.7.tgz#cdb25e85458612ec80f0157c3815fac187d0b6d2"
+  integrity sha512-Li91pVKcLvQJK3ZolwCPo85oxf2gKBCApgnesRxYg4OVYchLXcJB2eivX8S87vfQVv6ZRnyCO1lLDosZGJfpRg==
 
 "@types/long@^4.0.0":
   version "4.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4554,17 +4554,17 @@ levn@^0.3.0, levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
-libsodium-wrappers@^0.7.5:
-  version "0.7.5"
-  resolved "https://registry.yarnpkg.com/libsodium-wrappers/-/libsodium-wrappers-0.7.5.tgz#a880a99250edecead36a336b9d9eb7192ca405b4"
-  integrity sha512-QE9Q+FxLLGdJRiJTuC2GB3LEHZeHX/VcbMQeNPdAixEKo86JPy6bOWND1XmMLu0tjWUu0xIY0YpJYQApxIZwbQ==
+libsodium-wrappers@^0.7.6:
+  version "0.7.6"
+  resolved "https://registry.yarnpkg.com/libsodium-wrappers/-/libsodium-wrappers-0.7.6.tgz#baed4c16d4bf9610104875ad8a8e164d259d48fb"
+  integrity sha512-OUO2CWW5bHdLr6hkKLHIKI4raEkZrf3QHkhXsJ1yCh6MZ3JDA7jFD3kCATNquuGSG6MjjPHQIQms0y0gBDzjQg==
   dependencies:
-    libsodium "0.7.5"
+    libsodium "0.7.6"
 
-libsodium@0.7.5:
-  version "0.7.5"
-  resolved "https://registry.yarnpkg.com/libsodium/-/libsodium-0.7.5.tgz#a45a0a88a6f7a39291b053447908a76570138e09"
-  integrity sha512-0YVU2QJc5sDR5HHkGCaliYImS7pGeXi11fiOfm4DirBd96PJVZIn3LJa06ZOFjLNsWkL3UbNjYhLRUOABPL9vw==
+libsodium@0.7.6:
+  version "0.7.6"
+  resolved "https://registry.yarnpkg.com/libsodium/-/libsodium-0.7.6.tgz#018b80c5728054817845fbffa554274441bda277"
+  integrity sha512-hPb/04sEuLcTRdWDtd+xH3RXBihpmbPCsKW/Jtf4PsvdyKh+D6z2D2gvp/5BfoxseP+0FCOg66kE+0oGUE/loQ==
 
 load-json-file@^1.0.0:
   version "1.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -960,7 +960,7 @@
     "@types/abstract-leveldown" "*"
     "@types/node" "*"
 
-"@types/libsodium-wrappers@^0.7.6":
+"@types/libsodium-wrappers@^0.7.7":
   version "0.7.7"
   resolved "https://registry.yarnpkg.com/@types/libsodium-wrappers/-/libsodium-wrappers-0.7.7.tgz#cdb25e85458612ec80f0157c3815fac187d0b6d2"
   integrity sha512-Li91pVKcLvQJK3ZolwCPo85oxf2gKBCApgnesRxYg4OVYchLXcJB2eivX8S87vfQVv6ZRnyCO1lLDosZGJfpRg==


### PR DESCRIPTION
Closes #1097

Confusingly, there’s a v0.7.7 available for @types/libsodium-wrappers even though I couldn’t see a v0.7.7 for libsodium-wrappers itself, and the v0.7.6 types were released at the same time as libsodium-wrappers.