### PR TITLE
Allow fee payer to be specified in BNS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## 2.0.0
 
 - @iov/bns: Add support for weave to v0.23.0.
+- @iov/bcp: Add optional payer field to Fee type.
+- @iov/bns: Add optional payer parameter to BnsConnection.withDefaultFee.
 
 Breaking changes
 

--- a/packages/iov-bcp/src/transactions.ts
+++ b/packages/iov-bcp/src/transactions.ts
@@ -194,6 +194,7 @@ export interface LightTransaction {
    */
   readonly kind: string;
   readonly fee?: Fee;
+  readonly feePayer?: Address;
 }
 
 export function isLightTransaction(data: unknown): data is LightTransaction {

--- a/packages/iov-bcp/src/transactions.ts
+++ b/packages/iov-bcp/src/transactions.ts
@@ -169,7 +169,7 @@ export interface Fee {
   readonly tokens?: Amount;
   readonly gasPrice?: Amount;
   readonly gasLimit?: string;
-  readonly feePayer?: Address;
+  readonly payer?: Address;
 }
 
 export function isFee(data: unknown): data is Fee {

--- a/packages/iov-bcp/src/transactions.ts
+++ b/packages/iov-bcp/src/transactions.ts
@@ -169,6 +169,7 @@ export interface Fee {
   readonly tokens?: Amount;
   readonly gasPrice?: Amount;
   readonly gasLimit?: string;
+  readonly feePayer?: Address;
 }
 
 export function isFee(data: unknown): data is Fee {
@@ -194,7 +195,6 @@ export interface LightTransaction {
    */
   readonly kind: string;
   readonly fee?: Fee;
-  readonly feePayer?: Address;
 }
 
 export function isLightTransaction(data: unknown): data is LightTransaction {

--- a/packages/iov-bcp/types/transactions.d.ts
+++ b/packages/iov-bcp/types/transactions.d.ts
@@ -101,7 +101,7 @@ export interface Fee {
   readonly tokens?: Amount;
   readonly gasPrice?: Amount;
   readonly gasLimit?: string;
-  readonly feePayer?: Address;
+  readonly payer?: Address;
 }
 export declare function isFee(data: unknown): data is Fee;
 /** The basic transaction type all transactions should extend */

--- a/packages/iov-bcp/types/transactions.d.ts
+++ b/packages/iov-bcp/types/transactions.d.ts
@@ -118,6 +118,7 @@ export interface LightTransaction {
    */
   readonly kind: string;
   readonly fee?: Fee;
+  readonly feePayer?: Address;
 }
 export declare function isLightTransaction(data: unknown): data is LightTransaction;
 export interface WithCreator {

--- a/packages/iov-bcp/types/transactions.d.ts
+++ b/packages/iov-bcp/types/transactions.d.ts
@@ -101,6 +101,7 @@ export interface Fee {
   readonly tokens?: Amount;
   readonly gasPrice?: Amount;
   readonly gasLimit?: string;
+  readonly feePayer?: Address;
 }
 export declare function isFee(data: unknown): data is Fee;
 /** The basic transaction type all transactions should extend */
@@ -118,7 +119,6 @@ export interface LightTransaction {
    */
   readonly kind: string;
   readonly fee?: Fee;
-  readonly feePayer?: Address;
 }
 export declare function isLightTransaction(data: unknown): data is LightTransaction;
 export interface WithCreator {

--- a/packages/iov-bns-governance/src/governor.spec.ts
+++ b/packages/iov-bns-governance/src/governor.spec.ts
@@ -211,6 +211,7 @@ describe("Governor", () => {
             fractionalDigits: 9,
             tokenTicker: "CASH" as TokenTicker,
           },
+          payer: undefined,
         },
       });
 
@@ -253,6 +254,7 @@ describe("Governor", () => {
             fractionalDigits: 9,
             tokenTicker: "CASH" as TokenTicker,
           },
+          payer: undefined,
         },
       });
 
@@ -294,6 +296,7 @@ describe("Governor", () => {
             fractionalDigits: 9,
             tokenTicker: "CASH" as TokenTicker,
           },
+          payer: undefined,
         },
       });
 
@@ -344,6 +347,7 @@ describe("Governor", () => {
             fractionalDigits: 9,
             tokenTicker: "CASH" as TokenTicker,
           },
+          payer: undefined,
         },
       });
 
@@ -394,6 +398,7 @@ describe("Governor", () => {
             fractionalDigits: 9,
             tokenTicker: "CASH" as TokenTicker,
           },
+          payer: undefined,
         },
       });
 
@@ -437,6 +442,7 @@ describe("Governor", () => {
             fractionalDigits: 9,
             tokenTicker: "CASH" as TokenTicker,
           },
+          payer: undefined,
         },
       });
 
@@ -479,6 +485,7 @@ describe("Governor", () => {
             fractionalDigits: 9,
             tokenTicker: "CASH" as TokenTicker,
           },
+          payer: undefined,
         },
       });
 
@@ -525,6 +532,7 @@ describe("Governor", () => {
             fractionalDigits: 9,
             tokenTicker: "CASH" as TokenTicker,
           },
+          payer: undefined,
         },
       });
       options.connection.disconnect();
@@ -612,6 +620,7 @@ describe("Governor", () => {
             fractionalDigits: 9,
             tokenTicker: "CASH" as TokenTicker,
           },
+          payer: undefined,
         },
       });
 
@@ -637,6 +646,7 @@ describe("Governor", () => {
             fractionalDigits: 9,
             tokenTicker: "CASH" as TokenTicker,
           },
+          payer: undefined,
         },
       });
 

--- a/packages/iov-bns/src/bnsconnection.posttxs.spec.ts
+++ b/packages/iov-bns/src/bnsconnection.posttxs.spec.ts
@@ -84,6 +84,7 @@ describe("BnsConnection (txs)", () => {
       const sendTx = await connection.withDefaultFee<SendTransaction & WithCreator>({
         kind: "bcp/send",
         creator: faucet,
+        feePayer: faucetAddr,
         sender: bnsCodec.identityToAddress(faucet),
         recipient: recipient,
         memo: "My first payment",

--- a/packages/iov-bns/src/bnsconnection.posttxs.spec.ts
+++ b/packages/iov-bns/src/bnsconnection.posttxs.spec.ts
@@ -81,19 +81,21 @@ describe("BnsConnection (txs)", () => {
       const recipient = await randomBnsAddress();
 
       // construct a sendtx, this is normally used in the MultiChainSigner api
-      const sendTx = await connection.withDefaultFee<SendTransaction & WithCreator>({
-        kind: "bcp/send",
-        creator: faucet,
-        feePayer: faucetAddr,
-        sender: bnsCodec.identityToAddress(faucet),
-        recipient: recipient,
-        memo: "My first payment",
-        amount: {
-          quantity: "5000075000",
-          fractionalDigits: 9,
-          tokenTicker: cash,
+      const sendTx = await connection.withDefaultFee<SendTransaction & WithCreator>(
+        {
+          kind: "bcp/send",
+          creator: faucet,
+          sender: bnsCodec.identityToAddress(faucet),
+          recipient: recipient,
+          memo: "My first payment",
+          amount: {
+            quantity: "5000075000",
+            fractionalDigits: 9,
+            tokenTicker: cash,
+          },
         },
-      });
+        faucetAddr,
+      );
       const nonce = await connection.getNonce({ pubkey: faucet.pubkey });
       const signed = await profile.signTransaction(sendTx, bnsCodec, nonce);
       const txBytes = bnsCodec.bytesToPost(signed);
@@ -514,13 +516,15 @@ describe("BnsConnection (txs)", () => {
           address: "some-initial-address" as Address,
         },
       ];
-      const registerUsernameTx = await connection.withDefaultFee<RegisterUsernameTx & WithCreator>({
-        kind: "bns/register_username",
-        creator: user,
-        username: username,
-        targets: initialTargets,
-        feePayer: faucetAddress,
-      });
+      const registerUsernameTx = await connection.withDefaultFee<RegisterUsernameTx & WithCreator>(
+        {
+          kind: "bns/register_username",
+          creator: user,
+          username: username,
+          targets: initialTargets,
+        },
+        faucetAddress,
+      );
       const nonceUser1 = await connection.getNonce({ pubkey: user.pubkey });
       const signed1 = await profile.signTransaction(registerUsernameTx, bnsCodec, nonceUser1);
       const nonceFaucet1 = await connection.getNonce({ pubkey: faucet.pubkey });

--- a/packages/iov-bns/src/bnsconnection.posttxs.spec.ts
+++ b/packages/iov-bns/src/bnsconnection.posttxs.spec.ts
@@ -1,4 +1,5 @@
 import {
+  Address,
   BlockInfo,
   ChainId,
   isBlockInfoPending,
@@ -36,6 +37,7 @@ import {
 } from "./testutils.spec";
 import {
   ActionKind,
+  ChainAddressPair,
   CreateEscrowTx,
   CreateMultisignatureTx,
   CreateProposalTx,
@@ -484,6 +486,79 @@ describe("BnsConnection (txs)", () => {
 
       const usernameAfterTransfer = (await connection.getUsernames({ username: username }))[0];
       expect(usernameAfterTransfer.owner).toEqual(unusedAddress);
+
+      connection.disconnect();
+    });
+
+    it("can register and update a username for an empty account", async () => {
+      pendingWithoutBnsd();
+      const connection = await BnsConnection.establish(bnsdTendermintUrl);
+      const chainId = connection.chainId();
+
+      const { profile, faucet, walletId } = await userProfileWithFaucet(chainId);
+      const faucetAddress = identityToAddress(faucet);
+      const brokeAccountPath = HdPaths.iov(666);
+      const user = await profile.createIdentity(walletId, chainId, brokeAccountPath);
+      const userAddress = identityToAddress(user);
+      const username = `user${Math.random()}*iov`;
+
+      const userAccount = await connection.getAccount({ address: userAddress });
+      if (userAccount && userAccount.balance.length) {
+        throw new Error("Test should be run using empty account");
+      }
+
+      const initialTargets: readonly ChainAddressPair[] = [
+        {
+          chainId: "some-initial-chain" as ChainId,
+          address: "some-initial-address" as Address,
+        },
+      ];
+      const registerUsernameTx = await connection.withDefaultFee<RegisterUsernameTx & WithCreator>({
+        kind: "bns/register_username",
+        creator: user,
+        username: username,
+        targets: initialTargets,
+        feePayer: faucetAddress,
+      });
+      const nonceUser1 = await connection.getNonce({ pubkey: user.pubkey });
+      const signed1 = await profile.signTransaction(registerUsernameTx, bnsCodec, nonceUser1);
+      const nonceFaucet1 = await connection.getNonce({ pubkey: faucet.pubkey });
+      const doubleSigned1 = await profile.appendSignature(faucet, signed1, bnsCodec, nonceFaucet1);
+      const txBytes1 = bnsCodec.bytesToPost(doubleSigned1);
+      const response1 = await connection.postTx(txBytes1);
+      const blockInfo1 = await response1.blockInfo.waitFor(info => !isBlockInfoPending(info));
+      expect(blockInfo1.state).toEqual(TransactionState.Succeeded);
+
+      const retrieved1 = await connection.getUsernames({ username: username });
+      expect(retrieved1.length).toEqual(1);
+      expect(retrieved1[0].owner).toEqual(userAddress);
+      expect(retrieved1[0].targets).toEqual(initialTargets);
+
+      const updatedTargets: readonly ChainAddressPair[] = [
+        {
+          chainId: "some-updated-chain" as ChainId,
+          address: "some-updated-address" as Address,
+        },
+      ];
+      const updateTargetsTx = await connection.withDefaultFee<UpdateTargetsOfUsernameTx & WithCreator>({
+        kind: "bns/update_targets_of_username",
+        creator: faucet,
+        username: username,
+        targets: updatedTargets,
+      });
+      const nonce3 = await connection.getNonce({ pubkey: faucet.pubkey });
+      const signed3 = await profile.signTransaction(updateTargetsTx, bnsCodec, nonce3);
+      const nonce4 = await connection.getNonce({ pubkey: user.pubkey });
+      const doubleSigned2 = await profile.appendSignature(user, signed3, bnsCodec, nonce4);
+      const txBytes3 = bnsCodec.bytesToPost(doubleSigned2);
+      const response3 = await connection.postTx(txBytes3);
+      const blockInfo3 = await response3.blockInfo.waitFor(info => !isBlockInfoPending(info));
+      expect(blockInfo3.state).toEqual(TransactionState.Succeeded);
+
+      const retrieved2 = await connection.getUsernames({ username: username });
+      expect(retrieved2.length).toEqual(1);
+      expect(retrieved2[0].owner).toEqual(userAddress);
+      expect(retrieved2[0].targets).toEqual(updatedTargets);
 
       connection.disconnect();
     });

--- a/packages/iov-bns/src/bnsconnection.ts
+++ b/packages/iov-bns/src/bnsconnection.ts
@@ -717,8 +717,9 @@ export class BnsConnection implements AtomicSwapConnection {
     return { tokens: fee };
   }
 
-  public async withDefaultFee<T extends UnsignedTransaction>(transaction: T): Promise<T> {
-    return { ...transaction, fee: await this.getFeeQuote(transaction) };
+  public async withDefaultFee<T extends UnsignedTransaction>(transaction: T, feePayer?: Address): Promise<T> {
+    const feeQuote = await this.getFeeQuote(transaction);
+    return { ...transaction, fee: { ...feeQuote, feePayer: feePayer } };
   }
 
   protected async query(path: string, data: Uint8Array): Promise<QueryResponse> {

--- a/packages/iov-bns/src/bnsconnection.ts
+++ b/packages/iov-bns/src/bnsconnection.ts
@@ -717,9 +717,9 @@ export class BnsConnection implements AtomicSwapConnection {
     return { tokens: fee };
   }
 
-  public async withDefaultFee<T extends UnsignedTransaction>(transaction: T, feePayer?: Address): Promise<T> {
+  public async withDefaultFee<T extends UnsignedTransaction>(transaction: T, payer?: Address): Promise<T> {
     const feeQuote = await this.getFeeQuote(transaction);
-    return { ...transaction, fee: { ...feeQuote, feePayer: feePayer } };
+    return { ...transaction, fee: { ...feeQuote, payer: payer } };
   }
 
   protected async query(path: string, data: Uint8Array): Promise<QueryResponse> {

--- a/packages/iov-bns/src/bnsconnection.txs.spec.ts
+++ b/packages/iov-bns/src/bnsconnection.txs.spec.ts
@@ -1,9 +1,7 @@
 import {
   Account,
-  Address,
   BlockInfoFailed,
   BlockInfoSucceeded,
-  ChainId,
   isBlockInfoPending,
   isConfirmedTransaction,
   isFailedTransaction,
@@ -32,7 +30,6 @@ import {
   tendermintSearchIndexUpdated,
   userProfileWithFaucet,
 } from "./testutils.spec";
-import { ChainAddressPair, RegisterUsernameTx, TransferUsernameTx, UpdateTargetsOfUsernameTx } from "./types";
 import { identityToAddress } from "./util";
 
 describe("BnsConnection (txs)", () => {
@@ -646,88 +643,6 @@ describe("BnsConnection (txs)", () => {
         .subtract(0_010000000) // the fee (0.01 CASH)
         .toString(),
     );
-
-    connection.disconnect();
-  });
-
-  it("can register/transfer and update a username for an empty account", async () => {
-    pendingWithoutBnsd();
-    const connection = await BnsConnection.establish(bnsdTendermintUrl);
-    const chainId = connection.chainId();
-
-    const { profile, faucet, walletId } = await userProfileWithFaucet(chainId);
-    const brokeAccountPath = HdPaths.iov(666);
-    const user = await profile.createIdentity(walletId, chainId, brokeAccountPath);
-    const userAddress = identityToAddress(user);
-    const username = `user${Math.random()}*iov`;
-
-    const userAccount = await connection.getAccount({ address: userAddress });
-    if (userAccount && userAccount.balance.length) {
-      throw new Error("Test should be run using empty account");
-    }
-
-    const initialTargets: readonly ChainAddressPair[] = [
-      {
-        chainId: "some-initial-chain" as ChainId,
-        address: "some-initial-address" as Address,
-      },
-    ];
-    const registerUsernameTx = await connection.withDefaultFee<RegisterUsernameTx & WithCreator>({
-      kind: "bns/register_username",
-      creator: faucet,
-      username: username,
-      targets: initialTargets,
-    });
-    const nonce1 = await connection.getNonce({ pubkey: faucet.pubkey });
-    const signed1 = await profile.signTransaction(registerUsernameTx, bnsCodec, nonce1);
-    const txBytes1 = bnsCodec.bytesToPost(signed1);
-    const response1 = await connection.postTx(txBytes1);
-    const blockInfo1 = await response1.blockInfo.waitFor(info => !isBlockInfoPending(info));
-    expect(blockInfo1.state).toEqual(TransactionState.Succeeded);
-
-    const transferUsernameTx = await connection.withDefaultFee<TransferUsernameTx & WithCreator>({
-      kind: "bns/transfer_username",
-      creator: faucet,
-      username: username,
-      newOwner: userAddress,
-    });
-    const nonce2 = await connection.getNonce({ pubkey: faucet.pubkey });
-    const signed2 = await profile.signTransaction(transferUsernameTx, bnsCodec, nonce2);
-    const txBytes2 = bnsCodec.bytesToPost(signed2);
-    const response2 = await connection.postTx(txBytes2);
-    const blockInfo2 = await response2.blockInfo.waitFor(info => !isBlockInfoPending(info));
-    expect(blockInfo2.state).toEqual(TransactionState.Succeeded);
-
-    const retrieved1 = await connection.getUsernames({ username: username });
-    expect(retrieved1.length).toEqual(1);
-    expect(retrieved1[0].owner).toEqual(userAddress);
-    expect(retrieved1[0].targets).toEqual(initialTargets);
-
-    const updatedTargets: readonly ChainAddressPair[] = [
-      {
-        chainId: "some-updated-chain" as ChainId,
-        address: "some-updated-address" as Address,
-      },
-    ];
-    const updateTargetsTx = await connection.withDefaultFee<UpdateTargetsOfUsernameTx & WithCreator>({
-      kind: "bns/update_targets_of_username",
-      creator: faucet,
-      username: username,
-      targets: updatedTargets,
-    });
-    const nonce3 = await connection.getNonce({ pubkey: faucet.pubkey });
-    const signed3 = await profile.signTransaction(updateTargetsTx, bnsCodec, nonce3);
-    const nonce4 = await connection.getNonce({ pubkey: user.pubkey });
-    const doubleSigned = await profile.appendSignature(user, signed3, bnsCodec, nonce4);
-    const txBytes3 = bnsCodec.bytesToPost(doubleSigned);
-    const response3 = await connection.postTx(txBytes3);
-    const blockInfo3 = await response3.blockInfo.waitFor(info => !isBlockInfoPending(info));
-    expect(blockInfo3.state).toEqual(TransactionState.Succeeded);
-
-    const retrieved2 = await connection.getUsernames({ username: username });
-    expect(retrieved2.length).toEqual(1);
-    expect(retrieved2[0].owner).toEqual(userAddress);
-    expect(retrieved2[0].targets).toEqual(updatedTargets);
 
     connection.disconnect();
   });

--- a/packages/iov-bns/src/decode.ts
+++ b/packages/iov-bns/src/decode.ts
@@ -767,8 +767,8 @@ function parseBaseTx(tx: codecImpl.bnsd.ITx, sig: FullSignature, chainId: ChainI
   };
   if (tx.fees && tx.fees.fees) {
     const prefix = addressPrefix(base.creator.chainId);
-    const feePayer = tx.fees.payer ? encodeBnsAddress(prefix, tx.fees.payer) : undefined;
-    base = { ...base, fee: { tokens: decodeAmount(tx.fees.fees), feePayer: feePayer } };
+    const payer = tx.fees.payer ? encodeBnsAddress(prefix, tx.fees.payer) : undefined;
+    base = { ...base, fee: { tokens: decodeAmount(tx.fees.fees), payer: payer } };
   }
   if (tx.multisig && tx.multisig.length) {
     base = { ...base, multisig: tx.multisig.map(decodeNumericId) };

--- a/packages/iov-bns/src/decode.ts
+++ b/packages/iov-bns/src/decode.ts
@@ -766,11 +766,9 @@ function parseBaseTx(tx: codecImpl.bnsd.ITx, sig: FullSignature, chainId: ChainI
     },
   };
   if (tx.fees && tx.fees.fees) {
-    base = { ...base, fee: { tokens: decodeAmount(tx.fees.fees) } };
-  }
-  if (tx.fees && tx.fees.payer) {
     const prefix = addressPrefix(base.creator.chainId);
-    base = { ...base, feePayer: encodeBnsAddress(prefix, tx.fees.payer) };
+    const feePayer = tx.fees.payer ? encodeBnsAddress(prefix, tx.fees.payer) : undefined;
+    base = { ...base, fee: { tokens: decodeAmount(tx.fees.fees), feePayer: feePayer } };
   }
   if (tx.multisig && tx.multisig.length) {
     base = { ...base, multisig: tx.multisig.map(decodeNumericId) };

--- a/packages/iov-bns/src/decode.ts
+++ b/packages/iov-bns/src/decode.ts
@@ -768,6 +768,10 @@ function parseBaseTx(tx: codecImpl.bnsd.ITx, sig: FullSignature, chainId: ChainI
   if (tx.fees && tx.fees.fees) {
     base = { ...base, fee: { tokens: decodeAmount(tx.fees.fees) } };
   }
+  if (tx.fees && tx.fees.payer) {
+    const prefix = addressPrefix(base.creator.chainId);
+    base = { ...base, feePayer: encodeBnsAddress(prefix, tx.fees.payer) };
+  }
   if (tx.multisig && tx.multisig.length) {
     base = { ...base, multisig: tx.multisig.map(decodeNumericId) };
   }

--- a/packages/iov-bns/src/encode.spec.ts
+++ b/packages/iov-bns/src/encode.spec.ts
@@ -241,6 +241,32 @@ describe("Encode", () => {
       expect(encoded.cashSendMsg!.memo).toEqual("paid transaction");
     });
 
+    it("can encode transaction with fees when fee payer is not the main signer", () => {
+      const defaultRecipientWeaveAddress = fromHex("b1ca7e78f74423ae01da3b51e676934d9105f282");
+      const transaction: SendTransaction & WithCreator = {
+        kind: "bcp/send",
+        creator: defaultCreator,
+        amount: defaultAmount,
+        sender: defaultSender,
+        recipient: defaultRecipient,
+        memo: "paid transaction",
+        fee: {
+          tokens: defaultAmount,
+        },
+        feePayer: defaultRecipient,
+      };
+
+      const encoded = buildUnsignedTx(transaction);
+      expect(encoded.fees).toBeDefined();
+      expect(encoded.fees!.fees!.whole).toEqual(1);
+      expect(encoded.fees!.fees!.fractional).toEqual(1);
+      expect(encoded.fees!.fees!.ticker).toEqual("CASH");
+      expect(encoded.fees!.payer!).toEqual(defaultRecipientWeaveAddress);
+
+      expect(encoded.cashSendMsg).toBeDefined();
+      expect(encoded.cashSendMsg!.memo).toEqual("paid transaction");
+    });
+
     it("can encode transaction with multisig", () => {
       const transaction: SendTransaction & MultisignatureTx & WithCreator = {
         kind: "bcp/send",

--- a/packages/iov-bns/src/encode.spec.ts
+++ b/packages/iov-bns/src/encode.spec.ts
@@ -252,7 +252,7 @@ describe("Encode", () => {
         memo: "paid transaction",
         fee: {
           tokens: defaultAmount,
-          feePayer: defaultRecipient,
+          payer: defaultRecipient,
         },
       };
 

--- a/packages/iov-bns/src/encode.spec.ts
+++ b/packages/iov-bns/src/encode.spec.ts
@@ -252,8 +252,8 @@ describe("Encode", () => {
         memo: "paid transaction",
         fee: {
           tokens: defaultAmount,
+          feePayer: defaultRecipient,
         },
-        feePayer: defaultRecipient,
       };
 
       const encoded = buildUnsignedTx(transaction);

--- a/packages/iov-bns/src/encode.ts
+++ b/packages/iov-bns/src/encode.ts
@@ -499,8 +499,8 @@ export function buildUnsignedTx(tx: UnsignedTransaction): codecImpl.bnsd.ITx {
   const msg = buildMsg(tx);
 
   let feePayerAddressBytes: Uint8Array;
-  if (tx.fee && tx.fee.feePayer) {
-    feePayerAddressBytes = decodeBnsAddress(tx.fee.feePayer).data;
+  if (tx.fee && tx.fee.payer) {
+    feePayerAddressBytes = decodeBnsAddress(tx.fee.payer).data;
   } else if (isMultisignatureTx(tx)) {
     const firstContract = tx.multisig.find(() => true);
     if (firstContract === undefined) throw new Error("Empty multisig arrays are currently unsupported");

--- a/packages/iov-bns/src/encode.ts
+++ b/packages/iov-bns/src/encode.ts
@@ -498,13 +498,15 @@ export function buildMsg(tx: UnsignedTransaction): codecImpl.bnsd.ITx {
 export function buildUnsignedTx(tx: UnsignedTransaction): codecImpl.bnsd.ITx {
   const msg = buildMsg(tx);
 
-  let feePayer: Uint8Array;
-  if (isMultisignatureTx(tx)) {
+  let feePayerAddressBytes: Uint8Array;
+  if (tx.feePayer) {
+    feePayerAddressBytes = decodeBnsAddress(tx.feePayer).data;
+  } else if (isMultisignatureTx(tx)) {
     const firstContract = tx.multisig.find(() => true);
     if (firstContract === undefined) throw new Error("Empty multisig arrays are currently unsupported");
-    feePayer = conditionToWeaveAddress(buildMultisignatureCondition(firstContract));
+    feePayerAddressBytes = conditionToWeaveAddress(buildMultisignatureCondition(firstContract));
   } else {
-    feePayer = decodeBnsAddress(identityToAddress(tx.creator)).data;
+    feePayerAddressBytes = decodeBnsAddress(identityToAddress(tx.creator)).data;
   }
 
   return codecImpl.bnsd.Tx.create({
@@ -513,7 +515,7 @@ export function buildUnsignedTx(tx: UnsignedTransaction): codecImpl.bnsd.ITx {
       tx.fee && tx.fee.tokens
         ? {
             fees: encodeAmount(tx.fee.tokens),
-            payer: feePayer,
+            payer: feePayerAddressBytes,
           }
         : null,
     multisig: isMultisignatureTx(tx) ? tx.multisig.map(encodeNumericId) : null,

--- a/packages/iov-bns/src/encode.ts
+++ b/packages/iov-bns/src/encode.ts
@@ -499,8 +499,8 @@ export function buildUnsignedTx(tx: UnsignedTransaction): codecImpl.bnsd.ITx {
   const msg = buildMsg(tx);
 
   let feePayerAddressBytes: Uint8Array;
-  if (tx.feePayer) {
-    feePayerAddressBytes = decodeBnsAddress(tx.feePayer).data;
+  if (tx.fee && tx.fee.feePayer) {
+    feePayerAddressBytes = decodeBnsAddress(tx.fee.feePayer).data;
   } else if (isMultisignatureTx(tx)) {
     const firstContract = tx.multisig.find(() => true);
     if (firstContract === undefined) throw new Error("Empty multisig arrays are currently unsupported");

--- a/packages/iov-bns/src/testdata.spec.ts
+++ b/packages/iov-bns/src/testdata.spec.ts
@@ -130,6 +130,7 @@ const randomMsg: SendTransaction & WithCreator = {
       tokenTicker: "PSQL" as TokenTicker,
     },
   },
+  feePayer: address,
 };
 
 export const randomTxJson: SignedTransaction = {

--- a/packages/iov-bns/src/testdata.spec.ts
+++ b/packages/iov-bns/src/testdata.spec.ts
@@ -129,7 +129,7 @@ const randomMsg: SendTransaction & WithCreator = {
       fractionalDigits: 9,
       tokenTicker: "PSQL" as TokenTicker,
     },
-    feePayer: address,
+    payer: address,
   },
 };
 

--- a/packages/iov-bns/src/testdata.spec.ts
+++ b/packages/iov-bns/src/testdata.spec.ts
@@ -129,8 +129,8 @@ const randomMsg: SendTransaction & WithCreator = {
       fractionalDigits: 9,
       tokenTicker: "PSQL" as TokenTicker,
     },
+    feePayer: address,
   },
-  feePayer: address,
 };
 
 export const randomTxJson: SignedTransaction = {

--- a/packages/iov-bns/types/bnsconnection.d.ts
+++ b/packages/iov-bns/types/bnsconnection.d.ts
@@ -119,7 +119,7 @@ export declare class BnsConnection implements AtomicSwapConnection {
   getVotes(voter: Address): Promise<readonly Vote[]>;
   getUsernames(query: BnsUsernamesQuery): Promise<readonly BnsUsernameNft[]>;
   getFeeQuote(transaction: UnsignedTransaction): Promise<Fee>;
-  withDefaultFee<T extends UnsignedTransaction>(transaction: T): Promise<T>;
+  withDefaultFee<T extends UnsignedTransaction>(transaction: T, feePayer?: Address): Promise<T>;
   protected query(path: string, data: Uint8Array): Promise<QueryResponse>;
   protected updateSwapAmounts<T extends AtomicSwap>(swap: T): Promise<T>;
   /**

--- a/packages/iov-bns/types/bnsconnection.d.ts
+++ b/packages/iov-bns/types/bnsconnection.d.ts
@@ -119,7 +119,7 @@ export declare class BnsConnection implements AtomicSwapConnection {
   getVotes(voter: Address): Promise<readonly Vote[]>;
   getUsernames(query: BnsUsernamesQuery): Promise<readonly BnsUsernameNft[]>;
   getFeeQuote(transaction: UnsignedTransaction): Promise<Fee>;
-  withDefaultFee<T extends UnsignedTransaction>(transaction: T, feePayer?: Address): Promise<T>;
+  withDefaultFee<T extends UnsignedTransaction>(transaction: T, payer?: Address): Promise<T>;
   protected query(path: string, data: Uint8Array): Promise<QueryResponse>;
   protected updateSwapAmounts<T extends AtomicSwap>(swap: T): Promise<T>;
   /**

--- a/packages/iov-multichain/src/jsonrpcsigningserver.spec.ts
+++ b/packages/iov-multichain/src/jsonrpcsigningserver.spec.ts
@@ -229,14 +229,17 @@ describe("JsonRpcSigningServer", () => {
       throw new Error("Identity element is not valid");
     }
 
-    const send = await bnsConnection.withDefaultFee<SendTransaction & WithCreator>({
-      kind: "bcp/send",
-      creator: signer,
-      sender: bnsCodec.identityToAddress(signer),
-      memo: `Hello ${Math.random()}`,
-      amount: defaultAmount,
-      recipient: await randomBnsAddress(),
-    });
+    const send = await bnsConnection.withDefaultFee<SendTransaction & WithCreator>(
+      {
+        kind: "bcp/send",
+        creator: signer,
+        sender: bnsCodec.identityToAddress(signer),
+        memo: `Hello ${Math.random()}`,
+        amount: defaultAmount,
+        recipient: await randomBnsAddress(),
+      },
+      "tiov1q5lyl7asgr2dcweqrhlfyexqpkgcuzrm4e0cku" as Address,
+    );
 
     const signAndPostResponse = await server.handleChecked({
       jsonrpc: "2.0",

--- a/packages/iov-multichain/src/signingservice.spec.ts
+++ b/packages/iov-multichain/src/signingservice.spec.ts
@@ -235,14 +235,17 @@ describe("signingservice.worker", () => {
       throw new Error("Identity element is not valid");
     }
 
-    const send = await bnsConnection.withDefaultFee<SendTransaction & WithCreator>({
-      kind: "bcp/send",
-      creator: signer,
-      sender: bnsCodec.identityToAddress(signer),
-      memo: `Hello ${Math.random()}`,
-      amount: defaultAmount,
-      recipient: await randomBnsAddress(),
-    });
+    const send = await bnsConnection.withDefaultFee<SendTransaction & WithCreator>(
+      {
+        kind: "bcp/send",
+        creator: signer,
+        sender: bnsCodec.identityToAddress(signer),
+        memo: `Hello ${Math.random()}`,
+        amount: defaultAmount,
+        recipient: await randomBnsAddress(),
+      },
+      "tiov1q5lyl7asgr2dcweqrhlfyexqpkgcuzrm4e0cku" as Address,
+    );
 
     const signAndPostResponse = await client.run({
       jsonrpc: "2.0",


### PR DESCRIPTION
Closes #1299

Exposes functionality required for #1299 without implementing batch transactions.

~~Not covered by this PR: decoding transactions to include the payer, which would perhaps require our `Fee` type to be updated.~~