### PR TITLE
Add helper to estimate BNS tx size

### DIFF
--- a/packages/iov-bns/src/bnsconnection.spec.ts
+++ b/packages/iov-bns/src/bnsconnection.spec.ts
@@ -4,6 +4,7 @@ import {
   ChainId,
   isBlockInfoPending,
   Nonce,
+  SendTransaction,
   TokenTicker,
   UnsignedTransaction,
 } from "@iov/bcp";
@@ -580,6 +581,77 @@ describe("BnsConnection (basic class methods)", () => {
         const results = await connection.getUsernames({ owner: await randomBnsAddress() });
         expect(results.length).toEqual(0);
       }
+
+      connection.disconnect();
+    });
+  });
+
+  describe("estimateTxSize", () => {
+    it("works for send transaction without fee or nonce", async () => {
+      pendingWithoutBnsd();
+      const connection = await BnsConnection.establish(bnsdTendermintUrl);
+
+      const sender = await randomBnsAddress();
+      const sendTransaction: SendTransaction = {
+        kind: "bcp/send",
+        chainId: connection.chainId(),
+        sender: sender,
+        recipient: await randomBnsAddress(),
+        memo: `We ❤️ developers – iov.one`,
+        amount: defaultAmount,
+      };
+      const numberOfSignatures = 3;
+      const txSize = connection.estimateTxSize(sendTransaction, numberOfSignatures);
+      expect(txSize).toEqual(489);
+
+      connection.disconnect();
+    });
+
+    it("works for send transaction with fee", async () => {
+      pendingWithoutBnsd();
+      const connection = await BnsConnection.establish(bnsdTendermintUrl);
+
+      const sender = await randomBnsAddress();
+      const sendTransaction: SendTransaction = {
+        kind: "bcp/send",
+        chainId: connection.chainId(),
+        sender: sender,
+        recipient: await randomBnsAddress(),
+        memo: `We ❤️ developers – iov.one`,
+        amount: defaultAmount,
+        fee: {
+          tokens: {
+            fractionalDigits: 9,
+            quantity: "1",
+            tokenTicker: "CASH" as TokenTicker,
+          },
+          payer: sender,
+        },
+      };
+      const numberOfSignatures = 3;
+      const txSize = connection.estimateTxSize(sendTransaction, numberOfSignatures);
+      expect(txSize).toEqual(476);
+
+      connection.disconnect();
+    });
+
+    it("works for send transaction with nonce", async () => {
+      pendingWithoutBnsd();
+      const connection = await BnsConnection.establish(bnsdTendermintUrl);
+
+      const sender = await randomBnsAddress();
+      const sendTransaction: SendTransaction = {
+        kind: "bcp/send",
+        chainId: connection.chainId(),
+        sender: sender,
+        recipient: await randomBnsAddress(),
+        memo: `We ❤️ developers – iov.one`,
+        amount: defaultAmount,
+      };
+      const numberOfSignatures = 3;
+      const nonce = 1 as Nonce;
+      const txSize = connection.estimateTxSize(sendTransaction, numberOfSignatures, nonce);
+      expect(txSize).toEqual(468);
 
       connection.disconnect();
     });

--- a/packages/iov-bns/src/constants.ts
+++ b/packages/iov-bns/src/constants.ts
@@ -1,3 +1,4 @@
 import { ChainId } from "@iov/bcp";
 
 export const mainnetChainId = "iov-mainnet" as ChainId;
+export const weaveFractionalDigits = 9; // fixed for all weave tokens

--- a/packages/iov-bns/src/decodeobjects.ts
+++ b/packages/iov-bns/src/decodeobjects.ts
@@ -2,6 +2,7 @@ import { Address, Amount, ChainId, Token, TokenTicker } from "@iov/bcp";
 import { Encoding, Uint32, Uint64 } from "@iov/encoding";
 import BN from "bn.js";
 
+import { weaveFractionalDigits } from "./constants";
 import { asIntegerNumber, decodeNumericId, decodeString, ensure } from "./decodinghelpers";
 import * as codecImpl from "./generated/codecimpl";
 import {
@@ -34,13 +35,11 @@ export function decodeToken(data: codecImpl.currency.ITokenInfo & Keyed): Token 
   return {
     tokenTicker: Encoding.fromAscii(data._id) as TokenTicker,
     tokenName: ensure(data.name),
-    fractionalDigits: 9, // fixed for all weave tokens
+    fractionalDigits: weaveFractionalDigits,
   };
 }
 
 export function decodeAmount(coin: codecImpl.coin.ICoin): Amount {
-  const fractionalDigits = 9; // fixed for all tokens in BNS
-
   const wholeNumber = asIntegerNumber(coin.whole);
   if (wholeNumber < 0) {
     throw new Error("Component `whole` must not be negative");
@@ -52,13 +51,13 @@ export function decodeAmount(coin: codecImpl.coin.ICoin): Amount {
   }
 
   const quantity = new BN(wholeNumber)
-    .imul(new BN(10 ** fractionalDigits))
+    .imul(new BN(10 ** weaveFractionalDigits))
     .iadd(new BN(fractionalNumber))
     .toString();
 
   return {
     quantity: quantity,
-    fractionalDigits: fractionalDigits,
+    fractionalDigits: weaveFractionalDigits,
     tokenTicker: (coin.ticker || "") as TokenTicker,
   };
 }

--- a/packages/iov-bns/src/encodinghelpers.ts
+++ b/packages/iov-bns/src/encodinghelpers.ts
@@ -2,6 +2,7 @@ import { Amount } from "@iov/bcp";
 import { Int53 } from "@iov/encoding";
 import BN from "bn.js";
 
+import { weaveFractionalDigits } from "./constants";
 import * as codecImpl from "./generated/codecimpl";
 
 export function encodeInt(intNumber: number): number | null {
@@ -19,8 +20,8 @@ export function encodeString(data: string | undefined): string | null {
 }
 
 export function encodeAmount(amount: Amount): codecImpl.coin.ICoin {
-  if (amount.fractionalDigits !== 9) {
-    throw new Error(`Fractional digits must be 9 but was ${amount.fractionalDigits}`);
+  if (amount.fractionalDigits !== weaveFractionalDigits) {
+    throw new Error(`Fractional digits must be ${weaveFractionalDigits} but was ${amount.fractionalDigits}`);
   }
 
   const whole = Int53.fromString(amount.quantity.slice(0, -amount.fractionalDigits) || "0");

--- a/packages/iov-bns/src/util.ts
+++ b/packages/iov-bns/src/util.ts
@@ -3,6 +3,7 @@ import {
   Algorithm,
   ChainId,
   ConfirmedTransaction,
+  Fee,
   FullSignature,
   Hash,
   Identity,
@@ -18,6 +19,7 @@ import {
   SwapAbortTransaction,
   SwapClaimTransaction,
   SwapOfferTransaction,
+  TokenTicker,
   TransactionQuery,
   UnsignedTransaction,
 } from "@iov/bcp";
@@ -206,5 +208,24 @@ export function createDummySignature(nonce: Nonce = Number.MAX_SAFE_INTEGER as N
     },
     // ed25519 signature has 64 bytes https://blog.mozilla.org/warner/2011/11/29/ed25519-keys/
     signature: new Uint8Array(64) as SignatureBytes,
+  };
+}
+
+export function createDummyFee(): Fee {
+  // See limits specified here: https://github.com/iov-one/weave/blob/2c0f082/coin/codec.proto
+  // whole and fractional are stored as varints, so we use these values to be confident we pay a large enough fee
+  // at the risk of paying slightly too much
+  const maxWhole = 10 ** 15 - 1;
+  const maxFractional = 10 ** 9 - 1;
+  const maxTokenTickerLength = 4;
+  // See https://github.com/iov-one/weave/blob/4cb0080/conditions.go#L22
+  const addressLength = 20;
+  return {
+    tokens: {
+      fractionalDigits: constants.weaveFractionalDigits,
+      quantity: `${maxWhole}${maxFractional}`,
+      tokenTicker: "X".repeat(maxTokenTickerLength) as TokenTicker,
+    },
+    payer: encodeBnsAddress("tiov", new Uint8Array(addressLength)),
   };
 }

--- a/packages/iov-bns/src/util.ts
+++ b/packages/iov-bns/src/util.ts
@@ -3,6 +3,7 @@ import {
   Algorithm,
   ChainId,
   ConfirmedTransaction,
+  FullSignature,
   Hash,
   Identity,
   isSwapAbortTransaction,
@@ -11,7 +12,9 @@ import {
   isUnsignedTransaction,
   Nonce,
   PubkeyBundle,
+  PubkeyBytes,
   SignableBytes,
+  SignatureBytes,
   SwapAbortTransaction,
   SwapClaimTransaction,
   SwapOfferTransaction,
@@ -189,4 +192,19 @@ export function buildQueryString(query: TransactionQuery): QueryString {
     ...maxHeightComponents,
   ];
   return components.join(" AND ") as QueryString;
+}
+
+export function createDummySignature(nonce: Nonce = Number.MAX_SAFE_INTEGER as Nonce): FullSignature {
+  return {
+    // nonce is stored as a varint, so we use this default to be confident we pay a large enough fee
+    // at the risk of paying slightly too much
+    nonce: nonce,
+    pubkey: {
+      algo: Algorithm.Ed25519,
+      // ed25519 pubkey has 32 bytes https://blog.mozilla.org/warner/2011/11/29/ed25519-keys/
+      data: new Uint8Array(32) as PubkeyBytes,
+    },
+    // ed25519 signature has 64 bytes https://blog.mozilla.org/warner/2011/11/29/ed25519-keys/
+    signature: new Uint8Array(64) as SignatureBytes,
+  };
 }

--- a/packages/iov-bns/types/bnsconnection.d.ts
+++ b/packages/iov-bns/types/bnsconnection.d.ts
@@ -117,6 +117,7 @@ export declare class BnsConnection implements AtomicSwapConnection {
   getProposals(): Promise<readonly Proposal[]>;
   getVotes(voter: Address): Promise<readonly Vote[]>;
   getUsernames(query: BnsUsernamesQuery): Promise<readonly BnsUsernameNft[]>;
+  estimateTxSize(transaction: UnsignedTransaction, numberOfSignatures: number, nonce?: Nonce): number;
   getFeeQuote(transaction: UnsignedTransaction): Promise<Fee>;
   withDefaultFee<T extends UnsignedTransaction>(transaction: T, payer?: Address): Promise<T>;
   protected query(path: string, data: Uint8Array): Promise<QueryResponse>;

--- a/packages/iov-bns/types/constants.d.ts
+++ b/packages/iov-bns/types/constants.d.ts
@@ -1,2 +1,3 @@
 import { ChainId } from "@iov/bcp";
 export declare const mainnetChainId: ChainId;
+export declare const weaveFractionalDigits = 9;

--- a/packages/iov-bns/types/util.d.ts
+++ b/packages/iov-bns/types/util.d.ts
@@ -2,6 +2,7 @@ import {
   Address,
   ChainId,
   ConfirmedTransaction,
+  FullSignature,
   Hash,
   Identity,
   Nonce,
@@ -49,3 +50,4 @@ export declare function isConfirmedWithSwapClaimOrAbortTransaction(
   tx: ConfirmedTransaction<UnsignedTransaction>,
 ): tx is ConfirmedTransaction<SwapClaimTransaction | SwapAbortTransaction>;
 export declare function buildQueryString(query: TransactionQuery): QueryString;
+export declare function createDummySignature(nonce?: Nonce): FullSignature;

--- a/packages/iov-bns/types/util.d.ts
+++ b/packages/iov-bns/types/util.d.ts
@@ -2,6 +2,7 @@ import {
   Address,
   ChainId,
   ConfirmedTransaction,
+  Fee,
   FullSignature,
   Hash,
   Identity,
@@ -51,3 +52,4 @@ export declare function isConfirmedWithSwapClaimOrAbortTransaction(
 ): tx is ConfirmedTransaction<SwapClaimTransaction | SwapAbortTransaction>;
 export declare function buildQueryString(query: TransactionQuery): QueryString;
 export declare function createDummySignature(nonce?: Nonce): FullSignature;
+export declare function createDummyFee(): Fee;


### PR DESCRIPTION
Part 1 of #1349

This function lets you estimate the final tx size including signatures, so you can calculate the required fee, so you can sign the transaction. It's a chicken-and-egg problem.

- You have to tell it how many signatures you're expecting, otherwise the estimate will be way off.
- If you know the exact nonce that will be used you can specify it for a more accurate estimate.
- If you know the fee that will be used you can also specify it for a more accurate estimate. It's unclear why you'd need this estimate if you already know the fee, but possibly for iterative estimates to converge on more accurate, lower fees?

Not covered by this PR: making use of this function.