### PR TITLE
Set ECMAScript target version to ES2017

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@ Breaking changes
 - ALL: Upgrade TypeScript from 3.5 to 3.7. This changes the signature of getters
   in declaration files (see
   https://devblogs.microsoft.com/typescript/announcing-typescript-3-6/#get-and-set-accessors-allowed-in-ambient-contexts)
+- ALL: Change ECMAScript target version to ES2017, which results in JavaScript
+  output that is smaller, faster and easier to read and debug. The main change
+  is the usage of native `async`/`await`, which is
+  [supported by all relevant JavaScript environments](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function#Browser_compatibility).
 - @iov/bcp: Remove `LightTransaction` and `WithCreator` types and helpers.
 - @iov/bcp: `UnsignedTransaction` now has a `chainId` field instead of
   `creator`.

--- a/packages/iov-bns/src/testutils.spec.ts
+++ b/packages/iov-bns/src/testutils.spec.ts
@@ -52,10 +52,9 @@ export async function randomBnsAddress(): Promise<Address> {
 }
 
 export function randomDomain(): string {
-  const randomNumber = Math.random()
-    .toString()
-    // valid domain has length 3 to 16, we limit to `domain${randomNumber}` length (16 max).
-    .substring(10);
+  // Valid domain has length 3 to 16
+  // Make an integer < 1000000000 (i.e. up to 9 digits)
+  const randomNumber = Math.floor(Math.random() * 1_000_000_000).toString();
   return `domain${randomNumber}`;
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,8 +16,8 @@
     "resolveJsonModule": true,
     "sourceMap": true,
     "strict": true,
-    "target": "es6",
-    "lib": ["es6"],
+    "target": "es2017",
+    "lib": ["es2017"],
     "typeRoots": [
       "./custom_types",
       "./node_modules/@types"


### PR DESCRIPTION
Changes the ECMAScript target version to ES2017, which results in JavaScript output that is smaller, faster and easier to read and debug. The main change is the usage of native `async`/`await`, which is [supported by all relevant JavaScript environments](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function#Browser_compatibility).

The diff in https://gist.github.com/webmaster128/0568684962a1ab53dfb0d92f34cace08/revisions gives an idea about the old and the new output.