### PR TITLE
Bump typedoc to v0.15.4

### DIFF
--- a/scripts/typedoc/bin/typedoc
+++ b/scripts/typedoc/bin/typedoc
@@ -8,7 +8,7 @@ command -v shellcheck > /dev/null && shellcheck "$0"
 # cannot easily access configuration, input and output files of the host system.
 
 # tag, commit or branch
-TYPEDOC_VERSION="v0.15.3"
+TYPEDOC_VERSION="v0.15.4"
 
 TMP_DIR="${TMPDIR:-/tmp}/@iov"
 mkdir -p "$TMP_DIR"


### PR DESCRIPTION
The v0.15.3 tag and its commit of 31ae8d8fa176b8aa9c754994ea07094a52af633a on Nov 23, 2019 have mysteriously disappeared.

```
$ git remote show origin
* remote origin
  Fetch URL: https://github.com/TypeStrong/typedoc.git
  Push  URL: https://github.com/TypeStrong/typedoc.git
...
$ git tag | grep v0.15
v0.15.0
v0.15.0-0
v0.15.4
v0.15.5
v0.15.6
v0.15.7
v0.15.8
$ git checkout 31ae8d8fa176b8aa9c754994ea07094a52af633a
fatal: reference is not a tree: 31ae8d8fa176b8aa9c754994ea07094a52af633a
```

Yet https://github.com/TypeStrong/typedoc/commit/31ae8d8fa176b8aa9c754994ea07094a52af633a exists.