### PR TITLE
Reorganizes Escrow contract specific code

### DIFF
--- a/packages/iov-ethereum/src/atomicswapcontracttransactionbuilder.ts
+++ b/packages/iov-ethereum/src/atomicswapcontracttransactionbuilder.ts
@@ -17,7 +17,7 @@ import { Erc20TokensMap } from "types";
 import { Abi } from "./abi";
 import { pubkeyToAddress } from "./address";
 import { constants } from "./constants";
-import { SwapIdPrefix } from "./serialization";
+import { SwapIdPrefix } from "./serializationcommon";
 import { AtomicSwapContract, SwapContractMethod } from "./smartcontracts/atomicswapcontract";
 
 export class AtomicSwapContractTransactionBuilder {

--- a/packages/iov-ethereum/src/ethereumcodec.spec.ts
+++ b/packages/iov-ethereum/src/ethereumcodec.spec.ts
@@ -23,7 +23,7 @@ import { Encoding } from "@iov/encoding";
 import { Erc20ApproveTransaction, Erc20Options } from "./erc20";
 import { EthereumCodec } from "./ethereumcodec";
 import { EthereumRpcTransactionResult } from "./ethereumrpctransactionresult";
-import { SwapIdPrefix } from "./serialization";
+import { SwapIdPrefix } from "./serializationcommon";
 import { testConfig } from "./testconfig.spec";
 
 const { fromHex } = Encoding;

--- a/packages/iov-ethereum/src/ethereumcodec.ts
+++ b/packages/iov-ethereum/src/ethereumcodec.ts
@@ -32,7 +32,8 @@ import { BlknumForkState, Eip155ChainId, getRecoveryParam } from "./encoding";
 import { Erc20ApproveTransaction, Erc20TokensMap } from "./erc20";
 import { Erc20TokenTransactionBuilder } from "./erc20tokentransactionbuilder";
 import { EthereumRpcTransactionResult } from "./ethereumrpctransactionresult";
-import { Serialization, SwapIdPrefix } from "./serialization";
+import { Serialization } from "./serialization";
+import { SwapIdPrefix } from "./serializationcommon";
 import { SmartContractConfig } from "./smartcontracts/definitions";
 import {
   CustomSmartContractTransaction,

--- a/packages/iov-ethereum/src/ethereumconnection.spec.ts
+++ b/packages/iov-ethereum/src/ethereumconnection.spec.ts
@@ -45,7 +45,7 @@ import { pubkeyToAddress } from "./address";
 import { Erc20ApproveTransaction } from "./erc20";
 import { EthereumCodec } from "./ethereumcodec";
 import { EthereumConnection } from "./ethereumconnection";
-import { SwapIdPrefix } from "./serialization";
+import { SwapIdPrefix } from "./serializationcommon";
 import { testConfig } from "./testconfig.spec";
 
 const ETH = "ETH" as TokenTicker;

--- a/packages/iov-ethereum/src/ethereumconnection.ts
+++ b/packages/iov-ethereum/src/ethereumconnection.ts
@@ -63,7 +63,7 @@ import { EthereumCodec } from "./ethereumcodec";
 import { EthereumRpcClient } from "./ethereumrpcclient";
 import { HttpEthereumRpcClient } from "./httpethereumrpcclient";
 import { Parse } from "./parse";
-import { SwapIdPrefix } from "./serialization";
+import { SwapIdPrefix } from "./serializationcommon";
 import { AtomicSwapContract, SwapContractEvent } from "./smartcontracts/atomicswapcontract";
 import { SmartContractConfig } from "./smartcontracts/definitions";
 import {

--- a/packages/iov-ethereum/src/index.ts
+++ b/packages/iov-ethereum/src/index.ts
@@ -1,9 +1,12 @@
-// high level exports
+// High level exports
 export { Erc20ApproveTransaction, Erc20Options, Erc20TokensMap, isErc20ApproveTransaction } from "./erc20";
 export { EthereumConnection, EthereumConnectionOptions } from "./ethereumconnection";
 export { createEthereumConnector } from "./ethereumconnector";
 export { ethereumCodec, EthereumCodec, EthereumCodecOptions } from "./ethereumcodec";
-export { SwapIdPrefix } from "./serialization";
+export { SwapIdPrefix } from "./serializationcommon";
+// Smart contract exports
+export { SmartContractType, SmartContractTokenType, SmartContractConfig } from "./smartcontracts/definitions";
+export { getEscrowBySwapId } from "./smartcontracts/escrowcontract";
 
 // Custom helper functions
 export { pubkeyToAddress, toChecksummedAddress } from "./address";

--- a/packages/iov-ethereum/src/integrationtests/atomicswap.spec.ts
+++ b/packages/iov-ethereum/src/integrationtests/atomicswap.spec.ts
@@ -25,7 +25,7 @@ import BN from "bn.js";
 import { Erc20ApproveTransaction } from "../erc20";
 import { EthereumCodec } from "../ethereumcodec";
 import { EthereumConnection } from "../ethereumconnection";
-import { SwapIdPrefix } from "../serialization";
+import { SwapIdPrefix } from "../serializationcommon";
 import { testConfig } from "../testconfig.spec";
 
 const ETH = "ETH" as TokenTicker;

--- a/packages/iov-ethereum/src/serialization.spec.ts
+++ b/packages/iov-ethereum/src/serialization.spec.ts
@@ -22,8 +22,8 @@ import { Encoding } from "@iov/encoding";
 
 import { Erc20ApproveTransaction, Erc20Options } from "./erc20";
 import { Serialization } from "./serialization";
-import { testConfig } from "./testconfig.spec";
 import { SwapIdPrefix } from "./serializationcommon";
+import { testConfig } from "./testconfig.spec";
 
 const { serializeSignedTransaction, serializeUnsignedTransaction } = Serialization;
 const { fromHex } = Encoding;

--- a/packages/iov-ethereum/src/serialization.spec.ts
+++ b/packages/iov-ethereum/src/serialization.spec.ts
@@ -21,8 +21,9 @@ import { ExtendedSecp256k1Signature } from "@iov/crypto";
 import { Encoding } from "@iov/encoding";
 
 import { Erc20ApproveTransaction, Erc20Options } from "./erc20";
-import { Serialization, SwapIdPrefix } from "./serialization";
+import { Serialization } from "./serialization";
 import { testConfig } from "./testconfig.spec";
+import { SwapIdPrefix } from "./serializationcommon";
 
 const { serializeSignedTransaction, serializeUnsignedTransaction } = Serialization;
 const { fromHex } = Encoding;

--- a/packages/iov-ethereum/src/serializationcommon.ts
+++ b/packages/iov-ethereum/src/serializationcommon.ts
@@ -1,0 +1,67 @@
+import { Address, Amount, Nonce } from "@iov/bcp";
+
+import { constants } from "./constants";
+import { Erc20TokensMap } from "./erc20";
+
+export const ZERO_ETH_QUANTITY = "0";
+
+export enum SwapIdPrefix {
+  Ether = "ether",
+  Erc20 = "erc20",
+}
+
+export interface UnsignedSerializationOptions {
+  readonly chainIdHex: string;
+  readonly gasPriceHex: string;
+  readonly gasLimitHex: string;
+  readonly nonce: Nonce;
+  readonly erc20Tokens: Erc20TokensMap;
+  readonly atomicSwapContractAddress?: Address;
+  readonly customSmartContractAddress?: Address;
+}
+
+export interface SignedSerializationOptions {
+  readonly v: string;
+  readonly r: Uint8Array;
+  readonly s: Uint8Array;
+  readonly gasPriceHex: string;
+  readonly gasLimitHex: string;
+  readonly nonce: Nonce;
+  readonly erc20Tokens: Erc20TokensMap;
+  readonly atomicSwapContractAddress?: Address;
+  readonly customSmartContractAddress?: Address;
+}
+
+export interface GenericTransactionSerializerParameters {
+  readonly nonce: Nonce;
+  readonly gasPriceHex: string;
+  readonly gasLimitHex: string;
+  readonly recipient: Address;
+  readonly value: string;
+  readonly data: Uint8Array;
+  readonly v: string;
+  readonly r?: Uint8Array;
+  readonly s?: Uint8Array;
+}
+
+export class SerializationCommon {
+  public static checkEtherAmount(amounts: readonly Amount[]): void {
+    if (amounts.length !== 1) {
+      throw new Error("Cannot serialize a swap offer with more than one amount");
+    }
+    const { tokenTicker } = amounts[0];
+    if (tokenTicker !== constants.primaryTokenTicker) {
+      throw new Error("Invalid amount: Ether atomic swap must specify amount in ETH");
+    }
+  }
+
+  public static checkErc20Amount(amounts: readonly Amount[], erc20Tokens: Erc20TokensMap): void {
+    if (amounts.length !== 1) {
+      throw new Error("Cannot serialize a swap offer with more than one amount");
+    }
+    const { tokenTicker } = amounts[0];
+    if (!erc20Tokens.get(tokenTicker)) {
+      throw new Error("Invalid amount: unknown ERC20 token");
+    }
+  }
+}

--- a/packages/iov-ethereum/src/smartcontracts/escrowcontract.ts
+++ b/packages/iov-ethereum/src/smartcontracts/escrowcontract.ts
@@ -5,6 +5,7 @@ import {
   ChainId,
   Fee,
   Hash,
+  isBlockHeightTimeout,
   PubkeyBundle,
   SwapId,
   SwapIdBytes,
@@ -17,6 +18,14 @@ import BN from "bn.js";
 import { Abi } from "../abi";
 import { pubkeyToAddress } from "../address";
 import { EthereumRpcTransactionResult } from "../ethereumrpctransactionresult";
+import {
+  GenericTransactionSerializerParameters,
+  SerializationCommon,
+  SignedSerializationOptions,
+  SwapIdPrefix,
+  UnsignedSerializationOptions,
+  ZERO_ETH_QUANTITY,
+} from "../serializationcommon";
 import { SmartContractConfig } from "../smartcontracts/definitions";
 import { decodeHexQuantityString } from "../utils";
 
@@ -59,6 +68,32 @@ export function isEscrowAbortTransaction(
   transaction: UnsignedTransaction,
 ): transaction is EscrowAbortTransaction {
   return (transaction as EscrowAbortTransaction).kind === "smartcontract/escrow_abort";
+}
+
+export function isEscrowTransaction(transaction: UnsignedTransaction): transaction is EscrowBaseTransaction {
+  const { kind } = transaction;
+  return kind.startsWith("smartcontract/escrow_");
+}
+
+export enum EscrowContractState {
+  NON_EXISTENT,
+  OPEN,
+  CLAIMED,
+  ABORTED,
+}
+
+export interface EscrowContractSwap {
+  readonly sender: Address;
+  readonly recipient: Address;
+  readonly arbiter: Address;
+  readonly hash: Hash;
+  readonly timeout: BlockHeightTimeout;
+  readonly amount: Amount;
+  readonly state: EscrowContractState;
+}
+
+export function getEscrowBySwapId(swapId: SwapIdBytes): EscrowContractSwap {
+  return {} as EscrowContractSwap;
 }
 
 enum EscrowContractMethod {
@@ -179,6 +214,36 @@ export class EscrowContract {
     ]);
   }
 
+  public static serializeUnsignedTransaction(
+    unsigned: EscrowBaseTransaction,
+    options: UnsignedSerializationOptions,
+  ): GenericTransactionSerializerParameters {
+    if (isEscrowOpenTransaction(unsigned)) {
+      return this.serializeUnsignedOpenTransaction(unsigned, options);
+    } else if (isEscrowAbortTransaction(unsigned)) {
+      return this.serializeUnsignedAbortTransaction(unsigned, options);
+    } else if (isEscrowClaimTransaction(unsigned)) {
+      return this.serializeUnsignedClaimTransaction(unsigned, options);
+    } else {
+      throw new Error("unsupported escrow transaction kind: " + unsigned.kind);
+    }
+  }
+
+  public static serializeSignedTransaction(
+    unsigned: EscrowBaseTransaction,
+    options: SignedSerializationOptions,
+  ): GenericTransactionSerializerParameters {
+    if (isEscrowOpenTransaction(unsigned)) {
+      return this.serializeSignedOpenTransaction(unsigned, options);
+    } else if (isEscrowAbortTransaction(unsigned)) {
+      return this.serializeSignedAbortTransaction(unsigned, options);
+    } else if (isEscrowClaimTransaction(unsigned)) {
+      return this.serializeSignedClaimTransaction(unsigned, options);
+    } else {
+      throw new Error("unsupported escrow transaction kind: " + unsigned.kind);
+    }
+  }
+
   private static readonly OPEN_METHOD_ID: string = Encoding.toHex(
     Abi.calculateMethodHash("open(bytes32,address,bytes32,uint256)"),
   );
@@ -194,6 +259,10 @@ export class EscrowContract {
     [EscrowContract.CLAIM_METHOD_ID]: EscrowContractMethod.Claim,
     [EscrowContract.ABORT_METHOD_ID]: EscrowContractMethod.Abort,
   };
+
+  private static readonly NO_SMART_CONTRACT_ADDRESS_ERROR: Error = new Error(
+    "Escrow smart contract address not set",
+  );
 
   private static checkTransaction(tx: EscrowBaseTransaction): void {
     const { swapId } = tx;
@@ -212,5 +281,192 @@ export class EscrowContract {
       throw new Error("Unknown method for escrow contract");
     }
     return method;
+  }
+
+  private static serializeSignedOpenTransaction(
+    unsigned: EscrowOpenTransaction,
+    { v, r, s, gasPriceHex, gasLimitHex, nonce, customSmartContractAddress }: SignedSerializationOptions,
+  ): GenericTransactionSerializerParameters {
+    const { amount } = unsigned;
+    if (customSmartContractAddress === undefined) {
+      throw EscrowContract.NO_SMART_CONTRACT_ADDRESS_ERROR;
+    }
+    return {
+      nonce: nonce,
+      gasPriceHex: gasPriceHex,
+      gasLimitHex: gasLimitHex,
+      recipient: customSmartContractAddress,
+      value: amount.quantity,
+      data: EscrowContract.open(unsigned.swapId, unsigned.arbiter, unsigned.hash, unsigned.timeout),
+      v: v,
+      r: r,
+      s: s,
+    };
+  }
+
+  private static serializeSignedClaimTransaction(
+    unsigned: EscrowClaimTransaction,
+    { v, r, s, gasPriceHex, gasLimitHex, nonce, customSmartContractAddress }: SignedSerializationOptions,
+  ): GenericTransactionSerializerParameters {
+    if (customSmartContractAddress === undefined) {
+      throw EscrowContract.NO_SMART_CONTRACT_ADDRESS_ERROR;
+    }
+    return {
+      nonce: nonce,
+      gasPriceHex: gasPriceHex,
+      gasLimitHex: gasLimitHex,
+      recipient: customSmartContractAddress,
+      value: ZERO_ETH_QUANTITY,
+      data: EscrowContract.claim(unsigned.swapId, unsigned.recipient),
+      v: v,
+      r: r,
+      s: s,
+    };
+  }
+
+  private static serializeSignedAbortTransaction(
+    unsigned: EscrowAbortTransaction,
+    { v, r, s, gasPriceHex, gasLimitHex, nonce, customSmartContractAddress }: SignedSerializationOptions,
+  ): GenericTransactionSerializerParameters {
+    if (customSmartContractAddress === undefined) {
+      throw EscrowContract.NO_SMART_CONTRACT_ADDRESS_ERROR;
+    }
+    return {
+      nonce: nonce,
+      gasPriceHex: gasPriceHex,
+      gasLimitHex: gasLimitHex,
+      recipient: customSmartContractAddress,
+      value: ZERO_ETH_QUANTITY,
+      data: EscrowContract.abort(unsigned.swapId),
+      v: v,
+      r: r,
+      s: s,
+    };
+  }
+
+  private static serializeUnsignedOpenTransaction(
+    unsigned: EscrowOpenTransaction,
+    {
+      chainIdHex,
+      gasPriceHex,
+      gasLimitHex,
+      nonce,
+      erc20Tokens,
+      customSmartContractAddress,
+    }: UnsignedSerializationOptions,
+  ): GenericTransactionSerializerParameters {
+    if (customSmartContractAddress === undefined) {
+      throw EscrowContract.NO_SMART_CONTRACT_ADDRESS_ERROR;
+    }
+    EscrowContract.checkOpenTransaction(unsigned);
+    if (!isBlockHeightTimeout(unsigned.timeout)) {
+      throw new Error("Timeout must be specified as a block height");
+    }
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    if (unsigned.swapId.prefix === SwapIdPrefix.Ether) {
+      // native ETH swap
+      SerializationCommon.checkEtherAmount([unsigned.amount]);
+      const escrowOpenCall = EscrowContract.open(
+        unsigned.swapId,
+        unsigned.arbiter,
+        unsigned.hash,
+        unsigned.timeout,
+      );
+      return {
+        nonce: nonce,
+        gasPriceHex: gasPriceHex,
+        gasLimitHex: gasLimitHex,
+        recipient: customSmartContractAddress,
+        value: unsigned.amount.quantity,
+        data: escrowOpenCall,
+        v: chainIdHex,
+      };
+    } else {
+      // ERC20 swap
+      SerializationCommon.checkErc20Amount([unsigned.amount], erc20Tokens);
+      const escrowOpenCall = EscrowContract.open(
+        unsigned.swapId,
+        unsigned.arbiter,
+        unsigned.hash,
+        unsigned.timeout,
+      );
+      return {
+        nonce: nonce,
+        gasPriceHex: gasPriceHex,
+        gasLimitHex: gasLimitHex,
+        recipient: customSmartContractAddress,
+        value: ZERO_ETH_QUANTITY,
+        data: escrowOpenCall,
+        v: chainIdHex,
+      };
+    }
+  }
+
+  private static serializeUnsignedClaimTransaction(
+    unsigned: EscrowClaimTransaction,
+    { chainIdHex, gasPriceHex, gasLimitHex, nonce, customSmartContractAddress }: UnsignedSerializationOptions,
+  ): GenericTransactionSerializerParameters {
+    if (customSmartContractAddress === undefined) {
+      throw EscrowContract.NO_SMART_CONTRACT_ADDRESS_ERROR;
+    }
+    EscrowContract.checkClaimTransaction(unsigned);
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    if (unsigned.swapId.prefix === SwapIdPrefix.Ether) {
+      const escrowClaimCall = EscrowContract.claim(unsigned.swapId, unsigned.recipient);
+      return {
+        nonce: nonce,
+        gasPriceHex: gasPriceHex,
+        gasLimitHex: gasLimitHex,
+        recipient: customSmartContractAddress,
+        value: ZERO_ETH_QUANTITY,
+        data: escrowClaimCall,
+        v: chainIdHex,
+      };
+    } else {
+      const escrowClaimCall = EscrowContract.claim(unsigned.swapId, unsigned.recipient);
+      return {
+        nonce: nonce,
+        gasPriceHex: gasPriceHex,
+        gasLimitHex: gasLimitHex,
+        recipient: customSmartContractAddress,
+        value: ZERO_ETH_QUANTITY,
+        data: escrowClaimCall,
+        v: chainIdHex,
+      };
+    }
+  }
+
+  private static serializeUnsignedAbortTransaction(
+    unsigned: EscrowAbortTransaction,
+    { chainIdHex, gasPriceHex, gasLimitHex, nonce, customSmartContractAddress }: UnsignedSerializationOptions,
+  ): GenericTransactionSerializerParameters {
+    if (customSmartContractAddress === undefined) {
+      throw EscrowContract.NO_SMART_CONTRACT_ADDRESS_ERROR;
+    }
+    EscrowContract.checkAbortTransaction(unsigned);
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    if (unsigned.swapId.prefix === SwapIdPrefix.Ether) {
+      const escrowAbortCall = EscrowContract.abort(unsigned.swapId);
+      return {
+        nonce: nonce,
+        gasPriceHex: gasPriceHex,
+        gasLimitHex: gasLimitHex,
+        recipient: customSmartContractAddress,
+        value: ZERO_ETH_QUANTITY,
+        data: escrowAbortCall,
+        v: chainIdHex,
+      };
+    } else {
+      const escrowAbortCall = EscrowContract.abort(unsigned.swapId);
+      return {
+        nonce: nonce,
+        gasPriceHex: gasPriceHex,
+        gasLimitHex: gasLimitHex,
+        recipient: customSmartContractAddress,
+        value: ZERO_ETH_QUANTITY,
+        data: escrowAbortCall,
+        v: chainIdHex,
+      };
+    }
   }
 }

--- a/packages/iov-ethereum/src/smartcontracts/escrowcontract.ts
+++ b/packages/iov-ethereum/src/smartcontracts/escrowcontract.ts
@@ -92,8 +92,11 @@ export interface EscrowContractSwap {
   readonly state: EscrowContractState;
 }
 
-export function getEscrowBySwapId(swapId: SwapIdBytes): EscrowContractSwap {
-  return {} as EscrowContractSwap;
+export function getEscrowBySwapId(swapId: SwapIdBytes): EscrowContractSwap | null {
+  if (swapId.length !== 32) {
+    throw new Error("Swap id must be 32 bytes");
+  }
+  return null;
 }
 
 enum EscrowContractMethod {

--- a/packages/iov-ethereum/src/testconfig.spec.ts
+++ b/packages/iov-ethereum/src/testconfig.spec.ts
@@ -87,7 +87,7 @@ const local: EthereumNetworkConfig = {
       tokenTicker: "ETH" as TokenTicker,
     },
   },
-  chainId: "ethereum-eip155-1" as ChainId,
+  chainId: "ethereum-eip155-5777" as ChainId,
   minHeight: 0, // ganache does not auto-generate a genesis block
   mnemonic: "oxygen fall sure lava energy veteran enroll frown question detail include maximum",
   accountStates: {

--- a/packages/iov-ethereum/src/testconfig.spec.ts
+++ b/packages/iov-ethereum/src/testconfig.spec.ts
@@ -87,7 +87,7 @@ const local: EthereumNetworkConfig = {
       tokenTicker: "ETH" as TokenTicker,
     },
   },
-  chainId: "ethereum-eip155-5777" as ChainId,
+  chainId: "ethereum-eip155-1" as ChainId,
   minHeight: 0, // ganache does not auto-generate a genesis block
   mnemonic: "oxygen fall sure lava energy veteran enroll frown question detail include maximum",
   accountStates: {

--- a/packages/iov-ethereum/types/atomicswapcontracttransactionbuilder.d.ts
+++ b/packages/iov-ethereum/types/atomicswapcontracttransactionbuilder.d.ts
@@ -8,7 +8,7 @@ import {
   SwapOfferTransaction,
 } from "@iov/bcp";
 import { Erc20TokensMap } from "types";
-import { SwapIdPrefix } from "./serialization";
+import { SwapIdPrefix } from "./serializationcommon";
 export declare class AtomicSwapContractTransactionBuilder {
   static buildTransaction(
     input: Uint8Array,

--- a/packages/iov-ethereum/types/index.d.ts
+++ b/packages/iov-ethereum/types/index.d.ts
@@ -2,5 +2,7 @@ export { Erc20ApproveTransaction, Erc20Options, Erc20TokensMap, isErc20ApproveTr
 export { EthereumConnection, EthereumConnectionOptions } from "./ethereumconnection";
 export { createEthereumConnector } from "./ethereumconnector";
 export { ethereumCodec, EthereumCodec, EthereumCodecOptions } from "./ethereumcodec";
-export { SwapIdPrefix } from "./serialization";
+export { SwapIdPrefix } from "./serializationcommon";
+export { SmartContractType, SmartContractTokenType, SmartContractConfig } from "./smartcontracts/definitions";
+export { getEscrowBySwapId } from "./smartcontracts/escrowcontract";
 export { pubkeyToAddress, toChecksummedAddress } from "./address";

--- a/packages/iov-ethereum/types/serialization.d.ts
+++ b/packages/iov-ethereum/types/serialization.d.ts
@@ -1,10 +1,8 @@
 import { Address, Nonce, SignedTransaction, UnsignedTransaction } from "@iov/bcp";
 import { Erc20TokensMap } from "./erc20";
-export declare enum SwapIdPrefix {
-  Ether = "ether",
-  Erc20 = "erc20",
-}
+import { GenericTransactionSerializerParameters } from "./serializationcommon";
 export declare class Serialization {
+  static serializeGenericTransactionObject(params: GenericTransactionSerializerParameters): Uint8Array;
   static serializeGenericTransaction(
     nonce: Nonce,
     gasPriceHex: string,
@@ -36,8 +34,6 @@ export declare class Serialization {
   private static checkPreimage;
   private static checkAtomicSwapContractAddress;
   private static checkMemoNotPresent;
-  private static checkEtherAmount;
-  private static checkErc20Amount;
   private static getChainIdHex;
   private static getGasPriceHex;
   private static getGasLimitHex;
@@ -61,15 +57,9 @@ export declare class Serialization {
   private static serializeUnsignedSwapClaimTransaction;
   private static serializeUnsignedSwapAbortTransaction;
   private static serializeUnsignedErc20ApproveTransaction;
-  private static serializeUnsignedEscrowOpenTransaction;
-  private static serializeUnsignedEscrowClaimTransaction;
-  private static serializeUnsignedEscrowAbortTransaction;
   private static serializeSignedSendTransaction;
   private static serializeSignedSwapOfferTransaction;
   private static serializeSignedSwapClaimTransaction;
   private static serializeSignedSwapAbortTransaction;
   private static serializeSignedErc20ApproveTransaction;
-  private static serializeSignedOpenTransaction;
-  private static serializeSignedClaimTransaction;
-  private static serializeSignedAbortTransaction;
 }

--- a/packages/iov-ethereum/types/serializationcommon.d.ts
+++ b/packages/iov-ethereum/types/serializationcommon.d.ts
@@ -1,0 +1,42 @@
+import { Address, Amount, Nonce } from "@iov/bcp";
+import { Erc20TokensMap } from "./erc20";
+export declare const ZERO_ETH_QUANTITY = "0";
+export declare enum SwapIdPrefix {
+  Ether = "ether",
+  Erc20 = "erc20",
+}
+export interface UnsignedSerializationOptions {
+  readonly chainIdHex: string;
+  readonly gasPriceHex: string;
+  readonly gasLimitHex: string;
+  readonly nonce: Nonce;
+  readonly erc20Tokens: Erc20TokensMap;
+  readonly atomicSwapContractAddress?: Address;
+  readonly customSmartContractAddress?: Address;
+}
+export interface SignedSerializationOptions {
+  readonly v: string;
+  readonly r: Uint8Array;
+  readonly s: Uint8Array;
+  readonly gasPriceHex: string;
+  readonly gasLimitHex: string;
+  readonly nonce: Nonce;
+  readonly erc20Tokens: Erc20TokensMap;
+  readonly atomicSwapContractAddress?: Address;
+  readonly customSmartContractAddress?: Address;
+}
+export interface GenericTransactionSerializerParameters {
+  readonly nonce: Nonce;
+  readonly gasPriceHex: string;
+  readonly gasLimitHex: string;
+  readonly recipient: Address;
+  readonly value: string;
+  readonly data: Uint8Array;
+  readonly v: string;
+  readonly r?: Uint8Array;
+  readonly s?: Uint8Array;
+}
+export declare class SerializationCommon {
+  static checkEtherAmount(amounts: readonly Amount[]): void;
+  static checkErc20Amount(amounts: readonly Amount[], erc20Tokens: Erc20TokensMap): void;
+}

--- a/packages/iov-ethereum/types/smartcontracts/escrowcontract.d.ts
+++ b/packages/iov-ethereum/types/smartcontracts/escrowcontract.d.ts
@@ -1,15 +1,22 @@
 import {
   Address,
   Amount,
+  BlockHeightTimeout,
   ChainId,
   Fee,
   Hash,
   PubkeyBundle,
   SwapId,
+  SwapIdBytes,
   SwapTimeout,
   UnsignedTransaction,
 } from "@iov/bcp";
 import { EthereumRpcTransactionResult } from "../ethereumrpctransactionresult";
+import {
+  GenericTransactionSerializerParameters,
+  SignedSerializationOptions,
+  UnsignedSerializationOptions,
+} from "../serializationcommon";
 import { SmartContractConfig } from "../smartcontracts/definitions";
 interface EscrowBaseTransaction extends UnsignedTransaction {
   readonly sender: Address;
@@ -39,6 +46,25 @@ export declare function isEscrowClaimTransaction(
 export declare function isEscrowAbortTransaction(
   transaction: UnsignedTransaction,
 ): transaction is EscrowAbortTransaction;
+export declare function isEscrowTransaction(
+  transaction: UnsignedTransaction,
+): transaction is EscrowBaseTransaction;
+export declare enum EscrowContractState {
+  NON_EXISTENT = 0,
+  OPEN = 1,
+  CLAIMED = 2,
+  ABORTED = 3,
+}
+export interface EscrowContractSwap {
+  readonly sender: Address;
+  readonly recipient: Address;
+  readonly arbiter: Address;
+  readonly hash: Hash;
+  readonly timeout: BlockHeightTimeout;
+  readonly amount: Amount;
+  readonly state: EscrowContractState;
+}
+export declare function getEscrowBySwapId(swapId: SwapIdBytes): EscrowContractSwap;
 export declare class EscrowContract {
   static buildTransaction(
     input: Uint8Array,
@@ -54,11 +80,26 @@ export declare class EscrowContract {
   static abort(swapId: SwapId): Uint8Array;
   static claim(swapId: SwapId, recipient: Address): Uint8Array;
   static open(swapId: SwapId, arbiter: Address, hash: Hash, timeout: SwapTimeout): Uint8Array;
+  static serializeUnsignedTransaction(
+    unsigned: EscrowBaseTransaction,
+    options: UnsignedSerializationOptions,
+  ): GenericTransactionSerializerParameters;
+  static serializeSignedTransaction(
+    unsigned: EscrowBaseTransaction,
+    options: SignedSerializationOptions,
+  ): GenericTransactionSerializerParameters;
   private static readonly OPEN_METHOD_ID;
   private static readonly CLAIM_METHOD_ID;
   private static readonly ABORT_METHOD_ID;
   private static readonly METHODS;
+  private static readonly NO_SMART_CONTRACT_ADDRESS_ERROR;
   private static checkTransaction;
   private static getMethodTypeFromInput;
+  private static serializeSignedOpenTransaction;
+  private static serializeSignedClaimTransaction;
+  private static serializeSignedAbortTransaction;
+  private static serializeUnsignedOpenTransaction;
+  private static serializeUnsignedClaimTransaction;
+  private static serializeUnsignedAbortTransaction;
 }
 export {};

--- a/packages/iov-ethereum/types/smartcontracts/escrowcontract.d.ts
+++ b/packages/iov-ethereum/types/smartcontracts/escrowcontract.d.ts
@@ -64,7 +64,7 @@ export interface EscrowContractSwap {
   readonly amount: Amount;
   readonly state: EscrowContractState;
 }
-export declare function getEscrowBySwapId(swapId: SwapIdBytes): EscrowContractSwap;
+export declare function getEscrowBySwapId(swapId: SwapIdBytes): EscrowContractSwap | null;
 export declare class EscrowContract {
   static buildTransaction(
     input: Uint8Array,


### PR DESCRIPTION
Move escrow smart contract specific serialization code to the spefic
escrow smart contract file.

This required some exports to be made that are some interfaces and
values shared between the serializer and the contract.

Also exported the escrow specific structure and the new smart contract
stuff out of the package.