### PR TITLE
decode hex encoded memo data

### DIFF
--- a/packages/iov-ethereum/src/encoding.ts
+++ b/packages/iov-ethereum/src/encoding.ts
@@ -1,5 +1,6 @@
-import { Int53 } from "@iov/encoding";
+import { Int53, Encoding } from "@iov/encoding";
 import * as rlp from "rlp";
+const { fromUtf8 } = Encoding;
 
 /**
  * Encode as RLP (Recursive Length Prefix)
@@ -7,6 +8,25 @@ import * as rlp from "rlp";
 export function toRlp(data: rlp.Input): Uint8Array {
   const dataBuffer = rlp.encode(data);
   return Uint8Array.from(dataBuffer);
+}
+
+/**
+ * Decode from RLP (Recursive Length Prefix)
+ */
+export function fromRlp(data: Uint8Array): Uint8Array {
+  // If this isn't hex data
+  if (!isHex(data)) {
+    return data;
+  }
+  const dataBuffer = rlp.decode(data);
+  return new Uint8Array(Buffer.from(dataBuffer.toString()));
+}
+/**
+ * IsHex returns true if the string starts with 0x
+ */
+export function isHex(data: Uint8Array): boolean {
+  const stringData = fromUtf8(data);
+  return stringData.length > 1 && stringData.toLocaleLowerCase().substring(0, 2) === "0x";
 }
 
 /** changes with each chain */

--- a/packages/iov-ethereum/src/ethereumcodec.ts
+++ b/packages/iov-ethereum/src/ethereumcodec.ts
@@ -28,7 +28,7 @@ import { Encoding } from "@iov/encoding";
 import { isValidAddress, pubkeyToAddress, toChecksummedAddress } from "./address";
 import { AtomicSwapContractTransactionBuilder } from "./atomicswapcontracttransactionbuilder";
 import { constants } from "./constants";
-import { BlknumForkState, Eip155ChainId, getRecoveryParam } from "./encoding";
+import { BlknumForkState, Eip155ChainId, getRecoveryParam, fromRlp } from "./encoding";
 import { Erc20ApproveTransaction, Erc20TokensMap } from "./erc20";
 import { Erc20TokenTransactionBuilder } from "./erc20tokentransactionbuilder";
 import { EthereumRpcTransactionResult } from "./ethereumrpctransactionresult";
@@ -80,7 +80,9 @@ type SupportedTransactionType =
 export class EthereumCodec implements TxCodec {
   private static getMemoFromInput(input: Uint8Array): string {
     try {
-      return Encoding.fromUtf8(input);
+      // RLP Decode if already a hex input
+      const memoInput = fromRlp(input);
+      return Encoding.fromUtf8(memoInput);
     } catch {
       const hexstring = Encoding.toHex(input);
       // split in space separated chunks up to 16 characters each

--- a/packages/iov-ethereum/types/encoding.d.ts
+++ b/packages/iov-ethereum/types/encoding.d.ts
@@ -3,6 +3,14 @@ import * as rlp from "rlp";
  * Encode as RLP (Recursive Length Prefix)
  */
 export declare function toRlp(data: rlp.Input): Uint8Array;
+/**
+ * Decode from RLP (Recursive Length Prefix)
+ */
+export function fromRlp(data: Uint8Array): Uint8Array;
+/**
+ * IsHex returns true if the string starts with 0x
+ */
+export function isHex(data: Uint8Array): boolean;
 /** changes with each chain */
 export declare enum BlknumForkState {
   /** before height 2,675,000 for mainnet */


### PR DESCRIPTION
There are a few conversions happening when paying with a memo: In our example we use the memo `0xc8b21e166f0d1604`

During the encoding we have the following process: 

We go from a string to UTF8 encoded (which gives the same result) `0xc8b21e166f0d1604` -> `0xc8b21e166f0d1604`

We then send it to a method called toRlp - https://github.com/iov-one/iov-core/blob/89f462d218cf5babda4fdea9eab9ffaa1c72c552/packages/iov-ethereum/src/encoding.ts#L8 which encodes it again (this here is the issue)

Utf8 encoded result gets converted to hex (less the 0x at the start) - https://github.com/iov-one/iov-core/blob/ccf3ec60590f68986db0bb8b6ad77cc86876a6c6/packages/iov-ethereum/src/ethereumcodec.ts#L85 `c8b21e166f0d1604` -> `63386232316531363666306431363034`
It then gets broadcasted on the blockchain as the result of 2 + 0x = `0x63386232316531363666306431363034`

However, at step 2 there is a small issue with the encoding. See below

toUtf8 = `48,120,99,56,98,50,49,101,49,54,54,102,48,100,49,54,48,52`
toRlp = `146,48,120,99,56,98,50,49,101,49,54,54,102,48,100,49,54,48,52`

The Utf8 encoding is fine, however the toRlp adds a non-ascii character during the encoding process. In turn this results in step 3 encoding as a hex which should not be happening. 

Due to the incorrect character during the toRlp encoding it causes the exception to be thrown here: https://github.com/iov-one/iov-core/blob/ccf3ec60590f68986db0bb8b6ad77cc86876a6c6/packages/iov-ethereum/src/ethereumcodec.ts#L83

This fix decodes the data prior to running the `Encoding.fromUtf8(decodedRlp);` line, this removes the non-ascii character which stops the Exception being thrown. 