### PR TITLE
Pull out free functions fromHex, toHex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## HEAD
 
+- @iov/encoding: Pull out free functions `fromHex` and `toHex` to simplify
+  usability. `Encoding.fromHex` and `Encoding.toHex` are now deprecated.
+
 ## 2.2.5
 
 - @iov/bns: Rename `thirdPartyToken` to `broker`.

--- a/packages/iov-bcp/src/atomicswaphelpers.spec.ts
+++ b/packages/iov-bcp/src/atomicswaphelpers.spec.ts
@@ -1,9 +1,7 @@
-import { Encoding } from "@iov/encoding";
+import { fromHex } from "@iov/encoding";
 
 import { AtomicSwapHelpers } from "./atomicswaphelpers";
 import { Preimage } from "./atomicswaptypes";
-
-const { fromHex } = Encoding;
 
 describe("AtomicSwapHelpers", () => {
   describe("createPreimage", () => {

--- a/packages/iov-bcp/src/atomicswapmerger.spec.ts
+++ b/packages/iov-bcp/src/atomicswapmerger.spec.ts
@@ -1,11 +1,9 @@
-import { Encoding } from "@iov/encoding";
+import { fromHex } from "@iov/encoding";
 
 import { AtomicSwapHelpers } from "./atomicswaphelpers";
 import { AtomicSwapMerger } from "./atomicswapmerger";
 import { ClaimedSwap, OpenSwap, Preimage, SwapClaimTransaction, SwapProcessState } from "./atomicswaptypes";
 import { Address, Amount, ChainId, SwapId, SwapIdBytes, TokenTicker } from "./transactions";
-
-const { fromHex } = Encoding;
 
 describe("AtomicSwapMerger", () => {
   const defaultAmount: Amount = {

--- a/packages/iov-bcp/src/transactions.spec.ts
+++ b/packages/iov-bcp/src/transactions.spec.ts
@@ -1,4 +1,4 @@
-import { Encoding } from "@iov/encoding";
+import { fromHex } from "@iov/encoding";
 
 import {
   Algorithm,
@@ -18,8 +18,6 @@ import {
   SignedTransaction,
   UnsignedTransaction,
 } from "./transactions";
-
-const { fromHex } = Encoding;
 
 describe("transactions", () => {
   describe("isPubkeyBundle", () => {

--- a/packages/iov-bns-governance/src/governor.spec.ts
+++ b/packages/iov-bns-governance/src/governor.spec.ts
@@ -2,7 +2,7 @@
 import { Address, Algorithm, isBlockInfoPending, PubkeyBundle, PubkeyBytes, TokenTicker } from "@iov/bcp";
 import { ActionKind, bnsCodec, BnsConnection, VoteOption } from "@iov/bns";
 import { Random } from "@iov/crypto";
-import { Bech32, Encoding } from "@iov/encoding";
+import { Bech32, toHex } from "@iov/encoding";
 import { Ed25519HdWallet, HdPaths, UserProfile } from "@iov/keycontrol";
 import { sleep } from "@iov/utils";
 import { ReadonlyDate } from "readonly-date";
@@ -421,7 +421,7 @@ describe("Governor", () => {
       const governor = new Governor(options);
 
       const pubkey = randomBnsPubkey();
-      const pubkeyHex = Encoding.toHex(pubkey.data);
+      const pubkeyHex = toHex(pubkey.data);
       const tx = await governor.buildCreateProposalTx({
         type: ProposalType.AddValidator,
         title: `Add ${pubkeyHex} as validator`,
@@ -464,7 +464,7 @@ describe("Governor", () => {
       const governor = new Governor(options);
 
       const pubkey = randomBnsPubkey();
-      const pubkeyHex = Encoding.toHex(pubkey.data);
+      const pubkeyHex = toHex(pubkey.data);
       const tx = await governor.buildCreateProposalTx({
         type: ProposalType.RemoveValidator,
         title: `Remove validator ${pubkeyHex}`,

--- a/packages/iov-bns-governance/src/governor.ts
+++ b/packages/iov-bns-governance/src/governor.ts
@@ -11,13 +11,11 @@ import {
   VoteOption,
   VoteTx,
 } from "@iov/bns";
-import { Encoding } from "@iov/encoding";
+import { toHex } from "@iov/encoding";
 import BN from "bn.js";
 
 import { ProposalOptions, ProposalType } from "./proposals";
 import { groupByCallback, maxWithComparatorCallback } from "./utils";
-
-const { toHex } = Encoding;
 
 function compareByVersion<E extends { readonly version: number }>(element1: E, element2: E): number {
   return element1.version - element2.version;

--- a/packages/iov-bns-governance/src/integrationtests/proposals.spec.ts
+++ b/packages/iov-bns-governance/src/integrationtests/proposals.spec.ts
@@ -20,7 +20,7 @@ import {
   SendAction,
   VoteOption,
 } from "@iov/bns";
-import { Encoding } from "@iov/encoding";
+import { toHex } from "@iov/encoding";
 import { Ed25519HdWallet, HdPaths, UserProfile } from "@iov/keycontrol";
 import { sleep } from "@iov/utils";
 import BN from "bn.js";
@@ -387,7 +387,7 @@ describe("Proposals", () => {
     expect(proposal1Pre.action).toEqual({
       kind: ActionKind.SetValidators,
       validatorUpdates: {
-        [`ed25519_${Encoding.toHex(identity.pubkey.data)}`]: { power: 2 },
+        [`ed25519_${toHex(identity.pubkey.data)}`]: { power: 2 },
       },
     });
     expect(proposal1Pre.status).toEqual(ProposalStatus.Submitted);
@@ -410,7 +410,7 @@ describe("Proposals", () => {
     const validatorsAfter1 = await connection.getValidators();
     expect(validatorsAfter1.length).toEqual(numValidatorsBefore + 1);
     const addedValidator = validatorsAfter1.find(
-      validator => Encoding.toHex(validator.pubkey.data) === Encoding.toHex(identity.pubkey.data),
+      validator => toHex(validator.pubkey.data) === toHex(identity.pubkey.data),
     );
     expect(addedValidator).toBeDefined();
     expect(addedValidator!.power).toEqual(2);
@@ -442,7 +442,7 @@ describe("Proposals", () => {
     expect(proposal2Pre.action).toEqual({
       kind: ActionKind.SetValidators,
       validatorUpdates: {
-        [`ed25519_${Encoding.toHex(identity.pubkey.data)}`]: { power: 0 },
+        [`ed25519_${toHex(identity.pubkey.data)}`]: { power: 0 },
       },
     });
     expect(proposal2Pre.status).toEqual(ProposalStatus.Submitted);
@@ -465,7 +465,7 @@ describe("Proposals", () => {
     const validatorsAfter2 = await connection.getValidators();
     expect(validatorsAfter2.length).toEqual(numValidatorsBefore);
     const removedValidator = validatorsAfter2.find(
-      validator => Encoding.toHex(validator.pubkey.data) === Encoding.toHex(identity.pubkey.data),
+      validator => toHex(validator.pubkey.data) === toHex(identity.pubkey.data),
     );
     expect(removedValidator).not.toBeDefined();
 

--- a/packages/iov-bns/src/bnscodec.ts
+++ b/packages/iov-bns/src/bnscodec.ts
@@ -9,7 +9,7 @@ import {
   TxCodec,
   UnsignedTransaction,
 } from "@iov/bcp";
-import { Encoding } from "@iov/encoding";
+import { toHex } from "@iov/encoding";
 import { TxBytes, v0_31 } from "@iov/tendermint-rpc";
 
 import { decodeSignedTx } from "./decode";
@@ -39,7 +39,7 @@ export const bnsCodec: TxCodec = {
   identifier: (tx: SignedTransaction): TransactionId => {
     const transactionBytes = (bnsCodec.bytesToPost(tx) as unknown) as TxBytes;
     const hash = v0_31.hashTx(transactionBytes);
-    return Encoding.toHex(hash).toUpperCase() as TransactionId;
+    return toHex(hash).toUpperCase() as TransactionId;
   },
 
   // parseBytes will recover bytes from the blockchain into a format we can use

--- a/packages/iov-bns/src/bnsconnection.posttxs.spec.ts
+++ b/packages/iov-bns/src/bnsconnection.posttxs.spec.ts
@@ -12,7 +12,7 @@ import {
   UnsignedTransaction,
 } from "@iov/bcp";
 import { Random } from "@iov/crypto";
-import { Encoding } from "@iov/encoding";
+import { fromHex } from "@iov/encoding";
 import { Ed25519HdWallet, HdPaths, UserProfile } from "@iov/keycontrol";
 import { assert, sleep } from "@iov/utils";
 import BN from "bn.js";
@@ -72,8 +72,6 @@ import {
   VoteTx,
 } from "./types";
 import { encodeBnsAddress, identityToAddress } from "./util";
-
-const { fromHex } = Encoding;
 
 describe("BnsConnection (post txs)", () => {
   describe("postTx", () => {

--- a/packages/iov-bns/src/conditions.spec.ts
+++ b/packages/iov-bns/src/conditions.spec.ts
@@ -1,5 +1,5 @@
 import { ChainId, Hash, SwapIdBytes } from "@iov/bcp";
-import { Encoding } from "@iov/encoding";
+import { Encoding, fromHex } from "@iov/encoding";
 
 import {
   buildCondition,
@@ -11,7 +11,7 @@ import {
   swapToAddress,
 } from "./conditions";
 
-const { fromHex, toAscii } = Encoding;
+const { toAscii } = Encoding;
 
 describe("conditions", () => {
   describe("buildCondition", () => {

--- a/packages/iov-bns/src/decode.spec.ts
+++ b/packages/iov-bns/src/decode.spec.ts
@@ -1,5 +1,5 @@
 import { Address, isSendTransaction, Nonce, TokenTicker } from "@iov/bcp";
-import { Encoding } from "@iov/encoding";
+import { fromHex } from "@iov/encoding";
 
 import { decodePrivkey, decodePubkey, decodeSignedTx, decodeUserData } from "./decode";
 import * as codecImpl from "./generated/codecimpl";
@@ -14,8 +14,6 @@ import {
   signedTxBin,
 } from "./testdata.spec";
 import { isMultisignatureTx } from "./types";
-
-const { fromHex } = Encoding;
 
 describe("Decode", () => {
   it("decode pubkey", () => {

--- a/packages/iov-bns/src/decodemsg.spec.ts
+++ b/packages/iov-bns/src/decodemsg.spec.ts
@@ -12,7 +12,7 @@ import {
   TokenTicker,
   UnsignedTransaction,
 } from "@iov/bcp";
-import { Encoding } from "@iov/encoding";
+import { fromHex } from "@iov/encoding";
 
 import { decodeMsg } from "./decodemsg";
 import { decodeAmount } from "./decodeobjects";
@@ -48,8 +48,6 @@ import {
   Participant,
   VoteOption,
 } from "./types";
-
-const { fromHex } = Encoding;
 
 /** A random user on an IOV testnet */
 const alice = {
@@ -898,9 +896,9 @@ describe("decodeMsg", () => {
             },
           }).finish(),
           description: "foo bar",
-          electionRuleId: Encoding.fromHex("000000bbccddbbff"),
+          electionRuleId: fromHex("000000bbccddbbff"),
           startTime: 42424242,
-          author: Encoding.fromHex("0011223344556677889900112233445566778899"),
+          author: fromHex("0011223344556677889900112233445566778899"),
         },
       };
       const decoded = decodeMsg(defaultBaseTx, transactionMessage);

--- a/packages/iov-bns/src/decodeobjects.spec.ts
+++ b/packages/iov-bns/src/decodeobjects.spec.ts
@@ -1,5 +1,5 @@
 import { Address, ChainId, TokenTicker } from "@iov/bcp";
-import { Bech32, Encoding } from "@iov/encoding";
+import { Bech32, Encoding, fromHex } from "@iov/encoding";
 
 import {
   decodeAccount,
@@ -19,7 +19,7 @@ import * as codecImpl from "./generated/codecimpl";
 import { coinBin, coinJson } from "./testdata.spec";
 import { ActionKind, Keyed, ProposalExecutorResult, ProposalResult, ProposalStatus } from "./types";
 
-const { fromHex, toUtf8 } = Encoding;
+const { toUtf8 } = Encoding;
 
 describe("decodeobjects", () => {
   describe("decodeToken", () => {

--- a/packages/iov-bns/src/decodeobjects.ts
+++ b/packages/iov-bns/src/decodeobjects.ts
@@ -1,5 +1,5 @@
 import { Address, Amount, ChainId, Token, TokenTicker } from "@iov/bcp";
-import { Encoding, Uint32, Uint64 } from "@iov/encoding";
+import { Encoding, toHex, Uint32, Uint64 } from "@iov/encoding";
 import BN from "bn.js";
 
 import { weaveFractionalDigits } from "./constants";
@@ -272,7 +272,7 @@ function decodeValidators(validators: readonly codecImpl.weave.IValidatorUpdate[
     if (!validator.pubKey || !validator.pubKey.data) {
       throw new Error("Validator is missing pubKey data");
     }
-    const index = `ed25519_${Encoding.toHex(validator.pubKey.data)}`;
+    const index = `ed25519_${toHex(validator.pubKey.data)}`;
     return {
       ...result,
       [index]: { power: asIntegerNumber(validator.power) },

--- a/packages/iov-bns/src/encode.spec.ts
+++ b/packages/iov-bns/src/encode.spec.ts
@@ -11,7 +11,7 @@ import {
   TokenTicker,
 } from "@iov/bcp";
 import { Ed25519, Ed25519Keypair, Sha512 } from "@iov/crypto";
-import { Encoding } from "@iov/encoding";
+import { fromHex } from "@iov/encoding";
 
 import { buildMultisignatureCondition, conditionToWeaveAddress } from "./conditions";
 import { encodeFullSignature, encodePrivkey, encodePubkey, encodeSignedTx, encodeUnsignedTx } from "./encode";
@@ -30,8 +30,6 @@ import {
 } from "./testdata.spec";
 import { MultisignatureTx } from "./types";
 import { appendSignBytes } from "./util";
-
-const { fromHex } = Encoding;
 
 describe("encode", () => {
   describe("encodePubkey", () => {

--- a/packages/iov-bns/src/encodemsg.spec.ts
+++ b/packages/iov-bns/src/encodemsg.spec.ts
@@ -1,5 +1,5 @@
 import { Address, Amount, ChainId, Hash, SendTransaction, SwapOfferTransaction, TokenTicker } from "@iov/bcp";
-import { Encoding } from "@iov/encoding";
+import { fromHex } from "@iov/encoding";
 import Long from "long";
 
 import { decodeAmount } from "./decodeobjects";
@@ -37,8 +37,6 @@ import {
   VoteOption,
   VoteTx,
 } from "./types";
-
-const { fromHex } = Encoding;
 
 /** A random user on an IOV testnet */
 const alice = {

--- a/packages/iov-bns/src/encodemsg.ts
+++ b/packages/iov-bns/src/encodemsg.ts
@@ -7,7 +7,7 @@ import {
   SwapOfferTransaction,
   UnsignedTransaction,
 } from "@iov/bcp";
-import { Encoding } from "@iov/encoding";
+import { Encoding, fromHex } from "@iov/encoding";
 
 import { encodeAmount, encodeInt, encodeNumericId, encodeString } from "./encodinghelpers";
 import * as codecImpl from "./generated/codecimpl";
@@ -441,7 +441,7 @@ function encodeValidators(validators: Validators): codecImpl.weave.IValidatorUpd
     }
 
     return {
-      pubKey: { data: Encoding.fromHex(matches[1]), type: "ed25519" },
+      pubKey: { data: fromHex(matches[1]), type: "ed25519" },
       power: power,
     };
   });

--- a/packages/iov-bns/src/tags.ts
+++ b/packages/iov-bns/src/tags.ts
@@ -6,7 +6,7 @@ import {
   isAtomicSwapSenderQuery,
   QueryTag,
 } from "@iov/bcp";
-import { Encoding } from "@iov/encoding";
+import { toHex } from "@iov/encoding";
 
 import { bucketKey, decodeBnsAddress, indexKey } from "./util";
 
@@ -27,7 +27,7 @@ export function bnsSwapQueryTag(query: AtomicSwapQuery, set = true): QueryTag {
   }
 
   return {
-    key: Encoding.toHex(binKey).toUpperCase(),
+    key: toHex(binKey).toUpperCase(),
     // "s" for set, "d" for delete.... we need to watch both changes to be clear
     // But if we return two tags here, that would AND not OR
     value: set ? "s" : "d",

--- a/packages/iov-bns/src/testdata.spec.ts
+++ b/packages/iov-bns/src/testdata.spec.ts
@@ -19,12 +19,10 @@ import {
   TokenTicker,
 } from "@iov/bcp";
 import { Ed25519, Ed25519Keypair } from "@iov/crypto";
-import { Encoding } from "@iov/encoding";
+import { fromHex } from "@iov/encoding";
 
 import data from "./testdata/bnsd.json";
 import { PrivkeyBundle, PrivkeyBytes } from "./types";
-
-const { fromHex } = Encoding;
 
 export const pubJson: PubkeyBundle = {
   algo: Algorithm.Ed25519,

--- a/packages/iov-bns/src/testutils.spec.ts
+++ b/packages/iov-bns/src/testutils.spec.ts
@@ -20,15 +20,13 @@ import {
   TokenTicker,
 } from "@iov/bcp";
 import { Random } from "@iov/crypto";
-import { Encoding } from "@iov/encoding";
+import { fromHex, toHex } from "@iov/encoding";
 import { Ed25519HdWallet, HdPaths, UserProfile, WalletId } from "@iov/keycontrol";
 import { sleep } from "@iov/utils";
 
 import { bnsCodec } from "./bnscodec";
 import { BnsConnection } from "./bnsconnection";
 import { encodeBnsAddress, identityToAddress } from "./util";
-
-const { fromHex, toHex } = Encoding;
 
 export const bash = "BASH" as TokenTicker;
 export const cash = "CASH" as TokenTicker;

--- a/packages/iov-bns/src/util.spec.ts
+++ b/packages/iov-bns/src/util.spec.ts
@@ -1,5 +1,5 @@
 import { Address, Algorithm, ChainId, PubkeyBundle, PubkeyBytes, TransactionId } from "@iov/bcp";
-import { Encoding } from "@iov/encoding";
+import { Encoding, fromHex, toHex } from "@iov/encoding";
 
 import * as testdata from "./testdata.spec";
 import {
@@ -14,7 +14,7 @@ import {
   pubkeyToAddress,
 } from "./util";
 
-const { fromHex, toAscii, toHex, toUtf8 } = Encoding;
+const { toAscii, toUtf8 } = Encoding;
 
 describe("Util", () => {
   describe("addressPrefix", () => {

--- a/packages/iov-bns/src/util.ts
+++ b/packages/iov-bns/src/util.ts
@@ -26,7 +26,7 @@ import {
   UnsignedTransaction,
 } from "@iov/bcp";
 import { Sha256 } from "@iov/crypto";
-import { Bech32, Encoding } from "@iov/encoding";
+import { Bech32, Encoding, toHex } from "@iov/encoding";
 import { QueryString } from "@iov/tendermint-rpc";
 import BN from "bn.js";
 import Long from "long";
@@ -165,14 +165,14 @@ export function isConfirmedWithSwapClaimOrAbortTransaction(
 
 function sentFromOrToTag(addr: Address): string {
   const id = Uint8Array.from([...Encoding.toAscii("cash:"), ...decodeBnsAddress(addr).data]);
-  const key = Encoding.toHex(id).toUpperCase();
+  const key = toHex(id).toUpperCase();
   const value = "s"; // "s" for "set"
   return `${key}='${value}'`;
 }
 
 function signedByTag(addr: Address): string {
   const id = Uint8Array.from([...Encoding.toAscii("sigs:"), ...decodeBnsAddress(addr).data]);
-  const key = Encoding.toHex(id).toUpperCase();
+  const key = toHex(id).toUpperCase();
   const value = "s"; // "s" for "set"
   return `${key}='${value}'`;
 }

--- a/packages/iov-cli/src/cli.ts
+++ b/packages/iov-cli/src/cli.ts
@@ -147,6 +147,8 @@ export function main(originalArgs: readonly string[]): void {
       [
         "Bech32",
         "Encoding",
+        "fromHex",
+        "toHex",
         // integers
         "Int53",
         "Uint32",
@@ -200,8 +202,6 @@ export function main(originalArgs: readonly string[]): void {
   }
   console.info(colors.yellow("  * helper functions"));
   console.info(colors.yellow("    - toAscii"));
-  console.info(colors.yellow("    - fromHex"));
-  console.info(colors.yellow("    - toHex"));
 
   let init = `
     import leveldown = require('leveldown');
@@ -214,7 +214,7 @@ export function main(originalArgs: readonly string[]): void {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     init += `import { ${imports.get(moduleName)!.join(", ")} } from "${moduleName}";\n`;
   }
-  init += `const { toAscii, fromHex, toHex } = Encoding;\n`;
+  init += `const { toAscii } = Encoding;\n`;
 
   if (args.selftest) {
     // execute some trival stuff and exit

--- a/packages/iov-cosmoshub/src/address.spec.ts
+++ b/packages/iov-cosmoshub/src/address.spec.ts
@@ -1,9 +1,9 @@
 import { Address, Algorithm, PubkeyBytes } from "@iov/bcp";
-import { Encoding } from "@iov/encoding";
+import { Encoding, fromHex } from "@iov/encoding";
 
 import { decodeCosmosAddress, decodeCosmosPubkey, isValidAddress, pubkeyToAddress } from "./address";
 
-const { fromBase64, fromHex } = Encoding;
+const { fromBase64 } = Encoding;
 
 describe("address", () => {
   // Bech32 encoding/decoding data generated using https://github.com/bitcoinjs/bech32

--- a/packages/iov-cosmoshub/src/address.ts
+++ b/packages/iov-cosmoshub/src/address.ts
@@ -1,6 +1,6 @@
 import { Address, Algorithm, PubkeyBundle } from "@iov/bcp";
 import { Ripemd160, Secp256k1, Sha256 } from "@iov/crypto";
-import { Bech32, Encoding } from "@iov/encoding";
+import { Bech32, fromHex, toHex } from "@iov/encoding";
 import equal from "fast-deep-equal";
 
 export type CosmosAddressBech32Prefix = "cosmos" | "cosmosvalcons" | "cosmosvaloper";
@@ -8,7 +8,7 @@ export type CosmosPubkeyBech32Prefix = "cosmospub" | "cosmosvalconspub" | "cosmo
 export type CosmosBech32Prefix = CosmosAddressBech32Prefix | CosmosPubkeyBech32Prefix;
 
 /** As discussed in https://github.com/binance-chain/javascript-sdk/issues/163 */
-const pubkeyAminoPrefix = Encoding.fromHex("eb5ae98721");
+const pubkeyAminoPrefix = fromHex("eb5ae98721");
 
 function isCosmosAddressBech32Prefix(prefix: string): prefix is CosmosAddressBech32Prefix {
   return ["cosmos", "cosmosvalcons", "cosmosvaloper"].includes(prefix);
@@ -45,7 +45,7 @@ export function decodeCosmosPubkey(
   }
 
   if (!equal(data.slice(0, pubkeyAminoPrefix.length), pubkeyAminoPrefix)) {
-    throw new Error("Pubkey does not have the expected amino prefix " + Encoding.toHex(pubkeyAminoPrefix));
+    throw new Error("Pubkey does not have the expected amino prefix " + toHex(pubkeyAminoPrefix));
   }
 
   const rest = data.slice(pubkeyAminoPrefix.length);

--- a/packages/iov-cosmoshub/src/caip5.ts
+++ b/packages/iov-cosmoshub/src/caip5.ts
@@ -1,8 +1,8 @@
 import { ChainId } from "@iov/bcp";
 import { Sha256 } from "@iov/crypto";
-import { Encoding } from "@iov/encoding";
+import { Encoding, toHex } from "@iov/encoding";
 
-const { toHex, toUtf8 } = Encoding;
+const { toUtf8 } = Encoding;
 
 const hashedPrefix = "hashed-";
 

--- a/packages/iov-cosmoshub/src/cosmoshubcodec.ts
+++ b/packages/iov-cosmoshub/src/cosmoshubcodec.ts
@@ -14,7 +14,7 @@ import {
   UnsignedTransaction,
 } from "@iov/bcp";
 import { Sha256 } from "@iov/crypto";
-import { Encoding } from "@iov/encoding";
+import { Encoding, toHex } from "@iov/encoding";
 import { marshalTx, unmarshalTx } from "@tendermint/amino-js";
 
 import { isValidAddress, pubkeyToAddress } from "./address";
@@ -22,7 +22,7 @@ import { Caip5 } from "./caip5";
 import { parseTx } from "./decode";
 import { buildSignedTx, buildUnsignedTx } from "./encode";
 
-const { toHex, toUtf8 } = Encoding;
+const { toUtf8 } = Encoding;
 
 function sortJson(json: any): any {
   if (typeof json !== "object" || json === null) {

--- a/packages/iov-cosmoshub/src/cosmoshubconnection.spec.ts
+++ b/packages/iov-cosmoshub/src/cosmoshubconnection.spec.ts
@@ -11,13 +11,13 @@ import {
   TransactionState,
 } from "@iov/bcp";
 import { Secp256k1 } from "@iov/crypto";
-import { Encoding } from "@iov/encoding";
+import { Encoding, toHex } from "@iov/encoding";
 import { HdPaths, Secp256k1HdWallet, UserProfile } from "@iov/keycontrol";
 
 import { cosmosHubCodec } from "./cosmoshubcodec";
 import { CosmosHubConnection } from "./cosmoshubconnection";
 
-const { fromBase64, toHex } = Encoding;
+const { fromBase64 } = Encoding;
 
 function pendingWithoutCosmosHub(): void {
   if (!process.env.COSMOSHUB_ENABLED) {

--- a/packages/iov-cosmoshub/src/decode.spec.ts
+++ b/packages/iov-cosmoshub/src/decode.spec.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/camelcase */
 import { Address, Algorithm, TokenTicker } from "@iov/bcp";
-import { Encoding } from "@iov/encoding";
+import { Encoding, fromHex } from "@iov/encoding";
 import amino from "@tendermint/amino-js";
 
 import {
@@ -16,7 +16,7 @@ import {
 import { chainId, nonce, signedTxJson, txId } from "./testdata.spec";
 import data from "./testdata/cosmoshub.json";
 
-const { fromBase64, fromHex } = Encoding;
+const { fromBase64 } = Encoding;
 
 describe("decode", () => {
   const defaultPubkey = {

--- a/packages/iov-crypto/src/bip39.spec.ts
+++ b/packages/iov-crypto/src/bip39.spec.ts
@@ -1,10 +1,8 @@
-import { Encoding } from "@iov/encoding";
+import { fromHex } from "@iov/encoding";
 
 import { Bip39 } from "./bip39";
 import { EnglishMnemonic } from "./englishmnemonic";
 import bip39Vectors from "./testdata/bip39.json";
-
-const fromHex = Encoding.fromHex;
 
 describe("Bip39", () => {
   describe("encode", () => {

--- a/packages/iov-crypto/src/bip39.ts
+++ b/packages/iov-crypto/src/bip39.ts
@@ -1,4 +1,4 @@
-import { Encoding } from "@iov/encoding";
+import { fromHex, toHex } from "@iov/encoding";
 import * as bip39 from "bip39";
 import { pbkdf2 } from "pbkdf2";
 import * as unorm from "unorm";
@@ -13,11 +13,11 @@ export class Bip39 {
       throw new Error("invalid input length");
     }
 
-    return new EnglishMnemonic(bip39.entropyToMnemonic(Encoding.toHex(entropy)));
+    return new EnglishMnemonic(bip39.entropyToMnemonic(toHex(entropy)));
   }
 
   public static decode(mnemonic: EnglishMnemonic): Uint8Array {
-    return Encoding.fromHex(bip39.mnemonicToEntropy(mnemonic.toString()));
+    return fromHex(bip39.mnemonicToEntropy(mnemonic.toString()));
   }
 
   public static async mnemonicToSeed(mnemonic: EnglishMnemonic, password?: string): Promise<Uint8Array> {

--- a/packages/iov-crypto/src/englishmnemonic.spec.ts
+++ b/packages/iov-crypto/src/englishmnemonic.spec.ts
@@ -1,10 +1,10 @@
-import { Encoding } from "@iov/encoding";
+import { Encoding, fromHex } from "@iov/encoding";
 
 import { EnglishMnemonic } from "./englishmnemonic";
 import { Sha256 } from "./sha";
 import wordlists from "./testdata/bip39_wordlists.json";
 
-const { fromAscii, fromBase64, fromHex } = Encoding;
+const { fromAscii, fromBase64 } = Encoding;
 
 describe("EnglishMnemonic", () => {
   describe("wordlist", () => {

--- a/packages/iov-crypto/src/hmac.spec.ts
+++ b/packages/iov-crypto/src/hmac.spec.ts
@@ -1,9 +1,7 @@
-import { Encoding } from "@iov/encoding";
+import { fromHex } from "@iov/encoding";
 
 import { Hmac } from "./hmac";
 import { Sha1, Sha256, Sha512 } from "./sha";
-
-const fromHex = Encoding.fromHex;
 
 describe("HMAC", () => {
   it("can perform HMAC(SHA1) according to Botan test vectors", () => {

--- a/packages/iov-crypto/src/keccak.spec.ts
+++ b/packages/iov-crypto/src/keccak.spec.ts
@@ -1,10 +1,7 @@
-import { Encoding } from "@iov/encoding";
+import { fromHex, toHex } from "@iov/encoding";
 
 import { Keccak256 } from "./keccak";
 import keccakVectors from "./testdata/keccak.json";
-
-const toHex = Encoding.toHex;
-const fromHex = Encoding.fromHex;
 
 describe("Keccak256", () => {
   it("exists", () => {

--- a/packages/iov-crypto/src/libsodium.spec.ts
+++ b/packages/iov-crypto/src/libsodium.spec.ts
@@ -1,5 +1,5 @@
 /* tslint:disable:no-bitwise */
-import { Encoding } from "@iov/encoding";
+import { Encoding, fromHex } from "@iov/encoding";
 
 import {
   Argon2id,
@@ -13,7 +13,7 @@ import {
   Xchacha20poly1305IetfNonce,
 } from "./libsodium";
 
-const { toAscii, fromHex } = Encoding;
+const { toAscii } = Encoding;
 
 describe("Libsodium", () => {
   describe("Argon2id", () => {

--- a/packages/iov-crypto/src/ripemd.spec.ts
+++ b/packages/iov-crypto/src/ripemd.spec.ts
@@ -1,9 +1,7 @@
-import { Encoding } from "@iov/encoding";
+import { fromHex } from "@iov/encoding";
 
 import { Ripemd160 } from "./ripemd";
 import ripemdVectors from "./testdata/ripemd.json";
-
-const { fromHex } = Encoding;
 
 describe("Ripemd160", () => {
   it("exists", () => {

--- a/packages/iov-crypto/src/secp256k1.spec.ts
+++ b/packages/iov-crypto/src/secp256k1.spec.ts
@@ -1,11 +1,9 @@
 /* tslint:disable:no-bitwise */
-import { Encoding } from "@iov/encoding";
+import { fromHex } from "@iov/encoding";
 
 import { Secp256k1 } from "./secp256k1";
 import { ExtendedSecp256k1Signature, Secp256k1Signature } from "./secp256k1signature";
 import { Sha256 } from "./sha";
-
-const { fromHex } = Encoding;
 
 describe("Secp256k1", () => {
   // How to generate Secp256k1 test vectors:

--- a/packages/iov-crypto/src/secp256k1.ts
+++ b/packages/iov-crypto/src/secp256k1.ts
@@ -1,4 +1,4 @@
-import { Encoding } from "@iov/encoding";
+import { fromHex, toHex } from "@iov/encoding";
 import BN from "bn.js";
 import elliptic from "elliptic";
 import { As } from "type-tagger";
@@ -36,7 +36,7 @@ export class Secp256k1 {
     }
 
     const out: Keypair = {
-      privkey: Encoding.fromHex(keypair.getPrivate("hex")),
+      privkey: fromHex(keypair.getPrivate("hex")),
       // encodes uncompressed as
       // - 1-byte prefix "04"
       // - 32-byte x coordinate
@@ -107,10 +107,10 @@ export class Secp256k1 {
   }
 
   public static recoverPubkey(signature: ExtendedSecp256k1Signature, messageHash: Uint8Array): Uint8Array {
-    const signatureForElliptic = { r: Encoding.toHex(signature.r()), s: Encoding.toHex(signature.s()) };
+    const signatureForElliptic = { r: toHex(signature.r()), s: toHex(signature.s()) };
     const point = secp256k1.recoverPubKey(messageHash, signatureForElliptic, signature.recovery);
     const keypair = secp256k1.keyFromPublic(point);
-    return Encoding.fromHex(keypair.getPublic(false, "hex"));
+    return fromHex(keypair.getPublic(false, "hex"));
   }
 
   public static compressPubkey(pubkey: Uint8Array): Uint8Array {

--- a/packages/iov-crypto/src/secp256k1signature.spec.ts
+++ b/packages/iov-crypto/src/secp256k1signature.spec.ts
@@ -1,8 +1,6 @@
-import { Encoding } from "@iov/encoding";
+import { fromHex } from "@iov/encoding";
 
 import { ExtendedSecp256k1Signature, Secp256k1Signature } from "./secp256k1signature";
-
-const { fromHex } = Encoding;
 
 describe("Secp256k1Signature", () => {
   describe("fromFixedLength", () => {

--- a/packages/iov-crypto/src/sha.spec.ts
+++ b/packages/iov-crypto/src/sha.spec.ts
@@ -1,10 +1,7 @@
-import { Encoding } from "@iov/encoding";
+import { fromHex, toHex } from "@iov/encoding";
 
 import { Sha256 } from "./sha";
 import shaVectors from "./testdata/sha.json";
-
-const toHex = Encoding.toHex;
-const fromHex = Encoding.fromHex;
 
 describe("Sha256", () => {
   it("exists", () => {

--- a/packages/iov-crypto/src/slip10.spec.ts
+++ b/packages/iov-crypto/src/slip10.spec.ts
@@ -1,8 +1,6 @@
-import { Encoding } from "@iov/encoding";
+import { fromHex } from "@iov/encoding";
 
 import { Slip10, Slip10Curve, slip10CurveFromString, Slip10RawIndex } from "./slip10";
-
-const fromHex = Encoding.fromHex;
 
 describe("Slip10", () => {
   it("has working slip10CurveFromString()", () => {

--- a/packages/iov-crypto/src/slip10.ts
+++ b/packages/iov-crypto/src/slip10.ts
@@ -1,4 +1,4 @@
-import { Encoding, Uint32 } from "@iov/encoding";
+import { Encoding, fromHex, Uint32 } from "@iov/encoding";
 import BN from "bn.js";
 import elliptic from "elliptic";
 
@@ -116,7 +116,7 @@ export class Slip10 {
   private static serializedPoint(curve: Slip10Curve, p: BN): Uint8Array {
     switch (curve) {
       case Slip10Curve.Secp256k1:
-        return Encoding.fromHex(secp256k1.g.mul(p).encodeCompressed("hex"));
+        return fromHex(secp256k1.g.mul(p).encodeCompressed("hex"));
       default:
         throw new Error("curve not supported");
     }

--- a/packages/iov-encoding/README.md
+++ b/packages/iov-encoding/README.md
@@ -10,9 +10,9 @@ on invalid input.
 ## Convert between bech32 and hex addresses
 
 ```
->> Bech32.encode("tiov", Encoding.fromHex("1234ABCD0000AA0000FFFF0000AA00001234ABCD"))
+>> Bech32.encode("tiov", fromHex("1234ABCD0000AA0000FFFF0000AA00001234ABCD"))
 'tiov1zg62hngqqz4qqq8lluqqp2sqqqfrf27dzrrmea'
->> Encoding.toHex(Bech32.decode("tiov1zg62hngqqz4qqq8lluqqp2sqqqfrf27dzrrmea").data)
+>> toHex(Bech32.decode("tiov1zg62hngqqz4qqq8lluqqp2sqqqfrf27dzrrmea").data)
 '1234abcd0000aa0000ffff0000aa00001234abcd'
 ```
 

--- a/packages/iov-encoding/src/bech32.spec.ts
+++ b/packages/iov-encoding/src/bech32.spec.ts
@@ -1,10 +1,10 @@
 import { Bech32 } from "./bech32";
-import { Encoding } from "./encoding";
+import { fromHex } from "./hex";
 
 describe("Bech32", () => {
   // test data generate using https://github.com/nym-zone/bech32
   // bech32 -e -h eth 9d4e856e572e442f0a4b2763e72d08a0e99d8ded
-  const ethAddressRaw = Encoding.fromHex("9d4e856e572e442f0a4b2763e72d08a0e99d8ded");
+  const ethAddressRaw = fromHex("9d4e856e572e442f0a4b2763e72d08a0e99d8ded");
 
   it("encodes", () => {
     expect(Bech32.encode("eth", ethAddressRaw)).toEqual("eth1n48g2mjh9ezz7zjtya37wtgg5r5emr0drkwlgw");

--- a/packages/iov-encoding/src/encoding.spec.ts
+++ b/packages/iov-encoding/src/encoding.spec.ts
@@ -1,45 +1,6 @@
 import { Encoding } from "./encoding";
 
 describe("Encoding", () => {
-  it("encodes to hex", () => {
-    expect(Encoding.toHex(new Uint8Array([]))).toEqual("");
-    expect(Encoding.toHex(new Uint8Array([0x00]))).toEqual("00");
-    expect(Encoding.toHex(new Uint8Array([0x01]))).toEqual("01");
-    expect(Encoding.toHex(new Uint8Array([0x10]))).toEqual("10");
-    expect(Encoding.toHex(new Uint8Array([0x11]))).toEqual("11");
-    expect(Encoding.toHex(new Uint8Array([0x11, 0x22, 0x33]))).toEqual("112233");
-    expect(Encoding.toHex(new Uint8Array([0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef]))).toEqual(
-      "0123456789abcdef",
-    );
-  });
-
-  it("decodes from hex", () => {
-    // simple
-    expect(Encoding.fromHex("")).toEqual(new Uint8Array([]));
-    expect(Encoding.fromHex("00")).toEqual(new Uint8Array([0x00]));
-    expect(Encoding.fromHex("01")).toEqual(new Uint8Array([0x01]));
-    expect(Encoding.fromHex("10")).toEqual(new Uint8Array([0x10]));
-    expect(Encoding.fromHex("11")).toEqual(new Uint8Array([0x11]));
-    expect(Encoding.fromHex("112233")).toEqual(new Uint8Array([0x11, 0x22, 0x33]));
-    expect(Encoding.fromHex("0123456789abcdef")).toEqual(
-      new Uint8Array([0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef]),
-    );
-
-    // capital letters
-    expect(Encoding.fromHex("AA")).toEqual(new Uint8Array([0xaa]));
-    expect(Encoding.fromHex("aAbBcCdDeEfF")).toEqual(new Uint8Array([0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff]));
-
-    // error
-    expect(() => Encoding.fromHex("a")).toThrow();
-    expect(() => Encoding.fromHex("aaa")).toThrow();
-    expect(() => Encoding.fromHex("a!")).toThrow();
-    expect(() => Encoding.fromHex("a ")).toThrow();
-    expect(() => Encoding.fromHex("aa ")).toThrow();
-    expect(() => Encoding.fromHex(" aa")).toThrow();
-    expect(() => Encoding.fromHex("a a")).toThrow();
-    expect(() => Encoding.fromHex("gg")).toThrow();
-  });
-
   it("encodes to base64", () => {
     expect(Encoding.toBase64(new Uint8Array([]))).toEqual("");
     expect(Encoding.toBase64(new Uint8Array([0x00]))).toEqual("AA==");

--- a/packages/iov-encoding/src/encoding.ts
+++ b/packages/iov-encoding/src/encoding.ts
@@ -1,6 +1,8 @@
 import * as base64js from "base64-js";
 import { ReadonlyDate } from "readonly-date";
 
+import { fromHex, toHex } from "./hex";
+
 // Global symbols in some environments
 // https://developer.mozilla.org/en-US/docs/Web/API/TextEncoder
 // https://developer.mozilla.org/en-US/docs/Web/API/TextDecoder
@@ -8,29 +10,14 @@ declare const TextEncoder: any | undefined;
 declare const TextDecoder: any | undefined;
 
 export class Encoding {
+  /** @deprecated use free function toHex from @iov/encoding */
   public static toHex(data: Uint8Array): string {
-    let out = "";
-    for (const byte of data) {
-      out += ("0" + byte.toString(16)).slice(-2);
-    }
-    return out;
+    return toHex(data);
   }
 
+  /** @deprecated use free function fromHex from @iov/encoding */
   public static fromHex(hexstring: string): Uint8Array {
-    if (hexstring.length % 2 !== 0) {
-      throw new Error("hex string length must be a multiple of 2");
-    }
-
-    // tslint:disable-next-line:readonly-array
-    const listOfInts: number[] = [];
-    for (let i = 0; i < hexstring.length; i += 2) {
-      const hexByteAsString = hexstring.substr(i, 2);
-      if (!hexByteAsString.match(/[0-9a-f]{2}/i)) {
-        throw new Error("hex string contains invalid characters");
-      }
-      listOfInts.push(parseInt(hexByteAsString, 16));
-    }
-    return new Uint8Array(listOfInts);
+    return fromHex(hexstring);
   }
 
   public static toBase64(data: Uint8Array): string {

--- a/packages/iov-encoding/src/hex.spec.ts
+++ b/packages/iov-encoding/src/hex.spec.ts
@@ -1,0 +1,44 @@
+import { fromHex, toHex } from "./hex";
+
+describe("fromHex", () => {
+  it("works", () => {
+    // simple
+    expect(fromHex("")).toEqual(new Uint8Array([]));
+    expect(fromHex("00")).toEqual(new Uint8Array([0x00]));
+    expect(fromHex("01")).toEqual(new Uint8Array([0x01]));
+    expect(fromHex("10")).toEqual(new Uint8Array([0x10]));
+    expect(fromHex("11")).toEqual(new Uint8Array([0x11]));
+    expect(fromHex("112233")).toEqual(new Uint8Array([0x11, 0x22, 0x33]));
+    expect(fromHex("0123456789abcdef")).toEqual(
+      new Uint8Array([0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef]),
+    );
+
+    // capital letters
+    expect(fromHex("AA")).toEqual(new Uint8Array([0xaa]));
+    expect(fromHex("aAbBcCdDeEfF")).toEqual(new Uint8Array([0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff]));
+
+    // error
+    expect(() => fromHex("a")).toThrow();
+    expect(() => fromHex("aaa")).toThrow();
+    expect(() => fromHex("a!")).toThrow();
+    expect(() => fromHex("a ")).toThrow();
+    expect(() => fromHex("aa ")).toThrow();
+    expect(() => fromHex(" aa")).toThrow();
+    expect(() => fromHex("a a")).toThrow();
+    expect(() => fromHex("gg")).toThrow();
+  });
+});
+
+describe("toHex", () => {
+  it("works", () => {
+    expect(toHex(new Uint8Array([]))).toEqual("");
+    expect(toHex(new Uint8Array([0x00]))).toEqual("00");
+    expect(toHex(new Uint8Array([0x01]))).toEqual("01");
+    expect(toHex(new Uint8Array([0x10]))).toEqual("10");
+    expect(toHex(new Uint8Array([0x11]))).toEqual("11");
+    expect(toHex(new Uint8Array([0x11, 0x22, 0x33]))).toEqual("112233");
+    expect(toHex(new Uint8Array([0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef]))).toEqual(
+      "0123456789abcdef",
+    );
+  });
+});

--- a/packages/iov-encoding/src/hex.ts
+++ b/packages/iov-encoding/src/hex.ts
@@ -1,0 +1,24 @@
+export function toHex(data: Uint8Array): string {
+  let out = "";
+  for (const byte of data) {
+    out += ("0" + byte.toString(16)).slice(-2);
+  }
+  return out;
+}
+
+export function fromHex(hexstring: string): Uint8Array {
+  if (hexstring.length % 2 !== 0) {
+    throw new Error("hex string length must be a multiple of 2");
+  }
+
+  // tslint:disable-next-line:readonly-array
+  const listOfInts: number[] = [];
+  for (let i = 0; i < hexstring.length; i += 2) {
+    const hexByteAsString = hexstring.substr(i, 2);
+    if (!hexByteAsString.match(/[0-9a-f]{2}/i)) {
+      throw new Error("hex string contains invalid characters");
+    }
+    listOfInts.push(parseInt(hexByteAsString, 16));
+  }
+  return new Uint8Array(listOfInts);
+}

--- a/packages/iov-encoding/src/index.ts
+++ b/packages/iov-encoding/src/index.ts
@@ -1,6 +1,7 @@
 export { Bech32 } from "./bech32";
 export { Decimal } from "./decimal";
 export { Encoding } from "./encoding";
+export { fromHex, toHex } from "./hex";
 export { Int53, Uint32, Uint53, Uint64 } from "./integers";
 export {
   JsonCompatibleValue,

--- a/packages/iov-encoding/src/transactionencoder.spec.ts
+++ b/packages/iov-encoding/src/transactionencoder.spec.ts
@@ -1,4 +1,4 @@
-import { Encoding } from "./encoding";
+import { fromHex } from "./hex";
 import { TransactionEncoder } from "./transactionencoder";
 import { isUint8Array } from "./typechecks";
 
@@ -39,7 +39,7 @@ describe("TransactionEncoder", () => {
   const defaultChainId = "testchain";
   const defaultPubkey = {
     algo: "ed25519",
-    data: Encoding.fromHex("aabbccdd"),
+    data: fromHex("aabbccdd"),
   };
   const defaultAmount = {
     quantity: "123",

--- a/packages/iov-encoding/src/transactionencoder.ts
+++ b/packages/iov-encoding/src/transactionencoder.ts
@@ -1,4 +1,4 @@
-import { Encoding } from "./encoding";
+import { fromHex, toHex } from "./hex";
 import { JsonCompatibleValue } from "./json";
 import { isUint8Array } from "./typechecks";
 
@@ -35,7 +35,7 @@ export class TransactionEncoder {
     }
 
     if (isUint8Array(data)) {
-      return `${prefixes.bytes}${Encoding.toHex(data)}`;
+      return `${prefixes.bytes}${toHex(data)}`;
     }
 
     if (Array.isArray(data)) {
@@ -83,7 +83,7 @@ export class TransactionEncoder {
       }
 
       if (data.startsWith(prefixes.bytes)) {
-        return Encoding.fromHex(data.slice(prefixes.bytes.length));
+        return fromHex(data.slice(prefixes.bytes.length));
       }
 
       throw new Error("Found string with unknown prefix");

--- a/packages/iov-encoding/types/encoding.d.ts
+++ b/packages/iov-encoding/types/encoding.d.ts
@@ -1,6 +1,8 @@
 import { ReadonlyDate } from "readonly-date";
 export declare class Encoding {
+  /** @deprecated use free function toHex from @iov/encoding */
   static toHex(data: Uint8Array): string;
+  /** @deprecated use free function fromHex from @iov/encoding */
   static fromHex(hexstring: string): Uint8Array;
   static toBase64(data: Uint8Array): string;
   static fromBase64(base64String: string): Uint8Array;

--- a/packages/iov-encoding/types/hex.d.ts
+++ b/packages/iov-encoding/types/hex.d.ts
@@ -1,0 +1,2 @@
+export declare function toHex(data: Uint8Array): string;
+export declare function fromHex(hexstring: string): Uint8Array;

--- a/packages/iov-encoding/types/index.d.ts
+++ b/packages/iov-encoding/types/index.d.ts
@@ -1,6 +1,7 @@
 export { Bech32 } from "./bech32";
 export { Decimal } from "./decimal";
 export { Encoding } from "./encoding";
+export { fromHex, toHex } from "./hex";
 export { Int53, Uint32, Uint53, Uint64 } from "./integers";
 export {
   JsonCompatibleValue,

--- a/packages/iov-ethereum/src/abi.spec.ts
+++ b/packages/iov-ethereum/src/abi.spec.ts
@@ -1,5 +1,5 @@
 import { Address, SwapProcessState } from "@iov/bcp";
-import { Encoding } from "@iov/encoding";
+import { fromHex } from "@iov/encoding";
 
 import { Abi } from "./abi";
 import {
@@ -7,8 +7,6 @@ import {
   SwapContractEvent,
   SwapContractMethod,
 } from "./smartcontracts/atomicswapcontract";
-
-const { fromHex } = Encoding;
 
 describe("Abi", () => {
   describe("calculateMethodHash", () => {

--- a/packages/iov-ethereum/src/abi.ts
+++ b/packages/iov-ethereum/src/abi.ts
@@ -1,6 +1,6 @@
 import { Address } from "@iov/bcp";
 import { Keccak256 } from "@iov/crypto";
-import { Encoding } from "@iov/encoding";
+import { Encoding, fromHex } from "@iov/encoding";
 import BN from "bn.js";
 
 import { isValidAddress, toChecksummedAddress } from "./address";
@@ -26,7 +26,7 @@ export class Abi {
       throw new Error("Invalid address format");
     }
 
-    const addressBytes = Encoding.fromHex(address.slice(2));
+    const addressBytes = fromHex(address.slice(2));
     return Abi.padTo32(addressBytes);
   }
 

--- a/packages/iov-ethereum/src/address.spec.ts
+++ b/packages/iov-ethereum/src/address.spec.ts
@@ -1,9 +1,7 @@
 import { Algorithm, PubkeyBundle, PubkeyBytes } from "@iov/bcp";
-import { Encoding } from "@iov/encoding";
+import { fromHex } from "@iov/encoding";
 
 import { isValidAddress, pubkeyToAddress, toChecksummedAddress } from "./address";
-
-const { fromHex } = Encoding;
 
 describe("address", () => {
   describe("isValidAddress", () => {

--- a/packages/iov-ethereum/src/address.ts
+++ b/packages/iov-ethereum/src/address.ts
@@ -1,8 +1,8 @@
 import { Address, Algorithm, PubkeyBundle } from "@iov/bcp";
 import { Keccak256 } from "@iov/crypto";
-import { Encoding } from "@iov/encoding";
+import { Encoding, toHex } from "@iov/encoding";
 
-const { toAscii, toHex } = Encoding;
+const { toAscii } = Encoding;
 
 export function isValidAddress(address: string): boolean {
   if (!address.match(/^0x[a-fA-F0-9]{40}$/)) {

--- a/packages/iov-ethereum/src/erc20reader.spec.ts
+++ b/packages/iov-ethereum/src/erc20reader.spec.ts
@@ -1,6 +1,6 @@
 import { Address, Algorithm, PubkeyBytes } from "@iov/bcp";
 import { Random, Secp256k1 } from "@iov/crypto";
-import { Encoding } from "@iov/encoding";
+import { fromHex } from "@iov/encoding";
 import { isJsonRpcErrorResponse } from "@iov/jsonrpc";
 import BN from "bn.js";
 
@@ -43,7 +43,7 @@ function makeClient(baseUrl: string): EthereumRpcClient {
         throw new Error(JSON.stringify(response.error));
       }
 
-      return Encoding.fromHex(normalizeHex(response.result));
+      return fromHex(normalizeHex(response.result));
     },
   };
 }

--- a/packages/iov-ethereum/src/ethereumcodec.spec.ts
+++ b/packages/iov-ethereum/src/ethereumcodec.spec.ts
@@ -18,15 +18,13 @@ import {
   TokenTicker,
 } from "@iov/bcp";
 import { ExtendedSecp256k1Signature } from "@iov/crypto";
-import { Encoding } from "@iov/encoding";
+import { Encoding, fromHex } from "@iov/encoding";
 
 import { Erc20ApproveTransaction, Erc20Options } from "./erc20";
 import { EthereumCodec } from "./ethereumcodec";
 import { EthereumRpcTransactionResult } from "./ethereumrpctransactionresult";
 import { SwapIdPrefix } from "./serializationcommon";
 import { testConfig } from "./testconfig.spec";
-
-const { fromHex } = Encoding;
 
 const ethereumCodec = new EthereumCodec({
   atomicSwapEtherContractAddress: testConfig.connectionOptions.atomicSwapEtherContractAddress,
@@ -88,8 +86,8 @@ describe("ethereumCodec", () => {
               data: expectedPubkey,
             },
             signature: new ExtendedSecp256k1Signature(
-              Encoding.fromHex("b9299dab50b3cddcaecd64b29bfbd5cd30fac1a1adea1b359a13c4e5171492a6"),
-              Encoding.fromHex("573059c66d894684488f92e7ce1f91b158ca57b0235485625b576a3b98c480ac"),
+              fromHex("b9299dab50b3cddcaecd64b29bfbd5cd30fac1a1adea1b359a13c4e5171492a6"),
+              fromHex("573059c66d894684488f92e7ce1f91b158ca57b0235485625b576a3b98c480ac"),
               0,
             ).toFixedLength() as SignatureBytes,
           },
@@ -163,8 +161,8 @@ describe("ethereumCodec", () => {
               data: expectedPubkey,
             },
             signature: new ExtendedSecp256k1Signature(
-              Encoding.fromHex("cbe96b38321e6ef536da5e74b558cf87acdda825be35be40627b2b3d8633b8f4"),
-              Encoding.fromHex("7fc31ca5bb3dbd02e5e8fc5093082f3f2ab3e0042d4e5b25fe09e5f7485d83b7"),
+              fromHex("cbe96b38321e6ef536da5e74b558cf87acdda825be35be40627b2b3d8633b8f4"),
+              fromHex("7fc31ca5bb3dbd02e5e8fc5093082f3f2ab3e0042d4e5b25fe09e5f7485d83b7"),
               0,
             ).toFixedLength() as SignatureBytes,
           },
@@ -234,8 +232,8 @@ describe("ethereumCodec", () => {
               data: expectedPubkey,
             },
             signature: new ExtendedSecp256k1Signature(
-              Encoding.fromHex("cbe96b38321e6ef536da5e74b558cf87acdda825be35be40627b2b3d8633b8f4"),
-              Encoding.fromHex("7fc31ca5bb3dbd02e5e8fc5093082f3f2ab3e0042d4e5b25fe09e5f7485d83b7"),
+              fromHex("cbe96b38321e6ef536da5e74b558cf87acdda825be35be40627b2b3d8633b8f4"),
+              fromHex("7fc31ca5bb3dbd02e5e8fc5093082f3f2ab3e0042d4e5b25fe09e5f7485d83b7"),
               0,
             ).toFixedLength() as SignatureBytes,
           },
@@ -307,8 +305,8 @@ describe("ethereumCodec", () => {
               data: expectedPubkey,
             },
             signature: new ExtendedSecp256k1Signature(
-              Encoding.fromHex("194013d2767d86e0aac07f5e713e52c1bafdbe20361b59257ae7e5665d504bf1"),
-              Encoding.fromHex("76deb0b778442ff69b61fa9c27333e4b2e6c184643b1ce3d60b4da2cb39266c3"),
+              fromHex("194013d2767d86e0aac07f5e713e52c1bafdbe20361b59257ae7e5665d504bf1"),
+              fromHex("76deb0b778442ff69b61fa9c27333e4b2e6c184643b1ce3d60b4da2cb39266c3"),
               0,
             ).toFixedLength() as SignatureBytes,
           },
@@ -387,8 +385,8 @@ describe("ethereumCodec", () => {
               data: expectedPubkey,
             },
             signature: new ExtendedSecp256k1Signature(
-              Encoding.fromHex("9351a7fa42078636bd36bbae0d8d5f009b92986991bcc92ae882bce8982360d5"),
-              Encoding.fromHex("706a6f90bb42b9d929150839fb9aa06207e40f8d814183e30789ac036263497f"),
+              fromHex("9351a7fa42078636bd36bbae0d8d5f009b92986991bcc92ae882bce8982360d5"),
+              fromHex("706a6f90bb42b9d929150839fb9aa06207e40f8d814183e30789ac036263497f"),
               0,
             ).toFixedLength() as SignatureBytes,
           },
@@ -453,8 +451,8 @@ describe("ethereumCodec", () => {
               data: expectedPubkey,
             },
             signature: new ExtendedSecp256k1Signature(
-              Encoding.fromHex("de9a75921207a5df2757d76408436e38f2186a0047e2955f884f0672c805282c"),
-              Encoding.fromHex("259c0f7c9a1383ef35fa5f41996dfb38744f9df6fe027a2e107d0b6d40ab1ae6"),
+              fromHex("de9a75921207a5df2757d76408436e38f2186a0047e2955f884f0672c805282c"),
+              fromHex("259c0f7c9a1383ef35fa5f41996dfb38744f9df6fe027a2e107d0b6d40ab1ae6"),
               1,
             ).toFixedLength() as SignatureBytes,
           },
@@ -514,8 +512,8 @@ describe("ethereumCodec", () => {
               data: expectedPubkey,
             },
             signature: new ExtendedSecp256k1Signature(
-              Encoding.fromHex("3449246d974d28fffae32af389ef7271c18ff6e6766ce6f54f6243764e6877d6"),
-              Encoding.fromHex("7e2280164650d4fc0c4a2fd1edfeedb70e7c8453117f9cbd6a644abd5e1ddf9b"),
+              fromHex("3449246d974d28fffae32af389ef7271c18ff6e6766ce6f54f6243764e6877d6"),
+              fromHex("7e2280164650d4fc0c4a2fd1edfeedb70e7c8453117f9cbd6a644abd5e1ddf9b"),
               0,
             ).toFixedLength() as SignatureBytes,
           },
@@ -607,8 +605,8 @@ describe("ethereumCodec", () => {
               data: expectedPubkey,
             },
             signature: new ExtendedSecp256k1Signature(
-              Encoding.fromHex("26a7e609ce83e01b8e754641fbd9315f5a558c7b279d1bbe186d8be786c6fb18"),
-              Encoding.fromHex("02555167f9584575f9740c0487dcdd2e1462a8374dd9dcc9e66cfa98eb1efd87"),
+              fromHex("26a7e609ce83e01b8e754641fbd9315f5a558c7b279d1bbe186d8be786c6fb18"),
+              fromHex("02555167f9584575f9740c0487dcdd2e1462a8374dd9dcc9e66cfa98eb1efd87"),
               1,
             ).toFixedLength() as SignatureBytes,
           },
@@ -687,8 +685,8 @@ describe("ethereumCodec", () => {
               data: expectedPubkey,
             },
             signature: new ExtendedSecp256k1Signature(
-              Encoding.fromHex("388baff61d88ff954b40e8980c42a50633d08f954a3b281513ffbd1759fa902e"),
-              Encoding.fromHex("578e59f1cfba37881d4851d0cb96eee287436fbe4a3a9ea4f6407c064f1e4f03"),
+              fromHex("388baff61d88ff954b40e8980c42a50633d08f954a3b281513ffbd1759fa902e"),
+              fromHex("578e59f1cfba37881d4851d0cb96eee287436fbe4a3a9ea4f6407c064f1e4f03"),
               0,
             ).toFixedLength() as SignatureBytes,
           },
@@ -748,8 +746,8 @@ describe("ethereumCodec", () => {
               data: expectedPubkey,
             },
             signature: new ExtendedSecp256k1Signature(
-              Encoding.fromHex("367e3b3f8253f2f0f4404754b139d93362973de949ccdd5f0dc5a342f8cd2131"),
-              Encoding.fromHex("0f80b13350349f083f44dd507a7ae7bc783389a7b4c18853d073e0e8c59c6ce0"),
+              fromHex("367e3b3f8253f2f0f4404754b139d93362973de949ccdd5f0dc5a342f8cd2131"),
+              fromHex("0f80b13350349f083f44dd507a7ae7bc783389a7b4c18853d073e0e8c59c6ce0"),
               1,
             ).toFixedLength() as SignatureBytes,
           },

--- a/packages/iov-ethereum/src/ethereumcodec.ts
+++ b/packages/iov-ethereum/src/ethereumcodec.ts
@@ -23,7 +23,7 @@ import {
   UnsignedTransaction,
 } from "@iov/bcp";
 import { ExtendedSecp256k1Signature, Keccak256, Secp256k1 } from "@iov/crypto";
-import { Encoding } from "@iov/encoding";
+import { Encoding, fromHex, toHex } from "@iov/encoding";
 
 import { isValidAddress, pubkeyToAddress, toChecksummedAddress } from "./address";
 import { AtomicSwapContractTransactionBuilder } from "./atomicswapcontracttransactionbuilder";
@@ -82,7 +82,7 @@ export class EthereumCodec implements TxCodec {
     try {
       return Encoding.fromUtf8(input);
     } catch {
-      const hexstring = Encoding.toHex(input);
+      const hexstring = toHex(input);
       // split in space separated chunks up to 16 characters each
       return (hexstring.match(/.{1,16}/g) || []).join(" ");
     }
@@ -130,13 +130,13 @@ export class EthereumCodec implements TxCodec {
     const json: EthereumRpcTransactionResult = JSON.parse(Encoding.fromUtf8(bytes));
     const nonce = decodeHexQuantityNonce(json.nonce);
     const value = decodeHexQuantityString(json.value);
-    const input = Encoding.fromHex(normalizeHex(json.input));
+    const input = fromHex(normalizeHex(json.input));
     const chain: Eip155ChainId = {
       forkState: BlknumForkState.Forked,
       chainId: fromBcpChainId(chainId),
     };
-    const r = Encoding.fromHex(normalizeHex(json.r));
-    const s = Encoding.fromHex(normalizeHex(json.s));
+    const r = fromHex(normalizeHex(json.r));
+    const s = fromHex(normalizeHex(json.s));
     const v = decodeHexQuantity(json.v);
     const recoveryParam = getRecoveryParam(chain, v);
     const signature = new ExtendedSecp256k1Signature(r, s, recoveryParam);

--- a/packages/iov-ethereum/src/ethereumconnection.ts
+++ b/packages/iov-ethereum/src/ethereumconnection.ts
@@ -44,7 +44,7 @@ import {
   UnsignedTransaction,
 } from "@iov/bcp";
 import { Random } from "@iov/crypto";
-import { Encoding, Uint53 } from "@iov/encoding";
+import { Encoding, fromHex, toHex, Uint53 } from "@iov/encoding";
 import { isJsonRpcErrorResponse, makeJsonRpcId } from "@iov/jsonrpc";
 import { concat, DefaultValueProducer, dropDuplicates, ValueAndUpdates } from "@iov/stream";
 import { sleep } from "@iov/utils";
@@ -328,7 +328,7 @@ export class EthereumConnection implements AtomicSwapConnection {
           throw new Error(JSON.stringify(response.error));
         }
 
-        return Encoding.fromHex(normalizeHex(response.result));
+        return fromHex(normalizeHex(response.result));
       },
     };
 
@@ -1241,7 +1241,7 @@ export class EthereumConnection implements AtomicSwapConnection {
     const erc20ContractAddressBegin = stateEnd;
     const erc20ContractAddressEnd = erc20ContractAddressBegin + 32;
 
-    const resultArray = Encoding.fromHex(normalizeHex(swapsResponse.result));
+    const resultArray = fromHex(normalizeHex(swapsResponse.result));
     const erc20ContractAddress =
       query.id.prefix === SwapIdPrefix.Erc20
         ? Abi.decodeAddress(resultArray.slice(erc20ContractAddressBegin, erc20ContractAddressEnd))
@@ -1316,10 +1316,8 @@ export class EthereumConnection implements AtomicSwapConnection {
       ...erc20Logs.map(log => ({ ...log, prefix: SwapIdPrefix.Erc20 })),
     ]
       .reduce((accumulator: readonly AtomicSwap[], log: EthereumLogWithPrefix): readonly AtomicSwap[] => {
-        const dataArray = Encoding.fromHex(normalizeHex(log.data));
-        const kind = AtomicSwapContract.abiDecodeEventSignature(
-          Encoding.fromHex(normalizeHex(log.topics[0])),
-        );
+        const dataArray = fromHex(normalizeHex(log.data));
+        const kind = AtomicSwapContract.abiDecodeEventSignature(fromHex(normalizeHex(log.topics[0])));
         switch (kind) {
           case SwapContractEvent.Opened: {
             const parsed = EthereumConnection.parseOpenedEventBytes(dataArray, log.prefix, this.erc20Tokens);
@@ -1343,7 +1341,7 @@ export class EthereumConnection implements AtomicSwapConnection {
         } else if (isAtomicSwapSenderQuery(query)) {
           return swap.data.sender === query.sender;
         } else if (isAtomicSwapHashQuery(query)) {
-          return Encoding.toHex(swap.data.hash) === Encoding.toHex(query.hash);
+          return toHex(swap.data.hash) === toHex(query.hash);
         }
         throw new Error("unsupported query type");
       });

--- a/packages/iov-ethereum/src/serialization.spec.ts
+++ b/packages/iov-ethereum/src/serialization.spec.ts
@@ -18,7 +18,7 @@ import {
   TokenTicker,
 } from "@iov/bcp";
 import { ExtendedSecp256k1Signature } from "@iov/crypto";
-import { Encoding } from "@iov/encoding";
+import { fromHex } from "@iov/encoding";
 
 import { Erc20ApproveTransaction, Erc20Options } from "./erc20";
 import { Serialization } from "./serialization";
@@ -26,7 +26,6 @@ import { SwapIdPrefix } from "./serializationcommon";
 import { testConfig } from "./testconfig.spec";
 
 const { serializeSignedTransaction, serializeUnsignedTransaction } = Serialization;
-const { fromHex } = Encoding;
 
 const ETH = "ETH" as TokenTicker;
 const HOT = "HOT" as TokenTicker;

--- a/packages/iov-ethereum/src/serialization.ts
+++ b/packages/iov-ethereum/src/serialization.ts
@@ -16,7 +16,7 @@ import {
   UnsignedTransaction,
 } from "@iov/bcp";
 import { ExtendedSecp256k1Signature } from "@iov/crypto";
-import { Encoding, Int53 } from "@iov/encoding";
+import { Encoding, fromHex, Int53 } from "@iov/encoding";
 import BN from "bn.js";
 
 import { Abi } from "./abi";
@@ -35,7 +35,7 @@ import {
 import { EscrowContract, isEscrowTransaction } from "./smartcontracts/escrowcontract";
 import { encodeQuantity, encodeQuantityString, fromBcpChainId, normalizeHex } from "./utils";
 
-const { fromHex, toUtf8 } = Encoding;
+const { toUtf8 } = Encoding;
 
 export class Serialization {
   public static serializeGenericTransactionObject(

--- a/packages/iov-ethereum/src/smartcontracts/atomicswapcontract.ts
+++ b/packages/iov-ethereum/src/smartcontracts/atomicswapcontract.ts
@@ -1,5 +1,5 @@
 import { SwapProcessState } from "@iov/bcp";
-import { Encoding } from "@iov/encoding";
+import { toHex } from "@iov/encoding";
 
 import { Abi } from "./../abi";
 
@@ -42,7 +42,7 @@ export class AtomicSwapContract {
     if (data.length !== 4) {
       throw new Error("Input data not 32 bit long");
     }
-    const key = Encoding.toHex(data);
+    const key = toHex(data);
 
     const map: { readonly [key: string]: SwapContractMethod } = {
       [AtomicSwapContract.abiMethodIds.openEth]: SwapContractMethod.Open,
@@ -64,7 +64,7 @@ export class AtomicSwapContract {
     if (data.length !== 32) {
       throw new Error("Input data not 256 bit long");
     }
-    const key = Encoding.toHex(data);
+    const key = toHex(data);
     const map: { readonly [key: string]: SwapContractEvent } = {
       [AtomicSwapContract.abiEventSignatures.openedEth]: SwapContractEvent.Opened,
       [AtomicSwapContract.abiEventSignatures.openedErc20]: SwapContractEvent.Opened,
@@ -87,14 +87,12 @@ export class AtomicSwapContract {
     readonly claimed: string;
     readonly aborted: string;
   } = {
-    openedEth: Encoding.toHex(
-      Abi.calculateMethodHash("Opened(bytes32,address,address,bytes32,uint256,uint256)"),
-    ),
-    openedErc20: Encoding.toHex(
+    openedEth: toHex(Abi.calculateMethodHash("Opened(bytes32,address,address,bytes32,uint256,uint256)")),
+    openedErc20: toHex(
       Abi.calculateMethodHash("Opened(bytes32,address,address,bytes32,uint256,uint256,address)"),
     ),
-    claimed: Encoding.toHex(Abi.calculateMethodHash("Claimed(bytes32,bytes32)")),
-    aborted: Encoding.toHex(Abi.calculateMethodHash("Aborted(bytes32)")),
+    claimed: toHex(Abi.calculateMethodHash("Claimed(bytes32,bytes32)")),
+    aborted: toHex(Abi.calculateMethodHash("Aborted(bytes32)")),
   };
 
   // ABI methods previously methodIds in ABI file
@@ -105,9 +103,9 @@ export class AtomicSwapContract {
     readonly claim: string;
     readonly abort: string;
   } = {
-    openEth: Encoding.toHex(Abi.calculateMethodId("open(bytes32,address,bytes32,uint256)")),
-    openErc20: Encoding.toHex(Abi.calculateMethodId("open(bytes32,address,bytes32,uint256,address,uint256)")),
-    claim: Encoding.toHex(Abi.calculateMethodId("claim(bytes32,bytes32)")),
-    abort: Encoding.toHex(Abi.calculateMethodId("abort(bytes32)")),
+    openEth: toHex(Abi.calculateMethodId("open(bytes32,address,bytes32,uint256)")),
+    openErc20: toHex(Abi.calculateMethodId("open(bytes32,address,bytes32,uint256,address,uint256)")),
+    claim: toHex(Abi.calculateMethodId("claim(bytes32,bytes32)")),
+    abort: toHex(Abi.calculateMethodId("abort(bytes32)")),
   };
 }

--- a/packages/iov-ethereum/src/smartcontracts/escrowcontract.ts
+++ b/packages/iov-ethereum/src/smartcontracts/escrowcontract.ts
@@ -12,7 +12,7 @@ import {
   SwapTimeout,
   UnsignedTransaction,
 } from "@iov/bcp";
-import { Encoding } from "@iov/encoding";
+import { fromHex, toHex } from "@iov/encoding";
 import { isJsonRpcErrorResponse, makeJsonRpcId } from "@iov/jsonrpc";
 import BN from "bn.js";
 
@@ -271,7 +271,7 @@ export class EscrowContract {
     const amountEnd = amountBegin + 32;
     const stateBegin = amountEnd;
     const stateEnd = stateBegin + 32;
-    const resultArray = Encoding.fromHex(normalizeHex(swapsResponse.result));
+    const resultArray = fromHex(normalizeHex(swapsResponse.result));
     return {
       sender: Abi.decodeAddress(resultArray.slice(senderBegin, senderEnd)),
       recipient: Abi.decodeAddress(resultArray.slice(recipientBegin, recipientEnd)),
@@ -289,15 +289,13 @@ export class EscrowContract {
     };
   }
 
-  private static readonly OPEN_METHOD_ID: string = Encoding.toHex(
+  private static readonly OPEN_METHOD_ID: string = toHex(
     Abi.calculateMethodHash("open(bytes32,address,bytes32,uint256)"),
   );
 
-  private static readonly CLAIM_METHOD_ID: string = Encoding.toHex(
-    Abi.calculateMethodHash("claim(bytes32,address)"),
-  );
+  private static readonly CLAIM_METHOD_ID: string = toHex(Abi.calculateMethodHash("claim(bytes32,address)"));
 
-  private static readonly ABORT_METHOD_ID: string = Encoding.toHex(Abi.calculateMethodHash("abort(bytes32)"));
+  private static readonly ABORT_METHOD_ID: string = toHex(Abi.calculateMethodHash("abort(bytes32)"));
 
   private static readonly METHODS: { readonly [key: string]: EscrowContractMethod } = {
     [EscrowContract.OPEN_METHOD_ID]: EscrowContractMethod.Open,
@@ -320,7 +318,7 @@ export class EscrowContract {
   }
 
   private static getMethodTypeFromInput(data: Uint8Array): EscrowContractMethod {
-    const id: string = Encoding.toHex(data);
+    const id = toHex(data);
     const method: EscrowContractMethod | undefined = EscrowContract.METHODS[id];
     if (method === undefined) {
       throw new Error("Unknown method for escrow contract");

--- a/packages/iov-ethereum/src/testconfig.spec.ts
+++ b/packages/iov-ethereum/src/testconfig.spec.ts
@@ -9,13 +9,11 @@ import {
   Token,
   TokenTicker,
 } from "@iov/bcp";
-import { Encoding } from "@iov/encoding";
+import { fromHex } from "@iov/encoding";
 
 import { Erc20Options, Erc20TokensMap } from "./erc20";
 import { EthereumConnectionOptions } from "./ethereumconnection";
 import { SmartContractTokenType, SmartContractType } from "./smartcontracts/definitions";
-
-const { fromHex } = Encoding;
 
 export interface Erc20TransferTest {
   readonly amount: Amount;

--- a/packages/iov-ethereum/src/utils.ts
+++ b/packages/iov-ethereum/src/utils.ts
@@ -1,5 +1,5 @@
 import { ChainId, Nonce } from "@iov/bcp";
-import { Encoding, Uint53 } from "@iov/encoding";
+import { toHex, Uint53 } from "@iov/encoding";
 import BN from "bn.js";
 
 const bcpChainIdPrefix = "ethereum-eip155-";
@@ -31,7 +31,7 @@ export function decodeHexQuantityNonce(hexString: string): Nonce {
  * representation with a prefix.
  */
 export function toEthereumHex(input: string | Uint8Array): string {
-  const str = typeof input === "string" ? input : Encoding.toHex(input);
+  const str = typeof input === "string" ? input : toHex(input);
   const match = str.match(/^(?:0x)?(.*)$/);
   if (!match) {
     throw new Error("Could not convert to Ethereum hex: invalid input");

--- a/packages/iov-keycontrol/src/keyring.spec.ts
+++ b/packages/iov-keycontrol/src/keyring.spec.ts
@@ -1,12 +1,10 @@
 import { ChainId } from "@iov/bcp";
 import { Ed25519, Ed25519Keypair, Random } from "@iov/crypto";
-import { Encoding } from "@iov/encoding";
+import { fromHex } from "@iov/encoding";
 
 import { HdPaths } from "./hdpaths";
 import { Keyring, KeyringSerializationString } from "./keyring";
 import { Ed25519HdWallet, Ed25519Wallet, Secp256k1HdWallet } from "./wallets";
-
-const { fromHex } = Encoding;
 
 async function makeRandomEd25519Keypair(): Promise<Ed25519Keypair> {
   return Ed25519.makeKeypair(Random.getBytes(32));

--- a/packages/iov-keycontrol/src/keyringencryptor.spec.ts
+++ b/packages/iov-keycontrol/src/keyringencryptor.spec.ts
@@ -1,4 +1,4 @@
-import { Encoding } from "@iov/encoding";
+import { Encoding, fromHex } from "@iov/encoding";
 
 import { Keyring } from "./keyring";
 import { EncryptedKeyring, KeyringEncryptor } from "./keyringencryptor";
@@ -7,7 +7,7 @@ describe("KeyringEncryptor", () => {
   it("can encrypt", async () => {
     const keyringSerialization = new Keyring().serialize();
     const serializationLength = Encoding.toUtf8(keyringSerialization).length;
-    const key = Encoding.fromHex("0000000000000000000000000000000000000000000000000000000000000000");
+    const key = fromHex("0000000000000000000000000000000000000000000000000000000000000000");
     const encrypted = await KeyringEncryptor.encrypt(keyringSerialization, key);
 
     expect(encrypted.length).toEqual(
@@ -17,7 +17,7 @@ describe("KeyringEncryptor", () => {
 
   it("can decrypt encrypted data", async () => {
     const originalSerialization = new Keyring().serialize();
-    const key = Encoding.fromHex("0000000000000000000000000000000000000000000000000000000000000000");
+    const key = fromHex("0000000000000000000000000000000000000000000000000000000000000000");
 
     const encrypted = await KeyringEncryptor.encrypt(originalSerialization, key);
     const decrypted = await KeyringEncryptor.decrypt(encrypted, key);
@@ -27,7 +27,7 @@ describe("KeyringEncryptor", () => {
 
   it("throws when decrypting unsupported format version", async () => {
     const originalSerialization = new Keyring().serialize();
-    const key = Encoding.fromHex("0000000000000000000000000000000000000000000000000000000000000000");
+    const key = fromHex("0000000000000000000000000000000000000000000000000000000000000000");
 
     const encrypted = await KeyringEncryptor.encrypt(originalSerialization, key);
     const manipulatedVersion = new Uint8Array([0, 0, 0, 123, ...encrypted.slice(4)]) as EncryptedKeyring;

--- a/packages/iov-keycontrol/src/userprofile.spec.ts
+++ b/packages/iov-keycontrol/src/userprofile.spec.ts
@@ -16,7 +16,7 @@ import {
   TxCodec,
 } from "@iov/bcp";
 import { Ed25519, Slip10RawIndex } from "@iov/crypto";
-import { Encoding } from "@iov/encoding";
+import { fromHex } from "@iov/encoding";
 import levelup from "levelup";
 import MemDownConstructor from "memdown";
 import { ReadonlyDate } from "readonly-date";
@@ -27,8 +27,6 @@ import userprofileData from "./testdata/userprofile.json";
 import { UnexpectedFormatVersionError, UserProfile, UserProfileEncryptionKey } from "./userprofile";
 import { WalletId } from "./wallet";
 import { Ed25519HdWallet, Ed25519Wallet, Secp256k1HdWallet } from "./wallets";
-
-const { fromHex } = Encoding;
 
 /**
  * A possibly incomplete equality checker that tests as well as possible if two profiles contain

--- a/packages/iov-keycontrol/src/wallets/ed25519hdwallet.spec.ts
+++ b/packages/iov-keycontrol/src/wallets/ed25519hdwallet.spec.ts
@@ -1,10 +1,10 @@
 import { ChainId, PrehashType, SignableBytes } from "@iov/bcp";
 import { Ed25519, Slip10RawIndex } from "@iov/crypto";
-import { Encoding } from "@iov/encoding";
+import { Encoding, fromHex } from "@iov/encoding";
 
 import { Ed25519HdWallet } from "./ed25519hdwallet";
 
-const { fromHex, toAscii } = Encoding;
+const { toAscii } = Encoding;
 
 describe("Ed25519HdWallet", () => {
   const defaultChain = "chain123" as ChainId;

--- a/packages/iov-keycontrol/src/wallets/ed25519wallet.spec.ts
+++ b/packages/iov-keycontrol/src/wallets/ed25519wallet.spec.ts
@@ -1,11 +1,9 @@
 import { Algorithm, ChainId, PrehashType, PubkeyBytes, SignableBytes } from "@iov/bcp";
 import { Ed25519Keypair, Sha256, Sha512 } from "@iov/crypto";
-import { Encoding } from "@iov/encoding";
+import { fromHex, toHex } from "@iov/encoding";
 
 import { WalletSerializationString } from "../wallet";
 import { Ed25519Wallet } from "./ed25519wallet";
-
-const { fromHex, toHex } = Encoding;
 
 describe("Ed25519Wallet", () => {
   const defaultChain = "chain123" as ChainId;
@@ -357,7 +355,7 @@ describe("Ed25519Wallet", () => {
       const firstIdentity = wallet.getIdentities()[0];
       expect(firstIdentity.chainId).toEqual("foonet");
       expect(firstIdentity.pubkey.algo).toEqual("ed25519");
-      expect(firstIdentity.pubkey.data).toEqual(Encoding.fromHex("aabbccdd"));
+      expect(firstIdentity.pubkey.data).toEqual(fromHex("aabbccdd"));
       expect(wallet.getIdentityLabel(firstIdentity)).toEqual("foo");
     }
 
@@ -396,11 +394,11 @@ describe("Ed25519Wallet", () => {
       const secondIdentity = wallet.getIdentities()[1];
       expect(firstIdentity.chainId).toEqual("xnet");
       expect(firstIdentity.pubkey.algo).toEqual("ed25519");
-      expect(firstIdentity.pubkey.data).toEqual(Encoding.fromHex("aabbccdd"));
+      expect(firstIdentity.pubkey.data).toEqual(fromHex("aabbccdd"));
       expect(wallet.getIdentityLabel(firstIdentity)).toEqual("foo");
       expect(secondIdentity.chainId).toEqual("ynet");
       expect(secondIdentity.pubkey.algo).toEqual("ed25519");
-      expect(secondIdentity.pubkey.data).toEqual(Encoding.fromHex("ddccbbaa"));
+      expect(secondIdentity.pubkey.data).toEqual(fromHex("ddccbbaa"));
       expect(wallet.getIdentityLabel(secondIdentity)).toEqual("bar");
     }
   });

--- a/packages/iov-keycontrol/src/wallets/ed25519wallet.ts
+++ b/packages/iov-keycontrol/src/wallets/ed25519wallet.ts
@@ -8,7 +8,7 @@ import {
   SignatureBytes,
 } from "@iov/bcp";
 import { Ed25519, Ed25519Keypair } from "@iov/crypto";
-import { Encoding } from "@iov/encoding";
+import { fromHex, toHex } from "@iov/encoding";
 import { DefaultValueProducer, ValueAndUpdates } from "@iov/stream";
 import PseudoRandom from "random-js";
 import { As } from "type-tagger";
@@ -88,7 +88,7 @@ export class Ed25519Wallet implements Wallet {
   }
 
   private static identityId(identity: Identity): IdentityId {
-    const id = [identity.chainId, identity.pubkey.algo, Encoding.toHex(identity.pubkey.data)].join("|");
+    const id = [identity.chainId, identity.pubkey.algo, toHex(identity.pubkey.data)].join("|");
     return id as IdentityId;
   }
 
@@ -147,8 +147,8 @@ export class Ed25519Wallet implements Wallet {
       // identities
       for (const record of decodedData.identities) {
         const keypair = new Ed25519Keypair(
-          Encoding.fromHex(record.privkey),
-          Encoding.fromHex(record.localIdentity.pubkey.data),
+          fromHex(record.privkey),
+          fromHex(record.localIdentity.pubkey.data),
         );
         if (Ed25519Wallet.algorithmFromString(record.localIdentity.pubkey.algo) !== Algorithm.Ed25519) {
           throw new Error("This keyring only supports ed25519 private keys");
@@ -244,7 +244,7 @@ export class Ed25519Wallet implements Wallet {
   public printableSecret(): string {
     const libsodiumPrivkeys = [...this.privkeys.values()].map(pair => pair.toLibsodiumPrivkey());
     const hexstringsSorted = libsodiumPrivkeys
-      .map(privkey => Encoding.toHex(privkey))
+      .map(privkey => toHex(privkey))
       .sort((a, b) => a.localeCompare(b));
     const outStrings = hexstringsSorted.map(hexstring => (hexstring.match(/.{1,16}/g) || []).join(" "));
     return outStrings.join("; ");
@@ -263,11 +263,11 @@ export class Ed25519Wallet implements Wallet {
             chainId: identity.chainId,
             pubkey: {
               algo: identity.pubkey.algo,
-              data: Encoding.toHex(identity.pubkey.data),
+              data: toHex(identity.pubkey.data),
             },
             label: label,
           },
-          privkey: Encoding.toHex(keypair.privkey),
+          privkey: toHex(keypair.privkey),
         };
       }),
     };

--- a/packages/iov-keycontrol/src/wallets/secp256k1hdwallet.spec.ts
+++ b/packages/iov-keycontrol/src/wallets/secp256k1hdwallet.spec.ts
@@ -1,10 +1,10 @@
 import { ChainId, PrehashType, SignableBytes } from "@iov/bcp";
 import { ExtendedSecp256k1Signature, Secp256k1, Sha256, Slip10RawIndex } from "@iov/crypto";
-import { Encoding } from "@iov/encoding";
+import { Encoding, fromHex } from "@iov/encoding";
 
 import { Secp256k1HdWallet } from "./secp256k1hdwallet";
 
-const { fromHex, toAscii } = Encoding;
+const { toAscii } = Encoding;
 
 describe("Secp256k1HdWallet", () => {
   const defaultChain = "chain123" as ChainId;

--- a/packages/iov-keycontrol/src/wallets/slip10wallet.spec.ts
+++ b/packages/iov-keycontrol/src/wallets/slip10wallet.spec.ts
@@ -1,11 +1,9 @@
 import { Algorithm, ChainId, PrehashType, PubkeyBytes, SignableBytes } from "@iov/bcp";
 import { Sha256, Sha512, Slip10Curve, Slip10RawIndex } from "@iov/crypto";
-import { Encoding } from "@iov/encoding";
+import { fromHex, toHex } from "@iov/encoding";
 
 import { WalletSerializationString } from "../wallet";
 import { Slip10Wallet } from "./slip10wallet";
-
-const { fromHex } = Encoding;
 
 describe("Slip10Wallet", () => {
   const defaultChain = "chain123" as ChainId;
@@ -39,7 +37,7 @@ describe("Slip10Wallet", () => {
   it("can be created from entropy", () => {
     const wallet = Slip10Wallet.fromEntropyWithCurve(
       Slip10Curve.Ed25519,
-      Encoding.fromHex("51385c41df88cbe7c579e99de04259b1aa264d8e2416f1885228a4d069629fad"),
+      fromHex("51385c41df88cbe7c579e99de04259b1aa264d8e2416f1885228a4d069629fad"),
     );
     expect(wallet).toBeTruthy();
     expect(wallet.getIdentities().length).toEqual(0);
@@ -139,7 +137,7 @@ describe("Slip10Wallet", () => {
       new Slip10Wallet(emptyWallet),
       Slip10Wallet.fromEntropyWithCurve(
         Slip10Curve.Ed25519,
-        Encoding.fromHex("51385c41df88cbe7c579e99de04259b1aa264d8e2416f1885228a4d069629fad"),
+        fromHex("51385c41df88cbe7c579e99de04259b1aa264d8e2416f1885228a4d069629fad"),
       ),
       Slip10Wallet.fromMnemonicWithCurve(
         Slip10Curve.Ed25519,
@@ -156,9 +154,7 @@ describe("Slip10Wallet", () => {
       ]);
 
       // all pubkeys must be different
-      const pubkeySet = new Set(
-        [newIdentity1, newIdentity2, newIdentity3].map(i => Encoding.toHex(i.pubkey.data)),
-      );
+      const pubkeySet = new Set([newIdentity1, newIdentity2, newIdentity3].map(i => toHex(i.pubkey.data)));
       expect(pubkeySet.size).toEqual(3);
 
       expect(newIdentity1.pubkey.data).not.toEqual(newIdentity2.pubkey.data);
@@ -219,7 +215,7 @@ describe("Slip10Wallet", () => {
       new Slip10Wallet(emptySecp256k1Wallet),
       Slip10Wallet.fromEntropyWithCurve(
         Slip10Curve.Secp256k1,
-        Encoding.fromHex("51385c41df88cbe7c579e99de04259b1aa264d8e2416f1885228a4d069629fad"),
+        fromHex("51385c41df88cbe7c579e99de04259b1aa264d8e2416f1885228a4d069629fad"),
       ),
       Slip10Wallet.fromMnemonicWithCurve(
         Slip10Curve.Secp256k1,
@@ -236,9 +232,7 @@ describe("Slip10Wallet", () => {
       ]);
 
       // all pubkeys must be different
-      const pubkeySet = new Set(
-        [newIdentity1, newIdentity2, newIdentity3].map(i => Encoding.toHex(i.pubkey.data)),
-      );
+      const pubkeySet = new Set([newIdentity1, newIdentity2, newIdentity3].map(i => toHex(i.pubkey.data)));
       expect(pubkeySet.size).toEqual(3);
 
       const identities = wallet.getIdentities();
@@ -560,7 +554,7 @@ describe("Slip10Wallet", () => {
       const firstIdentity = wallet.getIdentities()[0];
       expect(firstIdentity.chainId).toEqual("xnet");
       expect(firstIdentity.pubkey.algo).toEqual("ed25519");
-      expect(firstIdentity.pubkey.data).toEqual(Encoding.fromHex("aabbccdd"));
+      expect(firstIdentity.pubkey.data).toEqual(fromHex("aabbccdd"));
       expect(wallet.getIdentityLabel(firstIdentity)).toEqual("foo");
     }
 
@@ -605,11 +599,11 @@ describe("Slip10Wallet", () => {
       const secondIdentity = wallet.getIdentities()[1];
       expect(firstIdentity.chainId).toEqual("xnet");
       expect(firstIdentity.pubkey.algo).toEqual("ed25519");
-      expect(firstIdentity.pubkey.data).toEqual(Encoding.fromHex("aabbccdd"));
+      expect(firstIdentity.pubkey.data).toEqual(fromHex("aabbccdd"));
       expect(wallet.getIdentityLabel(firstIdentity)).toEqual("foo");
       expect(secondIdentity.chainId).toEqual("ynet");
       expect(secondIdentity.pubkey.algo).toEqual("ed25519");
-      expect(secondIdentity.pubkey.data).toEqual(Encoding.fromHex("ddccbbaa"));
+      expect(secondIdentity.pubkey.data).toEqual(fromHex("ddccbbaa"));
       expect(wallet.getIdentityLabel(secondIdentity)).toEqual("bar");
     }
   });

--- a/packages/iov-keycontrol/src/wallets/slip10wallet.ts
+++ b/packages/iov-keycontrol/src/wallets/slip10wallet.ts
@@ -17,7 +17,7 @@ import {
   slip10CurveFromString,
   Slip10RawIndex,
 } from "@iov/crypto";
-import { Encoding } from "@iov/encoding";
+import { fromHex, toHex } from "@iov/encoding";
 import { DefaultValueProducer, ValueAndUpdates } from "@iov/stream";
 import PseudoRandom from "random-js";
 import { As } from "type-tagger";
@@ -135,7 +135,7 @@ export class Slip10Wallet implements Wallet {
   }
 
   private static identityId(identity: Identity): IdentityId {
-    const id = [identity.chainId, identity.pubkey.algo, Encoding.toHex(identity.pubkey.data)].join("|");
+    const id = [identity.chainId, identity.pubkey.algo, toHex(identity.pubkey.data)].join("|");
     return id as IdentityId;
   }
 
@@ -222,7 +222,7 @@ export class Slip10Wallet implements Wallet {
       const identity = Slip10Wallet.buildIdentity(
         this.curve,
         record.localIdentity.chainId as ChainId,
-        Encoding.fromHex(record.localIdentity.pubkey.data) as PubkeyBytes,
+        fromHex(record.localIdentity.pubkey.data) as PubkeyBytes,
       );
 
       const privkeyPath: readonly Slip10RawIndex[] = record.privkeyPath.map(n => new Slip10RawIndex(n));
@@ -377,7 +377,7 @@ export class Slip10Wallet implements Wallet {
             chainId: identity.chainId,
             pubkey: {
               algo: identity.pubkey.algo,
-              data: Encoding.toHex(identity.pubkey.data),
+              data: toHex(identity.pubkey.data),
             },
             label: label,
           },

--- a/packages/iov-lisk/src/derivation.spec.ts
+++ b/packages/iov-lisk/src/derivation.spec.ts
@@ -1,9 +1,8 @@
 import { Algorithm, PubkeyBytes } from "@iov/bcp";
-import { Encoding } from "@iov/encoding";
+import { fromHex } from "@iov/encoding";
 
 import { Derivation } from "./derivation";
 
-const { fromHex } = Encoding;
 const { isValidAddress, pubkeyToAddress, passphraseToKeypair } = Derivation;
 
 describe("Derivation", () => {
@@ -72,7 +71,7 @@ describe("Derivation", () => {
       const keypair = await passphraseToKeypair(passphrase);
       expect(keypair.pubkey).toEqual(
         // 10176009299933723198L on Lisk Testnet
-        Encoding.fromHex("06ad4341a609af2de837e1156f81849b05bf3c280940a9f45db76d09a3a3f2fa"),
+        fromHex("06ad4341a609af2de837e1156f81849b05bf3c280940a9f45db76d09a3a3f2fa"),
       );
       expect(keypair.privkey).toEqual(jasmine.any(Uint8Array));
       expect(keypair.privkey.length).toEqual(32);

--- a/packages/iov-lisk/src/liskcodec.spec.ts
+++ b/packages/iov-lisk/src/liskcodec.spec.ts
@@ -12,11 +12,9 @@ import {
   SignedTransaction,
   TokenTicker,
 } from "@iov/bcp";
-import { Encoding } from "@iov/encoding";
+import { Encoding, fromHex } from "@iov/encoding";
 
 import { liskCodec } from "./liskcodec";
-
-const { fromHex } = Encoding;
 
 // use nethash as chain ID
 const liskTestnet = "lisk-da3ed6a454" as ChainId;

--- a/packages/iov-lisk/src/liskcodec.ts
+++ b/packages/iov-lisk/src/liskcodec.ts
@@ -18,7 +18,7 @@ import {
   TxCodec,
   UnsignedTransaction,
 } from "@iov/bcp";
-import { Encoding, Int53 } from "@iov/encoding";
+import { Encoding, fromHex, Int53, toHex } from "@iov/encoding";
 import { ReadonlyDate } from "readonly-date";
 
 import { constants } from "./constants";
@@ -65,13 +65,13 @@ export const liskCodec: TxCodec = {
         type: 0,
         amount: unsigned.amount.quantity,
         recipientId: unsigned.recipient,
-        senderPublicKey: Encoding.toHex(primarySignature.pubkey.data),
+        senderPublicKey: toHex(primarySignature.pubkey.data),
         timestamp: liskTimestamp,
         fee: "10000000", // 0.1 LSK fixed
         asset: {
           data: unsigned.memo,
         },
-        signature: Encoding.toHex(primarySignature.signature),
+        signature: toHex(primarySignature.signature),
         id: id,
       };
       return Encoding.toUtf8(JSON.stringify(postableObject)) as PostableBytes;
@@ -103,7 +103,7 @@ export const liskCodec: TxCodec = {
     const json = JSON.parse(Encoding.fromUtf8(bytes));
     const senderPublicKey: PubkeyBundle = {
       algo: Algorithm.Ed25519,
-      data: Encoding.fromHex(json.senderPublicKey) as PubkeyBytes,
+      data: fromHex(json.senderPublicKey) as PubkeyBytes,
     };
 
     let unsignedTransaction: UnsignedTransaction;
@@ -142,7 +142,7 @@ export const liskCodec: TxCodec = {
         {
           nonce: Parse.timeToNonce(Parse.fromTimestamp(json.timestamp)),
           pubkey: senderPublicKey,
-          signature: Encoding.fromHex(json.signature) as SignatureBytes,
+          signature: fromHex(json.signature) as SignatureBytes,
         },
       ],
     };

--- a/packages/iov-lisk/src/liskconnection.spec.ts
+++ b/packages/iov-lisk/src/liskconnection.spec.ts
@@ -24,7 +24,7 @@ import {
   UnsignedTransaction,
 } from "@iov/bcp";
 import { Ed25519, Random, Sha256 } from "@iov/crypto";
-import { Encoding } from "@iov/encoding";
+import { fromHex } from "@iov/encoding";
 import { Ed25519Wallet, UserProfile } from "@iov/keycontrol";
 import { toListPromise } from "@iov/stream";
 import { assert } from "@iov/utils";
@@ -35,7 +35,6 @@ import { Derivation } from "./derivation";
 import { liskCodec } from "./liskcodec";
 import { generateNonce, LiskConnection } from "./liskconnection";
 
-const { fromHex } = Encoding;
 const blockTime = 10_000;
 
 function pendingWithoutLiskDevnet(): void {

--- a/packages/iov-lisk/src/liskconnection.ts
+++ b/packages/iov-lisk/src/liskconnection.ts
@@ -27,7 +27,7 @@ import {
   TxCodec,
   UnsignedTransaction,
 } from "@iov/bcp";
-import { Encoding, Uint53, Uint64 } from "@iov/encoding";
+import { Encoding, fromHex, Uint53, Uint64 } from "@iov/encoding";
 import { concat, DefaultValueProducer, ValueAndUpdates } from "@iov/stream";
 import axios from "axios";
 import equal from "fast-deep-equal";
@@ -189,7 +189,7 @@ export class LiskConnection implements BlockchainConnection {
           typeof itemPubkey === "string" && itemPubkey
             ? {
                 algo: Algorithm.Ed25519,
-                data: Encoding.fromHex(itemPubkey) as PubkeyBytes,
+                data: fromHex(itemPubkey) as PubkeyBytes,
               }
             : undefined;
 

--- a/packages/iov-lisk/src/serialization.spec.ts
+++ b/packages/iov-lisk/src/serialization.spec.ts
@@ -9,12 +9,11 @@ import {
   SignedTransaction,
   TokenTicker,
 } from "@iov/bcp";
-import { Encoding } from "@iov/encoding";
+import { fromHex } from "@iov/encoding";
 import { ReadonlyDate } from "readonly-date";
 
 import { Serialization, TransactionSerializationOptions } from "./serialization";
 
-const { fromHex } = Encoding;
 const { serializeTransaction, toTimestamp, transactionId } = Serialization;
 
 const epochAsUnixTimestamp = 1464109200;

--- a/packages/iov-multichain/README.md
+++ b/packages/iov-multichain/README.md
@@ -82,8 +82,7 @@ Create identies on the two wallets:
 ```ts
 import { ChainId } from "@iov/bcp";
 import { HdPaths } from "@iov/keycontrol";
-import { Encoding } from "@iov/encoding";
-const { fromHex, toHex } = Encoding;
+import { fromHex, toHex } from "@iov/encoding";
 
 const chainId = "iov-exchangenet" as ChainId;
 // this creates two different public key identities, generated from the

--- a/packages/iov-multichain/src/jsonrpcsigningserver.spec.ts
+++ b/packages/iov-multichain/src/jsonrpcsigningserver.spec.ts
@@ -14,7 +14,7 @@ import {
 } from "@iov/bcp";
 import { bnsCodec, createBnsConnector } from "@iov/bns";
 import { Ed25519, Random } from "@iov/crypto";
-import { Encoding, TransactionEncoder } from "@iov/encoding";
+import { fromHex, TransactionEncoder } from "@iov/encoding";
 import { createEthereumConnector } from "@iov/ethereum";
 import { isJsonRpcErrorResponse } from "@iov/jsonrpc";
 import { Ed25519HdWallet, HdPaths, Secp256k1HdWallet, UserProfile } from "@iov/keycontrol";
@@ -23,8 +23,6 @@ import { firstEvent } from "@iov/stream";
 import { JsonRpcSigningServer } from "./jsonrpcsigningserver";
 import { MultiChainSigner } from "./multichainsigner";
 import { GetIdentitiesAuthorization, SignAndPostAuthorization, SigningServerCore } from "./signingservercore";
-
-const { fromHex } = Encoding;
 
 function pendingWithoutBnsd(): void {
   if (!process.env.BNSD_ENABLED) {
@@ -102,7 +100,7 @@ describe("JsonRpcSigningServer", () => {
     chainId: ethereumChainId,
     pubkey: {
       algo: Algorithm.Secp256k1,
-      data: Encoding.fromHex(
+      data: fromHex(
         "041d4c015b00cbd914e280b871d3c6ae2a047ca650d3ecea4b5246bb3036d4d74960b7feb09068164d2b82f1c7df9e95839b29ae38e90d60578b2318a54e108cf8",
       ) as PubkeyBytes,
     },

--- a/packages/iov-multichain/src/multichainsigner.spec.ts
+++ b/packages/iov-multichain/src/multichainsigner.spec.ts
@@ -13,7 +13,7 @@ import {
 } from "@iov/bcp";
 import { bnsCodec, createBnsConnector } from "@iov/bns";
 import { Ed25519, Random } from "@iov/crypto";
-import { Encoding } from "@iov/encoding";
+import { fromHex } from "@iov/encoding";
 import { createEthereumConnector, ethereumCodec } from "@iov/ethereum";
 import { Ed25519HdWallet, HdPaths, Secp256k1HdWallet, UserProfile, WalletId } from "@iov/keycontrol";
 
@@ -172,7 +172,7 @@ describe("MultiChainSigner", () => {
         chainId: ethereumChainId,
         pubkey: {
           algo: Algorithm.Secp256k1,
-          data: Encoding.fromHex(
+          data: fromHex(
             "04965fb72aad79318cd8c8c975cf18fa8bcac0c091605d10e89cd5a9f7cff564b0cb0459a7c22903119f7a42947c32c1cc6a434a86f0e26aad00ca2b2aff6ba381",
           ) as PubkeyBytes,
         },

--- a/packages/iov-multichain/src/signingservice.spec.ts
+++ b/packages/iov-multichain/src/signingservice.spec.ts
@@ -16,7 +16,7 @@ import {
 } from "@iov/bcp";
 import { bnsCodec, createBnsConnector } from "@iov/bns";
 import { Ed25519, Random } from "@iov/crypto";
-import { Encoding, TransactionEncoder } from "@iov/encoding";
+import { fromHex, TransactionEncoder } from "@iov/encoding";
 import {
   JsonRpcClient,
   JsonRpcRequest,
@@ -27,8 +27,6 @@ import {
 import { firstEvent } from "@iov/stream";
 import { sleep } from "@iov/utils";
 import { Producer, Stream } from "xstream";
-
-const { fromHex } = Encoding;
 
 function pendingWithoutBnsd(): void {
   if (!process.env.BNSD_ENABLED) {
@@ -100,7 +98,7 @@ describe("signingservice.worker", () => {
     chainId: ganacheChainId,
     pubkey: {
       algo: Algorithm.Secp256k1,
-      data: Encoding.fromHex(
+      data: fromHex(
         "041d4c015b00cbd914e280b871d3c6ae2a047ca650d3ecea4b5246bb3036d4d74960b7feb09068164d2b82f1c7df9e95839b29ae38e90d60578b2318a54e108cf8",
       ) as PubkeyBytes,
     },

--- a/packages/iov-tendermint-rpc/src/encodings.ts
+++ b/packages/iov-tendermint-rpc/src/encodings.ts
@@ -1,4 +1,4 @@
-import { Encoding, Int53 } from "@iov/encoding";
+import { Encoding, fromHex, Int53, toHex } from "@iov/encoding";
 import { As } from "type-tagger";
 
 import { BlockId, ReadonlyDateWithNanoseconds, Version } from "./responses";
@@ -171,11 +171,11 @@ export class DateTime {
 
 export class Hex {
   public static encode(data: Uint8Array): HexString {
-    return Encoding.toHex(data) as HexString;
+    return toHex(data) as HexString;
   }
 
   public static decode(hexString: HexString): Uint8Array {
-    return Encoding.fromHex(hexString);
+    return fromHex(hexString);
   }
 }
 

--- a/packages/iov-tendermint-rpc/src/v0-31/hasher.spec.ts
+++ b/packages/iov-tendermint-rpc/src/v0-31/hasher.spec.ts
@@ -1,11 +1,11 @@
-import { Encoding } from "@iov/encoding";
+import { Encoding, fromHex } from "@iov/encoding";
 import { ReadonlyDate } from "readonly-date";
 
 import { ReadonlyDateWithNanoseconds } from "../responses";
 import { TxBytes } from "../types";
 import { hashBlock, hashTx } from "./hasher";
 
-const { fromHex, fromBase64 } = Encoding;
+const { fromBase64 } = Encoding;
 
 describe("Hasher", () => {
   it("creates transaction hash equal to local test", () => {

--- a/packages/iov-tendermint-rpc/src/v0-31/requests.ts
+++ b/packages/iov-tendermint-rpc/src/v0-31/requests.ts
@@ -1,4 +1,4 @@
-import { Encoding } from "@iov/encoding";
+import { toHex } from "@iov/encoding";
 import { JsonRpcRequest } from "@iov/jsonrpc";
 
 import { assertNotEmpty, Base64, Base64String, HexString, Integer, IntegerString, may } from "../encodings";
@@ -38,7 +38,7 @@ interface RpcAbciQueryParams {
 function encodeAbciQueryParams(params: requests.AbciQueryParams): RpcAbciQueryParams {
   return {
     path: assertNotEmpty(params.path),
-    data: Encoding.toHex(params.data) as HexString,
+    data: toHex(params.data) as HexString,
     height: may(Integer.encode, params.height),
     prove: params.prove,
   };

--- a/packages/iov-tendermint-rpc/src/v0-31/responses.ts
+++ b/packages/iov-tendermint-rpc/src/v0-31/responses.ts
@@ -1,4 +1,4 @@
-import { Encoding } from "@iov/encoding";
+import { fromHex } from "@iov/encoding";
 import { JsonRpcSuccessResponse } from "@iov/jsonrpc";
 
 import {
@@ -227,10 +227,10 @@ interface RpcBlockId {
 
 function decodeBlockId(data: RpcBlockId): responses.BlockId {
   return {
-    hash: Encoding.fromHex(assertNotEmpty(data.hash)),
+    hash: fromHex(assertNotEmpty(data.hash)),
     parts: {
       total: Integer.parse(assertNotEmpty(data.parts.total)),
-      hash: Encoding.fromHex(assertNotEmpty(data.parts.hash)),
+      hash: fromHex(assertNotEmpty(data.parts.hash)),
     },
   };
 }
@@ -281,17 +281,17 @@ function decodeHeader(data: RpcHeader): responses.Header {
 
     lastBlockId: decodeBlockId(data.last_block_id),
 
-    lastCommitHash: Encoding.fromHex(assertNotEmpty(data.last_commit_hash)),
-    dataHash: Encoding.fromHex(assertSet(data.data_hash)),
+    lastCommitHash: fromHex(assertNotEmpty(data.last_commit_hash)),
+    dataHash: fromHex(assertSet(data.data_hash)),
 
-    validatorsHash: Encoding.fromHex(assertNotEmpty(data.validators_hash)),
-    nextValidatorsHash: Encoding.fromHex(assertNotEmpty(data.next_validators_hash)),
-    consensusHash: Encoding.fromHex(assertNotEmpty(data.consensus_hash)),
-    appHash: Encoding.fromHex(assertNotEmpty(data.app_hash)),
-    lastResultsHash: Encoding.fromHex(assertSet(data.last_results_hash)),
+    validatorsHash: fromHex(assertNotEmpty(data.validators_hash)),
+    nextValidatorsHash: fromHex(assertNotEmpty(data.next_validators_hash)),
+    consensusHash: fromHex(assertNotEmpty(data.consensus_hash)),
+    appHash: fromHex(assertNotEmpty(data.app_hash)),
+    lastResultsHash: fromHex(assertSet(data.last_results_hash)),
 
-    evidenceHash: Encoding.fromHex(assertSet(data.evidence_hash)),
-    proposerAddress: Encoding.fromHex(assertNotEmpty(data.proposer_address)),
+    evidenceHash: fromHex(assertSet(data.evidence_hash)),
+    proposerAddress: fromHex(assertNotEmpty(data.proposer_address)),
   };
 }
 
@@ -326,7 +326,7 @@ interface RpcBroadcastTxSyncResponse extends RpcTxData {
 function decodeBroadcastTxSync(data: RpcBroadcastTxSyncResponse): responses.BroadcastTxSyncResponse {
   return {
     ...decodeTxData(data),
-    hash: Encoding.fromHex(assertNotEmpty(data.hash)) as TxHash,
+    hash: fromHex(assertNotEmpty(data.hash)) as TxHash,
   };
 }
 
@@ -340,7 +340,7 @@ interface RpcBroadcastTxCommitResponse {
 function decodeBroadcastTxCommit(data: RpcBroadcastTxCommitResponse): responses.BroadcastTxCommitResponse {
   return {
     height: may(Integer.parse, data.height),
-    hash: Encoding.fromHex(assertNotEmpty(data.hash)) as TxHash,
+    hash: fromHex(assertNotEmpty(data.hash)) as TxHash,
     checkTx: decodeTxData(assertObject(data.check_tx)),
     deliverTx: may(decodeTxData, data.deliver_tx),
   };
@@ -369,7 +369,7 @@ interface RpcVote {
 function decodeVote(data: RpcVote): responses.Vote {
   return {
     type: Integer.parse(assertNumber(data.type)),
-    validatorAddress: Encoding.fromHex(assertNotEmpty(data.validator_address)),
+    validatorAddress: fromHex(assertNotEmpty(data.validator_address)),
     validatorIndex: Integer.parse(assertNotEmpty(data.validator_index)),
     height: Integer.parse(assertNotEmpty(data.height)),
     round: Integer.parse(assertNotEmpty(data.round)),
@@ -440,7 +440,7 @@ function decodeGenesis(data: RpcGenesisResponse): responses.GenesisResponse {
     chainId: assertNotEmpty(data.chain_id),
     consensusParams: decodeConsensusParams(data.consensus_params),
     validators: assertArray(data.validators).map(decodeValidatorGenesis),
-    appHash: Encoding.fromHex(assertSet(data.app_hash)), // empty string in kvstore app
+    appHash: fromHex(assertSet(data.app_hash)), // empty string in kvstore app
     appState: data.app_state,
   };
 }
@@ -456,7 +456,7 @@ function decodeValidatorInfo(data: RpcValidatorInfo): responses.Validator {
   return {
     pubkey: decodePubkey(assertObject(data.pub_key)),
     votingPower: Integer.parse(assertNotEmpty(data.voting_power)),
-    address: Encoding.fromHex(assertNotEmpty(data.address)),
+    address: fromHex(assertNotEmpty(data.address)),
   };
 }
 
@@ -484,7 +484,7 @@ interface RpcNodeInfo {
 
 function decodeNodeInfo(data: RpcNodeInfo): responses.NodeInfo {
   return {
-    id: Encoding.fromHex(assertNotEmpty(data.id)),
+    id: fromHex(assertNotEmpty(data.id)),
     listenAddr: assertNotEmpty(data.listen_addr),
     network: assertNotEmpty(data.network),
     version: assertNotEmpty(data.version),
@@ -509,8 +509,8 @@ interface RpcSyncInfo {
 
 function decodeSyncInfo(data: RpcSyncInfo): responses.SyncInfo {
   return {
-    latestBlockHash: Encoding.fromHex(assertNotEmpty(data.latest_block_hash)),
-    latestAppHash: Encoding.fromHex(assertNotEmpty(data.latest_app_hash)),
+    latestBlockHash: fromHex(assertNotEmpty(data.latest_block_hash)),
+    latestAppHash: fromHex(assertNotEmpty(data.latest_app_hash)),
     latestBlockTime: DateTime.decode(assertNotEmpty(data.latest_block_time)),
     latestBlockHeight: Integer.parse(assertNotEmpty(data.latest_block_height)),
     catchingUp: assertBoolean(data.catching_up),
@@ -558,7 +558,7 @@ interface RpcTxProof {
 function decodeTxProof(data: RpcTxProof): responses.TxProof {
   return {
     data: Base64.decode(assertNotEmpty(data.Data)),
-    rootHash: Encoding.fromHex(assertNotEmpty(data.RootHash)),
+    rootHash: fromHex(assertNotEmpty(data.RootHash)),
     proof: {
       total: Integer.parse(assertNotEmpty(data.Proof.total)),
       index: Integer.parse(assertNotEmpty(data.Proof.index)),
@@ -583,7 +583,7 @@ function decodeTxResponse(data: RpcTxResponse): responses.TxResponse {
     result: decodeTxData(assertObject(data.tx_result)),
     height: Integer.parse(assertNotEmpty(data.height)),
     index: Integer.parse(assertNumber(data.index)),
-    hash: Encoding.fromHex(assertNotEmpty(data.hash)) as TxHash,
+    hash: fromHex(assertNotEmpty(data.hash)) as TxHash,
     proof: may(decodeTxProof, data.proof),
   };
 }

--- a/packages/iov-tendermint-rpc/src/v0-32/hasher.spec.ts
+++ b/packages/iov-tendermint-rpc/src/v0-32/hasher.spec.ts
@@ -1,11 +1,11 @@
-import { Encoding } from "@iov/encoding";
+import { Encoding, fromHex } from "@iov/encoding";
 import { ReadonlyDate } from "readonly-date";
 
 import { ReadonlyDateWithNanoseconds } from "../responses";
 import { TxBytes } from "../types";
 import { hashBlock, hashTx } from "./hasher";
 
-const { fromHex, fromBase64 } = Encoding;
+const { fromBase64 } = Encoding;
 
 describe("Hasher", () => {
   it("creates transaction hash equal to local test", () => {

--- a/packages/iov-tendermint-rpc/src/v0-32/requests.ts
+++ b/packages/iov-tendermint-rpc/src/v0-32/requests.ts
@@ -1,4 +1,4 @@
-import { Encoding } from "@iov/encoding";
+import { toHex } from "@iov/encoding";
 import { JsonRpcRequest } from "@iov/jsonrpc";
 
 import { assertNotEmpty, Base64, Base64String, HexString, Integer, IntegerString, may } from "../encodings";
@@ -38,7 +38,7 @@ interface RpcAbciQueryParams {
 function encodeAbciQueryParams(params: requests.AbciQueryParams): RpcAbciQueryParams {
   return {
     path: assertNotEmpty(params.path),
-    data: Encoding.toHex(params.data) as HexString,
+    data: toHex(params.data) as HexString,
     height: may(Integer.encode, params.height),
     prove: params.prove,
   };

--- a/packages/iov-tendermint-rpc/src/v0-32/responses.ts
+++ b/packages/iov-tendermint-rpc/src/v0-32/responses.ts
@@ -1,4 +1,4 @@
-import { Encoding } from "@iov/encoding";
+import { fromHex } from "@iov/encoding";
 import { JsonRpcSuccessResponse } from "@iov/jsonrpc";
 
 import {
@@ -244,10 +244,10 @@ interface RpcBlockId {
 
 function decodeBlockId(data: RpcBlockId): responses.BlockId {
   return {
-    hash: Encoding.fromHex(assertNotEmpty(data.hash)),
+    hash: fromHex(assertNotEmpty(data.hash)),
     parts: {
       total: Integer.parse(assertNotEmpty(data.parts.total)),
-      hash: Encoding.fromHex(assertNotEmpty(data.parts.hash)),
+      hash: fromHex(assertNotEmpty(data.parts.hash)),
     },
   };
 }
@@ -298,17 +298,17 @@ function decodeHeader(data: RpcHeader): responses.Header {
 
     lastBlockId: decodeBlockId(data.last_block_id),
 
-    lastCommitHash: Encoding.fromHex(assertNotEmpty(data.last_commit_hash)),
-    dataHash: Encoding.fromHex(assertSet(data.data_hash)),
+    lastCommitHash: fromHex(assertNotEmpty(data.last_commit_hash)),
+    dataHash: fromHex(assertSet(data.data_hash)),
 
-    validatorsHash: Encoding.fromHex(assertNotEmpty(data.validators_hash)),
-    nextValidatorsHash: Encoding.fromHex(assertNotEmpty(data.next_validators_hash)),
-    consensusHash: Encoding.fromHex(assertNotEmpty(data.consensus_hash)),
-    appHash: Encoding.fromHex(assertNotEmpty(data.app_hash)),
-    lastResultsHash: Encoding.fromHex(assertSet(data.last_results_hash)),
+    validatorsHash: fromHex(assertNotEmpty(data.validators_hash)),
+    nextValidatorsHash: fromHex(assertNotEmpty(data.next_validators_hash)),
+    consensusHash: fromHex(assertNotEmpty(data.consensus_hash)),
+    appHash: fromHex(assertNotEmpty(data.app_hash)),
+    lastResultsHash: fromHex(assertSet(data.last_results_hash)),
 
-    evidenceHash: Encoding.fromHex(assertSet(data.evidence_hash)),
-    proposerAddress: Encoding.fromHex(assertNotEmpty(data.proposer_address)),
+    evidenceHash: fromHex(assertSet(data.evidence_hash)),
+    proposerAddress: fromHex(assertNotEmpty(data.proposer_address)),
   };
 }
 
@@ -343,7 +343,7 @@ interface RpcBroadcastTxSyncResponse extends RpcTxData {
 function decodeBroadcastTxSync(data: RpcBroadcastTxSyncResponse): responses.BroadcastTxSyncResponse {
   return {
     ...decodeTxData(data),
-    hash: Encoding.fromHex(assertNotEmpty(data.hash)) as TxHash,
+    hash: fromHex(assertNotEmpty(data.hash)) as TxHash,
   };
 }
 
@@ -357,7 +357,7 @@ interface RpcBroadcastTxCommitResponse {
 function decodeBroadcastTxCommit(data: RpcBroadcastTxCommitResponse): responses.BroadcastTxCommitResponse {
   return {
     height: may(Integer.parse, data.height),
-    hash: Encoding.fromHex(assertNotEmpty(data.hash)) as TxHash,
+    hash: fromHex(assertNotEmpty(data.hash)) as TxHash,
     checkTx: decodeTxData(assertObject(data.check_tx)),
     deliverTx: may(decodeTxData, data.deliver_tx),
   };
@@ -386,7 +386,7 @@ interface RpcVote {
 function decodeVote(data: RpcVote): responses.Vote {
   return {
     type: Integer.parse(assertNumber(data.type)),
-    validatorAddress: Encoding.fromHex(assertNotEmpty(data.validator_address)),
+    validatorAddress: fromHex(assertNotEmpty(data.validator_address)),
     validatorIndex: Integer.parse(assertNotEmpty(data.validator_index)),
     height: Integer.parse(assertNotEmpty(data.height)),
     round: Integer.parse(assertNotEmpty(data.round)),
@@ -457,7 +457,7 @@ function decodeGenesis(data: RpcGenesisResponse): responses.GenesisResponse {
     chainId: assertNotEmpty(data.chain_id),
     consensusParams: decodeConsensusParams(data.consensus_params),
     validators: assertArray(data.validators).map(decodeValidatorGenesis),
-    appHash: Encoding.fromHex(assertSet(data.app_hash)), // empty string in kvstore app
+    appHash: fromHex(assertSet(data.app_hash)), // empty string in kvstore app
     appState: data.app_state,
   };
 }
@@ -473,7 +473,7 @@ function decodeValidatorInfo(data: RpcValidatorInfo): responses.Validator {
   return {
     pubkey: decodePubkey(assertObject(data.pub_key)),
     votingPower: Integer.parse(assertNotEmpty(data.voting_power)),
-    address: Encoding.fromHex(assertNotEmpty(data.address)),
+    address: fromHex(assertNotEmpty(data.address)),
   };
 }
 
@@ -501,7 +501,7 @@ interface RpcNodeInfo {
 
 function decodeNodeInfo(data: RpcNodeInfo): responses.NodeInfo {
   return {
-    id: Encoding.fromHex(assertNotEmpty(data.id)),
+    id: fromHex(assertNotEmpty(data.id)),
     listenAddr: assertNotEmpty(data.listen_addr),
     network: assertNotEmpty(data.network),
     version: assertNotEmpty(data.version),
@@ -526,8 +526,8 @@ interface RpcSyncInfo {
 
 function decodeSyncInfo(data: RpcSyncInfo): responses.SyncInfo {
   return {
-    latestBlockHash: Encoding.fromHex(assertNotEmpty(data.latest_block_hash)),
-    latestAppHash: Encoding.fromHex(assertNotEmpty(data.latest_app_hash)),
+    latestBlockHash: fromHex(assertNotEmpty(data.latest_block_hash)),
+    latestAppHash: fromHex(assertNotEmpty(data.latest_app_hash)),
     latestBlockTime: DateTime.decode(assertNotEmpty(data.latest_block_time)),
     latestBlockHeight: Integer.parse(assertNotEmpty(data.latest_block_height)),
     catchingUp: assertBoolean(data.catching_up),
@@ -575,7 +575,7 @@ interface RpcTxProof {
 function decodeTxProof(data: RpcTxProof): responses.TxProof {
   return {
     data: Base64.decode(assertNotEmpty(data.Data)),
-    rootHash: Encoding.fromHex(assertNotEmpty(data.RootHash)),
+    rootHash: fromHex(assertNotEmpty(data.RootHash)),
     proof: {
       total: Integer.parse(assertNotEmpty(data.Proof.total)),
       index: Integer.parse(assertNotEmpty(data.Proof.index)),
@@ -600,7 +600,7 @@ function decodeTxResponse(data: RpcTxResponse): responses.TxResponse {
     result: decodeTxData(assertObject(data.tx_result)),
     height: Integer.parse(assertNotEmpty(data.height)),
     index: Integer.parse(assertNumber(data.index)),
-    hash: Encoding.fromHex(assertNotEmpty(data.hash)) as TxHash,
+    hash: fromHex(assertNotEmpty(data.hash)) as TxHash,
     proof: may(decodeTxProof, data.proof),
   };
 }

--- a/scripts/bnsd/deploy_proposals.js
+++ b/scripts/bnsd/deploy_proposals.js
@@ -2,7 +2,7 @@
 const { isBlockInfoPending, isBlockInfoSucceeded } = require("@iov/bcp");
 const { bnsCodec, BnsConnection, VoteOption } = require("@iov/bns");
 const { Governor, ProposalType } = require("@iov/bns-governance");
-const { Encoding } = require("@iov/encoding");
+const { fromHex } = require("@iov/encoding");
 const { Ed25519HdWallet, HdPaths, UserProfile } = require("@iov/keycontrol");
 const { sleep } = require("@iov/utils");
 
@@ -38,7 +38,7 @@ async function main() {
   const wallet = profile.addWallet(Ed25519HdWallet.fromMnemonic(adminMnemonic));
   const identity = await profile.createIdentity(wallet.id, chainId, adminPath);
   const senderAddress = bnsCodec.identityToAddress(identity);
-  const guaranteeFundEscrowId = Encoding.fromHex("0000000000000001");
+  const guaranteeFundEscrowId = fromHex("0000000000000001");
   const rewardFundAddress = "tiov1k0dp2fmdunscuwjjusqtk6mttx5ufk3z0mmp0z";
   const signAndPost = createSignAndPoster(connection, profile);
 


### PR DESCRIPTION
Using static class members instead of free functions was a mistake from the early days. The idea was to use the class for namespacing, but we never ran into any kind of naming collision and can just import `fromHex`/`toHex` directly.

This makes using them much simpler, especially avoiding all those destructions like `const { toHex } = Encoding;`

If this is good, I can do the same for the remaining functions in `Encoding`