### PR TITLE
Add HdPaths.iovSecondGen path maker

### DIFF
--- a/packages/iov-keycontrol/src/hdpaths.spec.ts
+++ b/packages/iov-keycontrol/src/hdpaths.spec.ts
@@ -3,39 +3,45 @@ import { Slip10RawIndex } from "@iov/crypto";
 import { HdPaths } from "./hdpaths";
 
 describe("HdPaths", () => {
-  it("has working bip44 implementation", () => {
-    // m/44'/1'/2'/3/4
-    expect(HdPaths.bip44(1, 2, 3, 4)).toEqual([
-      Slip10RawIndex.hardened(44),
-      Slip10RawIndex.hardened(1),
-      Slip10RawIndex.hardened(2),
-      Slip10RawIndex.normal(3),
-      Slip10RawIndex.normal(4),
-    ]);
+  describe("bip44", () => {
+    it("works", () => {
+      // m/44'/1'/2'/3/4
+      expect(HdPaths.bip44(1, 2, 3, 4)).toEqual([
+        Slip10RawIndex.hardened(44),
+        Slip10RawIndex.hardened(1),
+        Slip10RawIndex.hardened(2),
+        Slip10RawIndex.normal(3),
+        Slip10RawIndex.normal(4),
+      ]);
+    });
   });
 
-  it("has working bip44Like implementation", () => {
-    // m/44'/33'/22'
-    expect(HdPaths.bip44Like(33, 22)).toEqual([
-      Slip10RawIndex.hardened(44),
-      Slip10RawIndex.hardened(33),
-      Slip10RawIndex.hardened(22),
-    ]);
+  describe("bip44Like", () => {
+    it("works", () => {
+      // m/44'/33'/22'
+      expect(HdPaths.bip44Like(33, 22)).toEqual([
+        Slip10RawIndex.hardened(44),
+        Slip10RawIndex.hardened(33),
+        Slip10RawIndex.hardened(22),
+      ]);
+    });
   });
 
-  it("has working iov implementation", () => {
-    // m/44'/234'/0'
-    expect(HdPaths.iov(0)).toEqual([
-      Slip10RawIndex.hardened(44),
-      Slip10RawIndex.hardened(234),
-      Slip10RawIndex.hardened(0),
-    ]);
-    // m/44'/234'/1'
-    expect(HdPaths.iov(1)).toEqual([
-      Slip10RawIndex.hardened(44),
-      Slip10RawIndex.hardened(234),
-      Slip10RawIndex.hardened(1),
-    ]);
+  describe("iov", () => {
+    it("works", () => {
+      // m/44'/234'/0'
+      expect(HdPaths.iov(0)).toEqual([
+        Slip10RawIndex.hardened(44),
+        Slip10RawIndex.hardened(234),
+        Slip10RawIndex.hardened(0),
+      ]);
+      // m/44'/234'/1'
+      expect(HdPaths.iov(1)).toEqual([
+        Slip10RawIndex.hardened(44),
+        Slip10RawIndex.hardened(234),
+        Slip10RawIndex.hardened(1),
+      ]);
+    });
   });
 
   describe("iovSecondGen", () => {
@@ -83,23 +89,25 @@ describe("HdPaths", () => {
     });
   });
 
-  it("has working Ethereum implementation", () => {
-    // m/44'/60'/0'/0/0
-    expect(HdPaths.ethereum(0)).toEqual([
-      Slip10RawIndex.hardened(44),
-      Slip10RawIndex.hardened(60),
-      Slip10RawIndex.hardened(0),
-      Slip10RawIndex.normal(0),
-      Slip10RawIndex.normal(0),
-    ]);
-    // m/44'/60'/0'/0/123
-    expect(HdPaths.ethereum(123)).toEqual([
-      Slip10RawIndex.hardened(44),
-      Slip10RawIndex.hardened(60),
-      Slip10RawIndex.hardened(0),
-      Slip10RawIndex.normal(0),
-      Slip10RawIndex.normal(123),
-    ]);
+  describe("ethereum", () => {
+    it("works", () => {
+      // m/44'/60'/0'/0/0
+      expect(HdPaths.ethereum(0)).toEqual([
+        Slip10RawIndex.hardened(44),
+        Slip10RawIndex.hardened(60),
+        Slip10RawIndex.hardened(0),
+        Slip10RawIndex.normal(0),
+        Slip10RawIndex.normal(0),
+      ]);
+      // m/44'/60'/0'/0/123
+      expect(HdPaths.ethereum(123)).toEqual([
+        Slip10RawIndex.hardened(44),
+        Slip10RawIndex.hardened(60),
+        Slip10RawIndex.hardened(0),
+        Slip10RawIndex.normal(0),
+        Slip10RawIndex.normal(123),
+      ]);
+    });
   });
 
   describe("cosmosHub", () => {

--- a/packages/iov-keycontrol/src/hdpaths.spec.ts
+++ b/packages/iov-keycontrol/src/hdpaths.spec.ts
@@ -44,10 +44,10 @@ describe("HdPaths", () => {
     });
   });
 
-  describe("iovSecondGen", () => {
+  describe("iovCosmosSdk", () => {
     it("works", () => {
       // m/44'/234'/0'/0/0
-      expect(HdPaths.iovSecondGen(0)).toEqual([
+      expect(HdPaths.iovCosmosSdk(0)).toEqual([
         Slip10RawIndex.hardened(44),
         Slip10RawIndex.hardened(234),
         Slip10RawIndex.hardened(0),
@@ -55,7 +55,7 @@ describe("HdPaths", () => {
         Slip10RawIndex.normal(0),
       ]);
       // m/44'/234'/0'/0/123
-      expect(HdPaths.iovSecondGen(123)).toEqual([
+      expect(HdPaths.iovCosmosSdk(123)).toEqual([
         Slip10RawIndex.hardened(44),
         Slip10RawIndex.hardened(234),
         Slip10RawIndex.hardened(0),

--- a/packages/iov-keycontrol/src/hdpaths.spec.ts
+++ b/packages/iov-keycontrol/src/hdpaths.spec.ts
@@ -38,6 +38,27 @@ describe("HdPaths", () => {
     ]);
   });
 
+  describe("iovSecondGen", () => {
+    it("works", () => {
+      // m/44'/234'/0'/0/0
+      expect(HdPaths.iovSecondGen(0)).toEqual([
+        Slip10RawIndex.hardened(44),
+        Slip10RawIndex.hardened(234),
+        Slip10RawIndex.hardened(0),
+        Slip10RawIndex.normal(0),
+        Slip10RawIndex.normal(0),
+      ]);
+      // m/44'/234'/0'/0/123
+      expect(HdPaths.iovSecondGen(123)).toEqual([
+        Slip10RawIndex.hardened(44),
+        Slip10RawIndex.hardened(234),
+        Slip10RawIndex.hardened(0),
+        Slip10RawIndex.normal(0),
+        Slip10RawIndex.normal(123),
+      ]);
+    });
+  });
+
   describe("iovFaucet", () => {
     it("returns token holder account for instance 0 when called with no arguments", () => {
       // m/1229936198'/1'/0'/0'

--- a/packages/iov-keycontrol/src/hdpaths.ts
+++ b/packages/iov-keycontrol/src/hdpaths.ts
@@ -59,6 +59,16 @@ export class HdPaths {
   }
 
   /**
+   * A second generation IOV HD path in the form m/44'/234'/0'/0/a.
+   * This is used on the Cosmos SDK based chain starting from summer 2020.
+   *
+   * @param account The account index `a` starting at 0
+   */
+  public static iovSecondGen(account: number): readonly Slip10RawIndex[] {
+    return HdPaths.bip44(HdPaths.coinTypes.iov, 0, 0, account);
+  }
+
+  /**
    * An IOV faucet HD path in the form m/1229936198'/coinType'/instanceIndex'/accountIndex'
    * which was used in the IOV faucet < 0.10.0.
    *

--- a/packages/iov-keycontrol/src/hdpaths.ts
+++ b/packages/iov-keycontrol/src/hdpaths.ts
@@ -64,7 +64,7 @@ export class HdPaths {
    *
    * @param account The account index `a` starting at 0
    */
-  public static iovSecondGen(account: number): readonly Slip10RawIndex[] {
+  public static iovCosmosSdk(account: number): readonly Slip10RawIndex[] {
     return HdPaths.bip44(HdPaths.coinTypes.iov, 0, 0, account);
   }
 

--- a/packages/iov-keycontrol/types/hdpaths.d.ts
+++ b/packages/iov-keycontrol/types/hdpaths.d.ts
@@ -34,6 +34,13 @@ export declare class HdPaths {
    */
   static iov(account: number): readonly Slip10RawIndex[];
   /**
+   * A second generation IOV HD path in the form m/44'/234'/0'/0/a.
+   * This is used on the Cosmos SDK based chain starting from summer 2020.
+   *
+   * @param account The account index `a` starting at 0
+   */
+  static iovSecondGen(account: number): readonly Slip10RawIndex[];
+  /**
    * An IOV faucet HD path in the form m/1229936198'/coinType'/instanceIndex'/accountIndex'
    * which was used in the IOV faucet < 0.10.0.
    *

--- a/packages/iov-keycontrol/types/hdpaths.d.ts
+++ b/packages/iov-keycontrol/types/hdpaths.d.ts
@@ -39,7 +39,7 @@ export declare class HdPaths {
    *
    * @param account The account index `a` starting at 0
    */
-  static iovSecondGen(account: number): readonly Slip10RawIndex[];
+  static iovCosmosSdk(account: number): readonly Slip10RawIndex[];
   /**
    * An IOV faucet HD path in the form m/1229936198'/coinType'/instanceIndex'/accountIndex'
    * which was used in the IOV faucet < 0.10.0.


### PR DESCRIPTION
To refactor code like

```ts
const identity = await wallet.createIdentity(chainId, HdPaths.bip44(234, 0, 0, 0));
```

to

```ts
const identity = await wallet.createIdentity(chainId, HdPaths.iovSecondGen(0));
```

making it much harder to create bugs. Happy for better naming suggestions, if you have one.

The second commit is just test structure cleanup and doen't change things.